### PR TITLE
Particle attribute internal buffer for MPI communication

### DIFF
--- a/alpine/BumponTailInstability.cpp
+++ b/alpine/BumponTailInstability.cpp
@@ -327,8 +327,6 @@ int main(int argc, char* argv[]) {
 
         P->initializeFields(mesh, FL);
 
-        bunch_type bunchBuffer(PL);
-
         P->initSolver();
         P->time_m                 = 0.0;
         P->loadbalancethreshold_m = std::atof(argv[arg++]);
@@ -358,7 +356,7 @@ int main(int argc, char* argv[]) {
             Kokkos::fence();
 
             P->initializeORB(FL, mesh);
-            P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+            P->repartition(FL, mesh, isFirstRepartition);
             IpplTimings::stopTimer(domainDecomposition);
         }
 
@@ -465,14 +463,14 @@ int main(int argc, char* argv[]) {
 
             // Since the particles have moved spatially update them to correct processors
             IpplTimings::startTimer(updateTimer);
-            PL.update(*P, bunchBuffer);
+            P->update();
             IpplTimings::stopTimer(updateTimer);
 
             // Domain Decomposition
             if (P->balance(totalP, it + 1)) {
                 msg << "Starting repartition" << endl;
                 IpplTimings::startTimer(domainDecomposition);
-                P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+                P->repartition(FL, mesh, isFirstRepartition);
                 IpplTimings::stopTimer(domainDecomposition);
                 // IpplTimings::startTimer(dumpDataTimer);
                 // P->dumpLocalDomains(FL, it+1);

--- a/alpine/ChargedParticles.hpp
+++ b/alpine/ChargedParticles.hpp
@@ -232,16 +232,6 @@ public:
     typename Base::particle_position_type P;  // particle velocity
     typename Base::particle_position_type E;  // electric field at particle position
 
-    /*
-      This constructor is mandatory for all derived classes from
-      ParticleBase as the bunch buffer uses this
-    */
-    ChargedParticles(PLayout& pl)
-        : Base(pl) {
-        registerAttributes();
-        setPotentialBCs();
-    }
-
     ChargedParticles(PLayout& pl, Vector_t<double, Dim> hr, Vector_t<double, Dim> rmin,
                      Vector_t<double, Dim> rmax, ippl::e_dim_tag decomp[Dim], double Q,
                      std::string solver)

--- a/alpine/ChargedParticles.hpp
+++ b/alpine/ChargedParticles.hpp
@@ -280,8 +280,7 @@ public:
 
     void setupBCs() { setBCAllPeriodic(); }
 
-    void updateLayout(FieldLayout_t<Dim>& fl, Mesh_t<Dim>& mesh,
-                      ChargedParticles<PLayout, T, Dim>& buffer, bool& isFirstRepartition) {
+    void updateLayout(FieldLayout_t<Dim>& fl, Mesh_t<Dim>& mesh, bool& isFirstRepartition) {
         // Update local fields
         static IpplTimings::TimerRef tupdateLayout = IpplTimings::getTimer("updateLayout");
         IpplTimings::startTimer(tupdateLayout);
@@ -299,7 +298,7 @@ public:
         static IpplTimings::TimerRef tupdatePLayout = IpplTimings::getTimer("updatePB");
         IpplTimings::startTimer(tupdatePLayout);
         if (!isFirstRepartition) {
-            layout.update(*this, buffer);
+            this->update();
         }
         IpplTimings::stopTimer(tupdatePLayout);
     }
@@ -317,8 +316,7 @@ public:
         orb.initialize(fl, mesh, rho_m);
     }
 
-    void repartition(FieldLayout_t<Dim>& fl, Mesh_t<Dim>& mesh,
-                     ChargedParticles<PLayout, T, Dim>& buffer, bool& isFirstRepartition) {
+    void repartition(FieldLayout_t<Dim>& fl, Mesh_t<Dim>& mesh, bool& isFirstRepartition) {
         // Repartition the domains
         bool res = orb.binaryRepartition(this->R, fl, isFirstRepartition);
 
@@ -327,7 +325,7 @@ public:
             return;
         }
         // Update
-        this->updateLayout(fl, mesh, buffer, isFirstRepartition);
+        this->updateLayout(fl, mesh, isFirstRepartition);
         if constexpr (Dim == 2 || Dim == 3) {
             if (stype_m == "FFT") {
                 std::get<FFTSolver_t<T, Dim>>(solver_m).setRhs(rho_m);

--- a/alpine/LandauDamping.cpp
+++ b/alpine/LandauDamping.cpp
@@ -213,8 +213,6 @@ int main(int argc, char* argv[]) {
 
         P->initializeFields(mesh, FL);
 
-        bunch_type bunchBuffer(PL);
-
         P->initSolver();
         P->time_m                 = 0.0;
         P->loadbalancethreshold_m = std::atof(argv[arg++]);
@@ -244,7 +242,7 @@ int main(int argc, char* argv[]) {
             Kokkos::fence();
 
             P->initializeORB(FL, mesh);
-            P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+            P->repartition(FL, mesh, isFirstRepartition);
             IpplTimings::stopTimer(domainDecomposition);
         }
 
@@ -334,14 +332,14 @@ int main(int argc, char* argv[]) {
 
             // Since the particles have moved spatially update them to correct processors
             IpplTimings::startTimer(updateTimer);
-            PL.update(*P, bunchBuffer);
+            P->update();
             IpplTimings::stopTimer(updateTimer);
 
             // Domain Decomposition
             if (P->balance(totalP, it + 1)) {
                 msg << "Starting repartition" << endl;
                 IpplTimings::startTimer(domainDecomposition);
-                P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+                P->repartition(FL, mesh, isFirstRepartition);
                 IpplTimings::stopTimer(domainDecomposition);
                 // IpplTimings::startTimer(dumpDataTimer);
                 // P->dumpLocalDomains(FL, it+1);

--- a/alpine/LandauDampingMixedExec.cpp
+++ b/alpine/LandauDampingMixedExec.cpp
@@ -214,8 +214,6 @@ int main(int argc, char* argv[]) {
 
         P->initializeFields(mesh, FL);
 
-        bunch_type bunchBuffer(PL);
-
         P->initSolver();
         P->time_m                 = 0.0;
         P->loadbalancethreshold_m = std::atof(argv[arg++]);
@@ -249,7 +247,7 @@ int main(int argc, char* argv[]) {
             Kokkos::fence();
 
             P->initializeORB(FL, mesh);
-            P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+            P->repartition(FL, mesh, isFirstRepartition);
             IpplTimings::stopTimer(domainDecomposition);
         }
 
@@ -343,14 +341,14 @@ int main(int argc, char* argv[]) {
 
             // Since the particles have moved spatially update them to correct processors
             IpplTimings::startTimer(updateTimer);
-            PL.update(*P, bunchBuffer);
+            P->update();
             IpplTimings::stopTimer(updateTimer);
 
             // Domain Decomposition
             if (P->balance(totalP, it + 1)) {
                 msg << "Starting repartition" << endl;
                 IpplTimings::startTimer(domainDecomposition);
-                P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+                P->repartition(FL, mesh, isFirstRepartition);
                 IpplTimings::stopTimer(domainDecomposition);
                 // IpplTimings::startTimer(dumpDataTimer);
                 // P->dumpLocalDomains(FL, it+1);

--- a/alpine/LandauDampingMixedPrecision.cpp
+++ b/alpine/LandauDampingMixedPrecision.cpp
@@ -209,8 +209,6 @@ int main(int argc, char* argv[]) {
 
         P->initializeFields(mesh, FL);
 
-        bunch_type bunchBuffer(PL);
-
         P->initSolver();
         P->time_m                 = 0.0;
         P->loadbalancethreshold_m = std::atof(argv[arg++]);
@@ -240,7 +238,7 @@ int main(int argc, char* argv[]) {
             Kokkos::fence();
 
             P->initializeORB(FL, mesh);
-            P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+            P->repartition(FL, mesh, isFirstRepartition);
             IpplTimings::stopTimer(domainDecomposition);
         }
 
@@ -332,14 +330,14 @@ int main(int argc, char* argv[]) {
 
             // Since the particles have moved spatially update them to correct processors
             IpplTimings::startTimer(updateTimer);
-            PL.update(*P, bunchBuffer);
+            P->update();
             IpplTimings::stopTimer(updateTimer);
 
             // Domain Decomposition
             if (P->balance(totalP, it + 1)) {
                 msg << "Starting repartition" << endl;
                 IpplTimings::startTimer(domainDecomposition);
-                P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+                P->repartition(FL, mesh, isFirstRepartition);
                 IpplTimings::stopTimer(domainDecomposition);
                 // IpplTimings::startTimer(dumpDataTimer);
                 // P->dumpLocalDomains(FL, it+1);

--- a/alpine/PenningTrap.cpp
+++ b/alpine/PenningTrap.cpp
@@ -216,8 +216,6 @@ int main(int argc, char* argv[]) {
 
         P->initializeFields(mesh, FL);
 
-        bunch_type bunchBuffer(PL);
-
         P->initSolver();
         P->time_m                 = 0.0;
         P->loadbalancethreshold_m = std::atof(argv[7]);
@@ -251,7 +249,7 @@ int main(int argc, char* argv[]) {
             Kokkos::fence();
 
             P->initializeORB(FL, mesh);
-            P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+            P->repartition(FL, mesh, isFirstRepartition);
             IpplTimings::stopTimer(domainDecomposition);
         }
 
@@ -362,14 +360,14 @@ int main(int argc, char* argv[]) {
 
             // Since the particles have moved spatially update them to correct processors
             IpplTimings::startTimer(updateTimer);
-            PL.update(*P, bunchBuffer);
+            P->update();
             IpplTimings::stopTimer(updateTimer);
 
             // Domain Decomposition
             if (P->balance(totalP, it + 1)) {
                 msg << "Starting repartition" << endl;
                 IpplTimings::startTimer(domainDecomposition);
-                P->repartition(FL, mesh, bunchBuffer, isFirstRepartition);
+                P->repartition(FL, mesh, isFirstRepartition);
                 IpplTimings::stopTimer(domainDecomposition);
                 // IpplTimings::startTimer(dumpDataTimer);
                 // P->dumpLocalDomains(FL, it+1);

--- a/alpine/UniformPlasmaTest.cpp
+++ b/alpine/UniformPlasmaTest.cpp
@@ -158,10 +158,8 @@ int main(int argc, char* argv[]) {
 
         P->initializeFields(mesh, FL);
 
-        bunch_type bunchBuffer(PL);
-
         IpplTimings::startTimer(updateTimer);
-        PL.update(*P, bunchBuffer);
+        P->update();
         IpplTimings::stopTimer(updateTimer);
 
         msg << "particles created and initial conditions assigned " << endl;
@@ -218,14 +216,14 @@ int main(int argc, char* argv[]) {
 
             // Since the particles have moved spatially update them to correct processors
             IpplTimings::startTimer(updateTimer);
-            PL.update(*P, bunchBuffer);
+            P->update();
             IpplTimings::stopTimer(updateTimer);
 
             // Domain Decomposition
             if (P->balance(totalP, it + 1)) {
                 msg << "Starting repartition" << endl;
                 IpplTimings::startTimer(domainDecomposition);
-                P->repartition(FL, mesh, bunchBuffer, fromAnalyticDensity);
+                P->repartition(FL, mesh, fromAnalyticDensity);
                 IpplTimings::stopTimer(domainDecomposition);
             }
 

--- a/src/Particle/ParticleAttrib.h
+++ b/src/Particle/ParticleAttrib.h
@@ -38,6 +38,7 @@ namespace ippl {
         using hash_type = typename Base::hash_type;
 
         using view_type  = typename detail::ViewType<T, 1, Properties...>::view_type;
+
         using HostMirror = typename view_type::host_mirror_type;
 
         using memory_space    = typename view_type::memory_space;
@@ -59,16 +60,16 @@ namespace ippl {
         void destroy(const hash_type& deleteIndex, const hash_type& keepIndex,
                      size_type invalidCount) override;
 
-        void pack(void*, const hash_type&) const override;
+        void pack(const hash_type&) override;
 
-        void unpack(void*, size_type) override;
+        void unpack(size_type) override;
 
         void serialize(detail::Archive<memory_space>& ar, size_type nsends) override {
-            ar.serialize(dview_m, nsends);
+            ar.serialize(buf_m, nsends);
         }
 
         void deserialize(detail::Archive<memory_space>& ar, size_type nrecvs) override {
-            ar.deserialize(dview_m, nrecvs);
+            ar.deserialize(buf_m, nrecvs);
         }
 
         virtual ~ParticleAttrib() = default;
@@ -132,6 +133,7 @@ namespace ippl {
 
     private:
         view_type dview_m;
+        view_type buf_m;
     };
 }  // namespace ippl
 

--- a/src/Particle/ParticleAttribBase.h
+++ b/src/Particle/ParticleAttribBase.h
@@ -42,9 +42,9 @@ namespace ippl {
             virtual void destroy(const hash_type&, const hash_type&, size_type) = 0;
             virtual size_type packedSize(const size_type) const                 = 0;
 
-            virtual void pack(void*, const hash_type&) const = 0;
+            virtual void pack(const hash_type&) = 0;
 
-            virtual void unpack(void*, size_type) = 0;
+            virtual void unpack(size_type) = 0;
 
             virtual void serialize(Archive<memory_space>& ar, size_type nsends) = 0;
 

--- a/src/Particle/ParticleBase.h
+++ b/src/Particle/ParticleBase.h
@@ -248,12 +248,11 @@ namespace ippl {
         template <typename... Properties>
         void destroy(const Kokkos::View<bool*, Properties...>& invalid, const size_type destroyNum);
 
-        template <typename HashType, typename BufferType>
+        template <typename HashType>
         void sendToRank(int rank, int tag, int sendNum, std::vector<MPI_Request>& requests,
-                        const HashType& hash, BufferType& buffer);
+                        const HashType& hash);
 
-        template <typename BufferType>
-        void recvFromRank(int rank, int tag, int recvNum, size_type nRecvs, BufferType& buffer);
+        void recvFromRank(int rank, int tag, int recvNum, size_type nRecvs);
 
         /*!
          * Serialize to do MPI calls.
@@ -278,23 +277,21 @@ namespace ippl {
         template <typename MemorySpace>
         size_type packedSize(const size_type count) const;
 
+        void update() { layout_m->update(*this); }
+
     protected:
         /*!
          * Fill attributes of buffer.
-         * @tparam Buffer is a bunch type
          * @param buffer to send
          * @param hash function to access index.
          */
-        template <class Buffer>
-        void pack(Buffer& buffer, const hash_container_type& hash);
+        void pack(const hash_container_type& hash);
 
         /*!
          * Fill my attributes.
-         * @tparam Buffer is a bunch type
          * @param buffer received
          */
-        template <class Buffer>
-        void unpack(Buffer& buffer, size_type nrecvs);
+        void unpack(size_type nrecvs);
 
     private:
         //! particle layout

--- a/src/Particle/ParticleBase.h
+++ b/src/Particle/ParticleBase.h
@@ -71,17 +71,13 @@ namespace ippl {
      * of the provided types is ippl::DisableParticleIDs, then particle
      * IDs will be disabled for the bunch)
      */
-    template <class PLayout, typename... IDProperties>
+    template <typename... IDProperties>
     class ParticleBase {
         constexpr static bool EnableIDs = sizeof...(IDProperties) > 0;
 
     public:
-        using vector_type            = typename PLayout::vector_type;
-        using index_type             = typename PLayout::index_type;
-        using particle_position_type = typename PLayout::particle_position_type;
+        using index_type             = std::int64_t;
         using particle_index_type    = ParticleAttrib<index_type, IDProperties...>;
-
-        using Layout_t = PLayout;
 
         template <typename... Properties>
         using attribute_type = typename detail::ParticleAttribBase<Properties...>;
@@ -92,15 +88,13 @@ namespace ippl {
         using attribute_container_type =
             typename detail::ContainerForAllSpaces<container_type>::type;
 
-        using bc_container_type = typename PLayout::bc_container_type;
+//         using bc_container_type = typename PLayout::bc_container_type;
 
         using hash_container_type = typename detail::ContainerForAllSpaces<detail::hash_type>::type;
 
         using size_type = detail::size_type;
 
     public:
-        //! view of particle positions
-        particle_position_type R;
 
         //! view of particle IDs
         particle_index_type ID;
@@ -118,7 +112,7 @@ namespace ippl {
          * is null afterwards, i.e., layout == nullptr.
          * @param layout to be moved.
          */
-        ParticleBase(Layout_t& layout);
+        ParticleBase(std::shared_ptr<ParticleLayout> layout);
 
         /* cannot use '= default' since we get a
          * compiler warning otherwise:
@@ -135,7 +129,7 @@ namespace ippl {
          * when the ParticleBase instance is constructed with the
          * default ctor.
          */
-        void initialize(Layout_t& layout);
+        void initialize(std::shared_ptr<ParticleLayout> layout);
 
         /*!
          * @returns processor local number of particles
@@ -147,24 +141,24 @@ namespace ippl {
         /*!
          * @returns particle layout
          */
-        Layout_t& getLayout() { return *layout_m; }
+        std::shared_ptr<ParticleLayout> getLayout() { return layout_m; }
 
         /*!
          * @returns particle layout
          */
-        const Layout_t& getLayout() const { return *layout_m; }
+        const std::shared_ptr<ParticleLayout> getLayout() const { return layout_m; }
 
-        /*!
-         * Set all boundary conditions
-         * @param bc the boundary conditions
-         */
-        void setParticleBC(const bc_container_type& bcs) { layout_m->setParticleBC(bcs); }
+//         /*!
+//          * Set all boundary conditions
+//          * @param bc the boundary conditions
+//          */
+//         void setParticleBC(const bc_container_type& bcs) { layout_m->setParticleBC(bcs); }
 
-        /*!
-         * Set all boundary conditions to this BC
-         * @param bc the boundary conditions
-         */
-        void setParticleBC(BC bc) { layout_m->setParticleBC(bc); }
+//         /*!
+//          * Set all boundary conditions to this BC
+//          * @param bc the boundary conditions
+//          */
+//         void setParticleBC(BC bc) { layout_m->setParticleBC(bc); }
 
         /*!
          * Add particle attribute
@@ -299,7 +293,7 @@ namespace ippl {
     private:
         //! particle layout
         // cannot use std::unique_ptr due to Kokkos
-        Layout_t* layout_m;
+        std::shared_ptr<ParticleLayout> layout_m;
 
         //! processor local number of particles
         size_type localNum_m;

--- a/src/Particle/ParticleBase.hpp
+++ b/src/Particle/ParticleBase.hpp
@@ -51,8 +51,8 @@
 
 namespace ippl {
 
-    template <typename... IP>
-    ParticleBase<IP...>::ParticleBase()
+    template <class PLayout, typename... IP>
+    ParticleBase<PLayout, IP...>::ParticleBase()
         : layout_m(nullptr)
         , localNum_m(0)
         , nextID_m(Comm->rank())
@@ -60,28 +60,32 @@ namespace ippl {
         if constexpr (EnableIDs) {
             addAttribute(ID);
         }
+        addAttribute(R);
     }
 
-    template <typename... IP>
-    ParticleBase<IP...>::ParticleBase(std::shared_ptr<ParticleLayout> layout)
-        : ParticleBase()
-        , layout_m(std::move(layout))
-    { }
+    template <class PLayout, typename... IP>
+    ParticleBase<PLayout, IP...>::ParticleBase(PLayout& layout)
+        : ParticleBase() {
+        initialize(layout);
+    }
 
-    template <typename... IP>
+    template <class PLayout, typename... IP>
     template <typename MemorySpace>
-    void ParticleBase<IP...>::addAttribute(detail::ParticleAttribBase<MemorySpace>& pa) {
+    void ParticleBase<PLayout, IP...>::addAttribute(detail::ParticleAttribBase<MemorySpace>& pa) {
         attributes_m.template get<MemorySpace>().push_back(&pa);
         pa.setParticleCount(localNum_m);
     }
 
-    template <typename... IP>
-    void ParticleBase<IP...>::initialize(std::shared_ptr<ParticleLayout> layout) {
-        layout_m = std::move(layout);
+    template <class PLayout, typename... IP>
+    void ParticleBase<PLayout, IP...>::initialize(PLayout& layout) {
+        //         PAssert(layout_m == nullptr);
+
+        // save the layout, and perform setup tasks
+        layout_m = &layout;
     }
 
-    template <typename... IP>
-    void ParticleBase<IP...>::create(size_type nLocal) {
+    template <class PLayout, typename... IP>
+    void ParticleBase<PLayout, IP...>::create(size_type nLocal) {
         PAssert(layout_m != nullptr);
 
         forAllAttributes([&]<typename Attribute>(Attribute& attribute) {
@@ -106,8 +110,8 @@ namespace ippl {
         localNum_m += nLocal;
     }
 
-    template <typename... IP>
-    void ParticleBase<IP...>::createWithID(index_type id) {
+    template <class PLayout, typename... IP>
+    void ParticleBase<PLayout, IP...>::createWithID(index_type id) {
         PAssert(layout_m != nullptr);
 
         // temporary change
@@ -121,8 +125,8 @@ namespace ippl {
         numNodes_m = Comm->getNodes();
     }
 
-    template <typename... IP>
-    void ParticleBase<IP...>::globalCreate(size_type nTotal) {
+    template <class PLayout, typename... IP>
+    void ParticleBase<PLayout, IP...>::globalCreate(size_type nTotal) {
         PAssert(layout_m != nullptr);
 
         // Compute the number of particles local to each processor
@@ -138,9 +142,9 @@ namespace ippl {
         create(nLocal);
     }
 
-    template <typename... IP>
+    template <class PLayout, typename... IP>
     template <typename... Properties>
-    void ParticleBase<IP...>::destroy(const Kokkos::View<bool*, Properties...>& invalid,
+    void ParticleBase<PLayout, IP...>::destroy(const Kokkos::View<bool*, Properties...>& invalid,
                                                const size_type destroyNum) {
         PAssert(destroyNum <= localNum_m);
 
@@ -239,9 +243,9 @@ namespace ippl {
         });
     }
 
-    template <typename... IP>
+    template <class PLayout, typename... IP>
     template <typename HashType, typename BufferType>
-    void ParticleBase<IP...>::sendToRank(int rank, int tag, int sendNum,
+    void ParticleBase<PLayout, IP...>::sendToRank(int rank, int tag, int sendNum,
                                                   std::vector<MPI_Request>& requests,
                                                   const HashType& hash, BufferType& buffer) {
         size_type nSends = hash.size();
@@ -264,9 +268,9 @@ namespace ippl {
         });
     }
 
-    template <typename... IP>
+    template <class PLayout, typename... IP>
     template <typename BufferType>
-    void ParticleBase<IP...>::recvFromRank(int rank, int tag, int recvNum,
+    void ParticleBase<PLayout, IP...>::recvFromRank(int rank, int tag, int recvNum,
                                                     size_type nRecvs, BufferType& buffer) {
         detail::runForAllSpaces([&]<typename MemorySpace>() {
             size_type bufSize = packedSize<MemorySpace>(nRecvs);
@@ -282,27 +286,27 @@ namespace ippl {
         unpack(buffer, nRecvs);
     }
 
-    template <typename... IP>
+    template <class PLayout, typename... IP>
     template <typename Archive>
-    void ParticleBase<IP...>::serialize(Archive& ar, size_type nsends) {
+    void ParticleBase<PLayout, IP...>::serialize(Archive& ar, size_type nsends) {
         using memory_space = typename Archive::buffer_type::memory_space;
         forAllAttributes<memory_space>([&]<typename Attribute>(Attribute& att) {
             att->serialize(ar, nsends);
         });
     }
 
-    template <typename... IP>
+    template <class PLayout, typename... IP>
     template <typename Archive>
-    void ParticleBase<IP...>::deserialize(Archive& ar, size_type nrecvs) {
+    void ParticleBase<PLayout, IP...>::deserialize(Archive& ar, size_type nrecvs) {
         using memory_space = typename Archive::buffer_type::memory_space;
         forAllAttributes<memory_space>([&]<typename Attribute>(Attribute& att) {
             att->deserialize(ar, nrecvs);
         });
     }
 
-    template <typename... IP>
+    template <class PLayout, typename... IP>
     template <typename MemorySpace>
-    detail::size_type ParticleBase<IP...>::packedSize(const size_type count) const {
+    detail::size_type ParticleBase<PLayout, IP...>::packedSize(const size_type count) const {
         size_type total = 0;
         forAllAttributes<MemorySpace>([&]<typename Attribute>(const Attribute& att) {
             total += att->packedSize(count);
@@ -310,9 +314,9 @@ namespace ippl {
         return total;
     }
 
-    template <typename... IP>
+    template <class PLayout, typename... IP>
     template <class Buffer>
-    void ParticleBase<IP...>::pack(Buffer& buffer, const hash_container_type& hash) {
+    void ParticleBase<PLayout, IP...>::pack(Buffer& buffer, const hash_container_type& hash) {
         detail::runForAllSpaces([&]<typename MemorySpace>() {
             auto& att = attributes_m.template get<MemorySpace>();
             for (unsigned j = 0; j < att.size(); j++) {
@@ -322,9 +326,9 @@ namespace ippl {
         });
     }
 
-    template <typename... IP>
+    template <class PLayout, typename... IP>
     template <class Buffer>
-    void ParticleBase<IP...>::unpack(Buffer& buffer, size_type nrecvs) {
+    void ParticleBase<PLayout, IP...>::unpack(Buffer& buffer, size_type nrecvs) {
         detail::runForAllSpaces([&]<typename MemorySpace>() {
             auto& att = attributes_m.template get<MemorySpace>();
             for (unsigned j = 0; j < att.size(); j++) {

--- a/src/Particle/ParticleLayout.h
+++ b/src/Particle/ParticleLayout.h
@@ -37,23 +37,26 @@
 #include "Particle/ParticleBC.h"
 
 namespace ippl {
+    namespace detail {
         // ParticleLayout class definition.  Template parameters are the type
         // and dimension of the ParticlePos object used for the particles.
-//         template <typename T, unsigned Dim>
+        template <typename T, unsigned Dim, typename... PositionProperties>
         class ParticleLayout {
         public:
-//             typedef T value_type;
+            typedef T value_type;
+            typedef std::int64_t index_type;
+            typedef Vector<T, Dim> vector_type;
 
-//             using particle_position_type   = ParticleAttrib<vector_type, PositionProperties...>;
-//             using position_memory_space    = typename particle_position_type::memory_space;
-//             using position_execution_space = typename particle_position_type::execution_space;
+            using particle_position_type   = ParticleAttrib<vector_type, PositionProperties...>;
+            using position_memory_space    = typename particle_position_type::memory_space;
+            using position_execution_space = typename particle_position_type::execution_space;
 
-//             typedef std::array<BC, 2 * Dim> bc_container_type;
+            typedef std::array<BC, 2 * Dim> bc_container_type;
 
-//             static constexpr unsigned dim = Dim;
+            static constexpr unsigned dim = Dim;
 
         public:
-            ParticleLayout() { /*bcs_m.fill(BC::NO);*/ };
+            ParticleLayout() { bcs_m.fill(BC::NO); };
 
             ~ParticleLayout() = default;
 
@@ -63,30 +66,31 @@ namespace ippl {
                 std::cout << "TODO" << std::endl;
             }
 
-//             /*!
-//              * Copy over the given boundary conditions.
-//              * @param bcs are the boundary conditions
-//              */
-//             void setParticleBC(bc_container_type bcs) { bcs_m = bcs; }
+            /*!
+             * Copy over the given boundary conditions.
+             * @param bcs are the boundary conditions
+             */
+            void setParticleBC(bc_container_type bcs) { bcs_m = bcs; }
 
-//             /*!
-//              * Use the same boundary condition on each face
-//              * @param bcs are the boundary conditions
-//              */
-//             void setParticleBC(BC bc) { bcs_m.fill(bc); }
+            /*!
+             * Use the same boundary condition on each face
+             * @param bcs are the boundary conditions
+             */
+            void setParticleBC(BC bc) { bcs_m.fill(bc); }
 
-//             /*!
-//              * Apply the given boundary conditions to the current particle positions.
-//              * @tparam R is the particle position attribute
-//              * @tparam nr is the NDRegion
-//              * @param
-//              */
-//             void applyBC(const particle_position_type& R, const NDRegion<T, Dim>& nr);
-/*
+            /*!
+             * Apply the given boundary conditions to the current particle positions.
+             * @tparam R is the particle position attribute
+             * @tparam nr is the NDRegion
+             * @param
+             */
+            void applyBC(const particle_position_type& R, const NDRegion<T, Dim>& nr);
+
         private:
             //! the list of boundary conditions for this set of particles
-            bc_container_type bcs_m;*/
+            bc_container_type bcs_m;
         };
+    }  // namespace detail
 }  // namespace ippl
 
 #include "Particle/ParticleLayout.hpp"

--- a/src/Particle/ParticleLayout.h
+++ b/src/Particle/ParticleLayout.h
@@ -37,26 +37,23 @@
 #include "Particle/ParticleBC.h"
 
 namespace ippl {
-    namespace detail {
         // ParticleLayout class definition.  Template parameters are the type
         // and dimension of the ParticlePos object used for the particles.
-        template <typename T, unsigned Dim, typename... PositionProperties>
+//         template <typename T, unsigned Dim>
         class ParticleLayout {
         public:
-            typedef T value_type;
-            typedef std::int64_t index_type;
-            typedef Vector<T, Dim> vector_type;
+//             typedef T value_type;
 
-            using particle_position_type   = ParticleAttrib<vector_type, PositionProperties...>;
-            using position_memory_space    = typename particle_position_type::memory_space;
-            using position_execution_space = typename particle_position_type::execution_space;
+//             using particle_position_type   = ParticleAttrib<vector_type, PositionProperties...>;
+//             using position_memory_space    = typename particle_position_type::memory_space;
+//             using position_execution_space = typename particle_position_type::execution_space;
 
-            typedef std::array<BC, 2 * Dim> bc_container_type;
+//             typedef std::array<BC, 2 * Dim> bc_container_type;
 
-            static constexpr unsigned dim = Dim;
+//             static constexpr unsigned dim = Dim;
 
         public:
-            ParticleLayout() { bcs_m.fill(BC::NO); };
+            ParticleLayout() { /*bcs_m.fill(BC::NO);*/ };
 
             ~ParticleLayout() = default;
 
@@ -66,31 +63,30 @@ namespace ippl {
                 std::cout << "TODO" << std::endl;
             }
 
-            /*!
-             * Copy over the given boundary conditions.
-             * @param bcs are the boundary conditions
-             */
-            void setParticleBC(bc_container_type bcs) { bcs_m = bcs; }
+//             /*!
+//              * Copy over the given boundary conditions.
+//              * @param bcs are the boundary conditions
+//              */
+//             void setParticleBC(bc_container_type bcs) { bcs_m = bcs; }
 
-            /*!
-             * Use the same boundary condition on each face
-             * @param bcs are the boundary conditions
-             */
-            void setParticleBC(BC bc) { bcs_m.fill(bc); }
+//             /*!
+//              * Use the same boundary condition on each face
+//              * @param bcs are the boundary conditions
+//              */
+//             void setParticleBC(BC bc) { bcs_m.fill(bc); }
 
-            /*!
-             * Apply the given boundary conditions to the current particle positions.
-             * @tparam R is the particle position attribute
-             * @tparam nr is the NDRegion
-             * @param
-             */
-            void applyBC(const particle_position_type& R, const NDRegion<T, Dim>& nr);
-
+//             /*!
+//              * Apply the given boundary conditions to the current particle positions.
+//              * @tparam R is the particle position attribute
+//              * @tparam nr is the NDRegion
+//              * @param
+//              */
+//             void applyBC(const particle_position_type& R, const NDRegion<T, Dim>& nr);
+/*
         private:
             //! the list of boundary conditions for this set of particles
-            bc_container_type bcs_m;
+            bc_container_type bcs_m;*/
         };
-    }  // namespace detail
 }  // namespace ippl
 
 #include "Particle/ParticleLayout.hpp"

--- a/src/Particle/ParticleLayout.hpp
+++ b/src/Particle/ParticleLayout.hpp
@@ -30,47 +30,47 @@
 
 namespace ippl {
     namespace detail {
-        template <typename T, unsigned Dim, typename... Properties>
-        void ParticleLayout<T, Dim, Properties...>::applyBC(const particle_position_type& R,
-                                                            const NDRegion<T, Dim>& nr) {
-            /* loop over all faces
-             * 0: lower x-face
-             * 1: upper x-face
-             * 2: lower y-face
-             * 3: upper y-face
-             * etc...
-             */
-            Kokkos::RangePolicy<typename particle_position_type::execution_space> policy{
-                0, (unsigned)R.getParticleCount()};
-            for (unsigned face = 0; face < 2 * Dim; ++face) {
-                // unsigned face = i % Dim;
-                unsigned d   = face / 2;
-                bool isUpper = face & 1;
-                switch (bcs_m[face]) {
-                    case BC::PERIODIC:
-                        // Periodic faces come in pairs and the application of
-                        // BCs checks both sides, so there is no reason to
-                        // apply periodic conditions twice
-                        if (isUpper) {
-                            break;
-                        }
-
-                        Kokkos::parallel_for("Periodic BC", policy,
-                                             PeriodicBC(R.getView(), nr, d, isUpper));
-                        break;
-                    case BC::REFLECTIVE:
-                        Kokkos::parallel_for("Reflective BC", policy,
-                                             ReflectiveBC(R.getView(), nr, d, isUpper));
-                        break;
-                    case BC::SINK:
-                        Kokkos::parallel_for("Sink BC", policy,
-                                             SinkBC(R.getView(), nr, d, isUpper));
-                        break;
-                    case BC::NO:
-                    default:
-                        break;
-                }
-            }
-        }
+//         template <typename T, unsigned Dim, typename... Properties>
+//         void ParticleLayout<Properties...>::applyBC(const particle_position_type& R,
+//                                                             const NDRegion<T, Dim>& nr) {
+//             /* loop over all faces
+//              * 0: lower x-face
+//              * 1: upper x-face
+//              * 2: lower y-face
+//              * 3: upper y-face
+//              * etc...
+//              */
+//             Kokkos::RangePolicy<typename particle_position_type::execution_space> policy{
+//                 0, (unsigned)R.getParticleCount()};
+//             for (unsigned face = 0; face < 2 * Dim; ++face) {
+//                 // unsigned face = i % Dim;
+//                 unsigned d   = face / 2;
+//                 bool isUpper = face & 1;
+//                 switch (bcs_m[face]) {
+//                     case BC::PERIODIC:
+//                         // Periodic faces come in pairs and the application of
+//                         // BCs checks both sides, so there is no reason to
+//                         // apply periodic conditions twice
+//                         if (isUpper) {
+//                             break;
+//                         }
+//
+//                         Kokkos::parallel_for("Periodic BC", policy,
+//                                              PeriodicBC(R.getView(), nr, d, isUpper));
+//                         break;
+//                     case BC::REFLECTIVE:
+//                         Kokkos::parallel_for("Reflective BC", policy,
+//                                              ReflectiveBC(R.getView(), nr, d, isUpper));
+//                         break;
+//                     case BC::SINK:
+//                         Kokkos::parallel_for("Sink BC", policy,
+//                                              SinkBC(R.getView(), nr, d, isUpper));
+//                         break;
+//                     case BC::NO:
+//                     default:
+//                         break;
+//                 }
+//             }
+//         }
     }  // namespace detail
 }  // namespace ippl

--- a/src/Particle/ParticleLayout.hpp
+++ b/src/Particle/ParticleLayout.hpp
@@ -30,47 +30,47 @@
 
 namespace ippl {
     namespace detail {
-//         template <typename T, unsigned Dim, typename... Properties>
-//         void ParticleLayout<Properties...>::applyBC(const particle_position_type& R,
-//                                                             const NDRegion<T, Dim>& nr) {
-//             /* loop over all faces
-//              * 0: lower x-face
-//              * 1: upper x-face
-//              * 2: lower y-face
-//              * 3: upper y-face
-//              * etc...
-//              */
-//             Kokkos::RangePolicy<typename particle_position_type::execution_space> policy{
-//                 0, (unsigned)R.getParticleCount()};
-//             for (unsigned face = 0; face < 2 * Dim; ++face) {
-//                 // unsigned face = i % Dim;
-//                 unsigned d   = face / 2;
-//                 bool isUpper = face & 1;
-//                 switch (bcs_m[face]) {
-//                     case BC::PERIODIC:
-//                         // Periodic faces come in pairs and the application of
-//                         // BCs checks both sides, so there is no reason to
-//                         // apply periodic conditions twice
-//                         if (isUpper) {
-//                             break;
-//                         }
-//
-//                         Kokkos::parallel_for("Periodic BC", policy,
-//                                              PeriodicBC(R.getView(), nr, d, isUpper));
-//                         break;
-//                     case BC::REFLECTIVE:
-//                         Kokkos::parallel_for("Reflective BC", policy,
-//                                              ReflectiveBC(R.getView(), nr, d, isUpper));
-//                         break;
-//                     case BC::SINK:
-//                         Kokkos::parallel_for("Sink BC", policy,
-//                                              SinkBC(R.getView(), nr, d, isUpper));
-//                         break;
-//                     case BC::NO:
-//                     default:
-//                         break;
-//                 }
-//             }
-//         }
+        template <typename T, unsigned Dim, typename... Properties>
+        void ParticleLayout<T, Dim, Properties...>::applyBC(const particle_position_type& R,
+                                                            const NDRegion<T, Dim>& nr) {
+            /* loop over all faces
+             * 0: lower x-face
+             * 1: upper x-face
+             * 2: lower y-face
+             * 3: upper y-face
+             * etc...
+             */
+            Kokkos::RangePolicy<typename particle_position_type::execution_space> policy{
+                0, (unsigned)R.getParticleCount()};
+            for (unsigned face = 0; face < 2 * Dim; ++face) {
+                // unsigned face = i % Dim;
+                unsigned d   = face / 2;
+                bool isUpper = face & 1;
+                switch (bcs_m[face]) {
+                    case BC::PERIODIC:
+                        // Periodic faces come in pairs and the application of
+                        // BCs checks both sides, so there is no reason to
+                        // apply periodic conditions twice
+                        if (isUpper) {
+                            break;
+                        }
+
+                        Kokkos::parallel_for("Periodic BC", policy,
+                                             PeriodicBC(R.getView(), nr, d, isUpper));
+                        break;
+                    case BC::REFLECTIVE:
+                        Kokkos::parallel_for("Reflective BC", policy,
+                                             ReflectiveBC(R.getView(), nr, d, isUpper));
+                        break;
+                    case BC::SINK:
+                        Kokkos::parallel_for("Sink BC", policy,
+                                             SinkBC(R.getView(), nr, d, isUpper));
+                        break;
+                    case BC::NO:
+                    default:
+                        break;
+                }
+            }
+        }
     }  // namespace detail
 }  // namespace ippl

--- a/src/Particle/ParticleSpatialLayout.h
+++ b/src/Particle/ParticleSpatialLayout.h
@@ -64,8 +64,8 @@ namespace ippl {
 
         void updateLayout(FieldLayout<Dim>&, Mesh&);
 
-        template <class BufferType>
-        void update(BufferType& pdata, BufferType& buffer);
+        template <class ParticleContainer>
+        void update(ParticleContainer& pc);
 
         const RegionLayout_t& getRegionLayout() const { return rlayout_m; }
 
@@ -83,15 +83,15 @@ namespace ippl {
         /*!
          * For each particle in the bunch, determine the rank on which it should
          * be stored based on its location
-         * @tparam ParticleBunch the bunch type
-         * @param pdata the particle bunch
+         * @tparam ParticleContainer the particle container type
+         * @param pc the particle container
          * @param ranks the integer view in which to store the destination ranks
          * @param invalid the boolean view in which to store whether each particle
          * is invalidated, i.e. needs to be sent to another rank
          * @return The total number of invalidated particles
          */
-        template <typename ParticleBunch>
-        size_type locateParticles(const ParticleBunch& pdata, locate_type& ranks,
+        template <typename ParticleContainer>
+        size_type locateParticles(const ParticleContainer& pc, locate_type& ranks,
                                   bool_type& invalid) const;
 
         /*!

--- a/src/Particle/ParticleSpatialLayout.h
+++ b/src/Particle/ParticleSpatialLayout.h
@@ -36,18 +36,18 @@ namespace ippl {
      * @tparam Dim dimension
      * @tparam Mesh type
      */
-    template <typename T, unsigned Dim, class Mesh = UniformCartesian<T, Dim>,
-              typename... PositionProperties>
-    class ParticleSpatialLayout : public detail::ParticleLayout<T, Dim, PositionProperties...> {
+    template <typename T, unsigned Dim, class Mesh, typename... PositionProperties>
+    class ParticleSpatialLayout : public ParticleLayout {
     public:
-        using Base = detail::ParticleLayout<T, Dim, PositionProperties...>;
-        using typename Base::position_memory_space, typename Base::position_execution_space;
+        using particle_position_type   = ParticleAttrib<T, PositionProperties...>;
+        using position_memory_space    = typename particle_position_type::memory_space;
+        using position_execution_space = typename particle_position_type::execution_space;
 
         using hash_type   = detail::hash_type<position_memory_space>;
         using locate_type = typename detail::ViewType<int, 1, position_memory_space>::view_type;
         using bool_type   = typename detail::ViewType<bool, 1, position_memory_space>::view_type;
 
-        using vector_type = typename Base::vector_type;
+        using position_type = T;
         using RegionLayout_t =
             typename detail::RegionLayout<T, Dim, Mesh, position_memory_space>::uniform_type;
 
@@ -58,7 +58,7 @@ namespace ippl {
         ParticleSpatialLayout(FieldLayout<Dim>&, Mesh&);
 
         ParticleSpatialLayout()
-            : detail::ParticleLayout<T, Dim, PositionProperties...>() {}
+            : ParticleLayout() {}
 
         ~ParticleSpatialLayout() = default;
 
@@ -66,8 +66,6 @@ namespace ippl {
 
         template <class BufferType>
         void update(BufferType& pdata, BufferType& buffer);
-
-        const RegionLayout_t& getRegionLayout() const { return rlayout_m; }
 
     protected:
         //! The RegionLayout which determines where our particles go.
@@ -77,7 +75,7 @@ namespace ippl {
 
         template <size_t... Idx>
         KOKKOS_INLINE_FUNCTION constexpr static bool positionInRegion(
-            const std::index_sequence<Idx...>&, const vector_type& pos, const region_type& region);
+            const std::index_sequence<Idx...>&, const position_type& pos, const region_type& region);
 
     public:
         /*!

--- a/src/Particle/ParticleSpatialLayout.hpp
+++ b/src/Particle/ParticleSpatialLayout.hpp
@@ -159,7 +159,7 @@ namespace ippl {
     template <size_t... Idx>
     KOKKOS_INLINE_FUNCTION constexpr bool
     ParticleSpatialLayout<T, Dim, Mesh, Properties...>::positionInRegion(
-        const std::index_sequence<Idx...>&, const vector_type& pos, const region_type& region) {
+        const std::index_sequence<Idx...>&, const position_type& pos, const region_type& region) {
         return ((pos[Idx] >= region[Idx].min()) && ...) && ((pos[Idx] <= region[Idx].max()) && ...);
     };
 

--- a/src/Particle/ParticleSpatialLayout.hpp
+++ b/src/Particle/ParticleSpatialLayout.hpp
@@ -159,7 +159,7 @@ namespace ippl {
     template <size_t... Idx>
     KOKKOS_INLINE_FUNCTION constexpr bool
     ParticleSpatialLayout<T, Dim, Mesh, Properties...>::positionInRegion(
-        const std::index_sequence<Idx...>&, const position_type& pos, const region_type& region) {
+        const std::index_sequence<Idx...>&, const vector_type& pos, const region_type& region) {
         return ((pos[Idx] >= region[Idx].min()) && ...) && ((pos[Idx] <= region[Idx].max()) && ...);
     };
 

--- a/src/Particle/ParticleSpatialLayout.hpp
+++ b/src/Particle/ParticleSpatialLayout.hpp
@@ -39,12 +39,11 @@ namespace ippl {
     }
 
     template <typename T, unsigned Dim, class Mesh, typename... Properties>
-    template <class BufferType>
-    void ParticleSpatialLayout<T, Dim, Mesh, Properties...>::update(BufferType& pdata,
-                                                                    BufferType& buffer) {
+    template <class ParticleContainer>
+    void ParticleSpatialLayout<T, Dim, Mesh, Properties...>::update(ParticleContainer& pc) {
         static IpplTimings::TimerRef ParticleBCTimer = IpplTimings::getTimer("particleBC");
         IpplTimings::startTimer(ParticleBCTimer);
-        this->applyBC(pdata.R, rlayout_m.getDomain());
+        this->applyBC(pc.R, rlayout_m.getDomain());
         IpplTimings::stopTimer(ParticleBCTimer);
 
         static IpplTimings::TimerRef ParticleUpdateTimer = IpplTimings::getTimer("updateParticle");
@@ -64,7 +63,7 @@ namespace ippl {
 
         static IpplTimings::TimerRef locateTimer = IpplTimings::getTimer("locateParticles");
         IpplTimings::startTimer(locateTimer);
-        size_type localnum = pdata.getLocalNum();
+        size_type localnum = pc.getLocalNum();
 
         // 1st step
 
@@ -78,7 +77,7 @@ namespace ippl {
          */
         bool_type invalid("invalid", localnum);
 
-        size_type invalidCount = locateParticles(pdata, ranks, invalid);
+        size_type invalidCount = locateParticles(pc, ranks, invalid);
         IpplTimings::stopTimer(locateTimer);
 
         // 2nd step
@@ -121,7 +120,7 @@ namespace ippl {
                 hash_type hash("hash", nSends[rank]);
                 fillHash(rank, ranks, hash);
 
-                pdata.sendToRank(rank, tag, sends++, requests, hash, buffer);
+                pc.sendToRank(rank, tag, sends++, requests, hash);
             }
         }
         IpplTimings::stopTimer(sendTimer);
@@ -130,7 +129,7 @@ namespace ippl {
         static IpplTimings::TimerRef destroyTimer = IpplTimings::getTimer("particleDestroy");
         IpplTimings::startTimer(destroyTimer);
 
-        pdata.destroy(invalid, invalidCount);
+        pc.destroy(invalid, invalidCount);
         Kokkos::fence();
 
         IpplTimings::stopTimer(destroyTimer);
@@ -140,7 +139,7 @@ namespace ippl {
         int recvs = 0;
         for (int rank = 0; rank < nRanks; ++rank) {
             if (nRecvs[rank] > 0) {
-                pdata.recvFromRank(rank, tag, recvs++, nRecvs[rank], buffer);
+                pc.recvFromRank(rank, tag, recvs++, nRecvs[rank]);
             }
         }
         IpplTimings::stopTimer(recvTimer);
@@ -166,8 +165,8 @@ namespace ippl {
     template <typename T, unsigned Dim, class Mesh, typename... Properties>
     template <typename ParticleBunch>
     detail::size_type ParticleSpatialLayout<T, Dim, Mesh, Properties...>::locateParticles(
-        const ParticleBunch& pdata, locate_type& ranks, bool_type& invalid) const {
-        auto& positions                            = pdata.R.getView();
+        const ParticleBunch& pc, locate_type& ranks, bool_type& invalid) const {
+        auto& positions                            = pc.R.getView();
         typename RegionLayout_t::view_type Regions = rlayout_m.getdLocalRegions();
 
         using mdrange_type = Kokkos::MDRangePolicy<Kokkos::Rank<2>, position_execution_space>;

--- a/src/Particle/ParticleSpatialLayout.hpp
+++ b/src/Particle/ParticleSpatialLayout.hpp
@@ -163,9 +163,9 @@ namespace ippl {
     };
 
     template <typename T, unsigned Dim, class Mesh, typename... Properties>
-    template <typename ParticleBunch>
+    template <typename ParticleContainer>
     detail::size_type ParticleSpatialLayout<T, Dim, Mesh, Properties...>::locateParticles(
-        const ParticleBunch& pc, locate_type& ranks, bool_type& invalid) const {
+        const ParticleContainer& pc, locate_type& ranks, bool_type& invalid) const {
         auto& positions                            = pc.R.getView();
         typename RegionLayout_t::view_type Regions = rlayout_m.getdLocalRegions();
 

--- a/test/particle/PICnd.cpp
+++ b/test/particle/PICnd.cpp
@@ -79,18 +79,6 @@ public:
     typename ippl::ParticleBase<PLayout>::particle_position_type
         E;  // electric field at particle position
 
-    /*
-      This constructor is mandatory for all derived classes from
-      ParticleBase as the update function invokes this
-    */
-    ChargedParticles(PLayout& pl)
-        : ippl::ParticleBase<PLayout>(pl) {
-        // register the particle attributes
-        this->addAttribute(qm);
-        this->addAttribute(P);
-        this->addAttribute(E);
-    }
-
     ChargedParticles(PLayout& pl, Vector_t hr, Vector_t rmin, Vector_t rmax,
                      ippl::e_dim_tag decomp[Dim], double Q)
         : ippl::ParticleBase<PLayout>(pl)

--- a/test/particle/TestGather.cpp
+++ b/test/particle/TestGather.cpp
@@ -59,8 +59,7 @@ int main(int argc, char* argv[]) {
         Kokkos::deep_copy(bunch.R.getView(), R_host);
         Kokkos::deep_copy(bunch.Q.getView(), Q_host);
 
-        bunch_type buffer(pl);
-        pl.update(bunch, buffer);
+        bunch.update();
 
         typedef ippl::Field<double, 3, Mesh_t, Centering_t> field_type;
 

--- a/test/particle/TestScatter.cpp
+++ b/test/particle/TestScatter.cpp
@@ -88,8 +88,7 @@ int main(int argc, char* argv[]) {
 
         bunch.Q = 1.0;
 
-        bunch_type bunchBuffer(pl);
-        pl.update(bunch, bunchBuffer);
+        bunch.update();
 
         field = 0.0;
 

--- a/test/particle/benchmarkParticleUpdate.cpp
+++ b/test/particle/benchmarkParticleUpdate.cpp
@@ -48,18 +48,6 @@ public:
     typename ippl::ParticleBase<PLayout>::particle_position_type
         E;  // electric field at particle position
 
-    /*
-      This constructor is mandatory for all derived classes from
-      ParticleBase as the update function invokes this
-    */
-    ChargedParticles(PLayout& pl)
-        : ippl::ParticleBase<PLayout>(pl) {
-        // register the particle attributes
-        this->addAttribute(qm);
-        this->addAttribute(P);
-        this->addAttribute(E);
-    }
-
     ChargedParticles(PLayout& pl, Vector_t hr, Vector_t rmin, Vector_t rmax,
                      ippl::e_dim_tag decomp[Dim], double Q)
         : ippl::ParticleBase<PLayout>(pl)

--- a/test/particle/benchmarkParticleUpdate.cpp
+++ b/test/particle/benchmarkParticleUpdate.cpp
@@ -218,10 +218,9 @@ int main(int argc, char* argv[]) {
         IpplTimings::stopTimer(particleCreation);
         P->E = 0.0;
 
-        bunch_type bunchBuffer(PL);
         static IpplTimings::TimerRef UpdateTimer = IpplTimings::getTimer("ParticleUpdate");
         IpplTimings::startTimer(UpdateTimer);
-        PL.update(*P, bunchBuffer);
+        P->update();
         IpplTimings::stopTimer(UpdateTimer);
 
         msg << "particles created and initial conditions assigned " << endl;
@@ -271,7 +270,7 @@ int main(int argc, char* argv[]) {
             IpplTimings::stopTimer(RTimer);
 
             IpplTimings::startTimer(UpdateTimer);
-            PL.update(*P, bunchBuffer);
+            P->update();
             IpplTimings::stopTimer(UpdateTimer);
 
             // advance the particle velocities

--- a/unit_tests/PIC/ORB.cpp
+++ b/unit_tests/PIC/ORB.cpp
@@ -130,18 +130,16 @@ TYPED_TEST_CASE(ORBTest, Tests);
 TYPED_TEST(ORBTest, Volume) {
     constexpr unsigned Dim = TestFixture::dim;
 
-    auto& pl     = this->playout;
     auto& bunch  = this->bunch;
     auto& layout = this->layout;
 
     ippl::NDIndex<Dim> dom = layout.getDomain();
-    typename TestFixture::bunch_type buffer(pl);
 
-    pl.update(*bunch, buffer);
+    bunch->update();
 
     this->repartition();
 
-    pl.update(*bunch, buffer);
+    bunch->update();
 
     ippl::NDIndex<Dim> ndom = layout.getDomain();
 
@@ -149,21 +147,18 @@ TYPED_TEST(ORBTest, Volume) {
 }
 
 TYPED_TEST(ORBTest, Charge) {
-    auto& pl    = this->playout;
     auto& bunch = this->bunch;
     auto& field = this->field;
-
-    typename TestFixture::bunch_type buffer(pl);
 
     double charge = 0.5;
 
     bunch->Q = charge;
 
-    pl.update(*bunch, buffer);
+    bunch->update();
 
     this->repartition();
 
-    pl.update(*bunch, buffer);
+    bunch->update();
 
     *field = 0.0;
     scatter(bunch->Q, *field, bunch->R);

--- a/unit_tests/PIC/PIC.cpp
+++ b/unit_tests/PIC/PIC.cpp
@@ -114,7 +114,7 @@ TYPED_TEST_CASE(PICTest, Tests);
 
 TYPED_TEST(PICTest, Scatter) {
     auto& field      = this->field;
-    auto& bunch = this->bunch;
+    auto& bunch      = this->bunch;
     auto& nParticles = this->nParticles;
 
     *field = 0.0;
@@ -134,7 +134,7 @@ TYPED_TEST(PICTest, Scatter) {
 
 TYPED_TEST(PICTest, Gather) {
     auto& field      = this->field;
-    auto& bunch = this->bunch;
+    auto& bunch      = this->bunch;
     auto& nParticles = this->nParticles;
 
     *field = 1.0;

--- a/unit_tests/PIC/PIC.cpp
+++ b/unit_tests/PIC/PIC.cpp
@@ -114,8 +114,7 @@ TYPED_TEST_CASE(PICTest, Tests);
 
 TYPED_TEST(PICTest, Scatter) {
     auto& field      = this->field;
-    auto& bunch      = this->bunch;
-    auto& pl         = this->playout;
+    auto& bunch = this->bunch;
     auto& nParticles = this->nParticles;
 
     *field = 0.0;
@@ -124,8 +123,7 @@ TYPED_TEST(PICTest, Scatter) {
 
     bunch->Q = charge;
 
-    typename TestFixture::bunch_type bunchBuffer(pl);
-    pl.update(*bunch, bunchBuffer);
+    bunch->update();
 
     scatter(bunch->Q, *field, bunch->R);
 
@@ -136,16 +134,14 @@ TYPED_TEST(PICTest, Scatter) {
 
 TYPED_TEST(PICTest, Gather) {
     auto& field      = this->field;
-    auto& bunch      = this->bunch;
-    auto& pl         = this->playout;
+    auto& bunch = this->bunch;
     auto& nParticles = this->nParticles;
 
     *field = 1.0;
 
     bunch->Q = 0.0;
 
-    typename TestFixture::bunch_type bunchBuffer(pl);
-    pl.update(*bunch, bunchBuffer);
+    bunch->update();
 
     gather(bunch->Q, *field, bunch->R);
 

--- a/unit_tests/Particle/ParticleSendRecv.cpp
+++ b/unit_tests/Particle/ParticleSendRecv.cpp
@@ -40,11 +40,6 @@ public:
 
         rank_type expectedRank;
         charge_container_type Q;
-
-        void update() {
-            PLayout& layout = this->getLayout();
-            layout.update(*this);
-        }
     };
 
     using bunch_type = Bunch<playout_type>;
@@ -151,11 +146,9 @@ TYPED_TEST_CASE(ParticleSendRecv, Tests);
 
 TYPED_TEST(ParticleSendRecv, SendAndRecieve) {
     const auto nParticles = this->nParticles;
-    auto& pl              = this->playout;
-    auto& bunch           = this->bunch;
+    auto& bunch = this->bunch;
 
-    typename TestFixture::bunch_type bunchBuffer(pl);
-    pl.update(*bunch, bunchBuffer);
+    bunch->update();
     // bunch->update();
     typename TestFixture::rank_type::view_type::host_mirror_type ER_host =
         bunch->expectedRank.getHostMirror();

--- a/unit_tests/Particle/ParticleSendRecv.cpp
+++ b/unit_tests/Particle/ParticleSendRecv.cpp
@@ -146,7 +146,7 @@ TYPED_TEST_CASE(ParticleSendRecv, Tests);
 
 TYPED_TEST(ParticleSendRecv, SendAndRecieve) {
     const auto nParticles = this->nParticles;
-    auto& bunch = this->bunch;
+    auto& bunch           = this->bunch;
 
     bunch->update();
     // bunch->update();


### PR DESCRIPTION
Add parcel attribute internal communication buffers. This simplifies the interface for parcel communication. No need of another particle container instance.