### PR TITLE
Field sum

### DIFF
--- a/src/Communicate/Collectives.hpp
+++ b/src/Communicate/Collectives.hpp
@@ -22,7 +22,7 @@ namespace ippl {
         void Communicator::reduce(const T* input, T* output, int count, Op op, int root) {
             MPI_Datatype type = get_mpi_datatype<T>(*input);
 
-            MPI_Op mpiOp = get_mpi_op<Op>(op);
+            MPI_Op mpiOp = get_mpi_op<Op, T>(op);
 
             MPI_Reduce(const_cast<T*>(input), output, count, type, mpiOp, root, *comm_m);
         }
@@ -36,7 +36,7 @@ namespace ippl {
         void Communicator::allreduce(const T* input, T* output, int count, Op op) {
             MPI_Datatype type = get_mpi_datatype<T>(*input);
 
-            MPI_Op mpiOp = get_mpi_op<Op>(op);
+            MPI_Op mpiOp = get_mpi_op<Op, T>(op);
 
             MPI_Allreduce(const_cast<T*>(input), output, count, type, mpiOp, *comm_m);
         }
@@ -50,7 +50,7 @@ namespace ippl {
         void Communicator::allreduce(T* inout, int count, Op op) {
             MPI_Datatype type = get_mpi_datatype<T>(*inout);
 
-            MPI_Op mpiOp = get_mpi_op<Op>(op);
+            MPI_Op mpiOp = get_mpi_op<Op, T>(op);
 
             MPI_Allreduce(MPI_IN_PLACE, inout, count, type, mpiOp, *comm_m);
         }

--- a/src/Communicate/Collectives.hpp
+++ b/src/Communicate/Collectives.hpp
@@ -19,10 +19,10 @@ namespace ippl {
         }
 
         template <typename T, class Op>
-        void Communicator::reduce(const T* input, T* output, int count, Op op, int root) {
+        void Communicator::reduce(const T* input, T* output, int count, Op, int root) {
             MPI_Datatype type = get_mpi_datatype<T>(*input);
 
-            MPI_Op mpiOp = get_mpi_op<Op, T>(op);
+            MPI_Op mpiOp = get_mpi_op<Op, T>();
 
             MPI_Reduce(const_cast<T*>(input), output, count, type, mpiOp, root, *comm_m);
         }
@@ -33,10 +33,10 @@ namespace ippl {
         }
 
         template <typename T, class Op>
-        void Communicator::allreduce(const T* input, T* output, int count, Op op) {
+        void Communicator::allreduce(const T* input, T* output, int count, Op) {
             MPI_Datatype type = get_mpi_datatype<T>(*input);
 
-            MPI_Op mpiOp = get_mpi_op<Op, T>(op);
+            MPI_Op mpiOp = get_mpi_op<Op, T>();
 
             MPI_Allreduce(const_cast<T*>(input), output, count, type, mpiOp, *comm_m);
         }
@@ -47,10 +47,10 @@ namespace ippl {
         }
 
         template <typename T, class Op>
-        void Communicator::allreduce(T* inout, int count, Op op) {
+        void Communicator::allreduce(T* inout, int count, Op) {
             MPI_Datatype type = get_mpi_datatype<T>(*inout);
 
-            MPI_Op mpiOp = get_mpi_op<Op, T>(op);
+            MPI_Op mpiOp = get_mpi_op<Op, T>();
 
             MPI_Allreduce(MPI_IN_PLACE, inout, count, type, mpiOp, *comm_m);
         }

--- a/src/Communicate/Operations.h
+++ b/src/Communicate/Operations.h
@@ -181,8 +181,7 @@ namespace ippl {
         IPPL_MPI_OP(std::logical_and<bool>, MPI_LAND);
 
         template <typename Op, typename Datatype>
-        MPI_Op get_mpi_op(Op op) {
-            (void)op;
+        MPI_Op get_mpi_op() {
             if constexpr (is_ippl_mpi_type<Op>::value) {
                 return getMpiOpImpl<Op, Datatype>{}();
             }

--- a/src/Communicate/Operations.h
+++ b/src/Communicate/Operations.h
@@ -6,6 +6,7 @@
 #define IPPL_MPI_OPERATIONS_H
 
 #include <Kokkos_Complex.hpp>
+#include <algorithm>
 #include <complex>
 #include <functional>
 #include <mpi.h>
@@ -13,22 +14,85 @@
 namespace ippl {
     namespace mpi {
 
+        enum struct binaryOperationKind {
+            SUM,
+            MIN, // Min and max are not really supported for nontrivial types such as vectors yet.
+            MAX, // This is due to min and max not being implemented for ippl expressions at all
+            MULTIPLICATION  // TODO: Add all
+        };
+        template <typename T>
+        struct extractBinaryOperationKind {};
+        template <typename T>
+        struct extractBinaryOperationKind<std::plus<T>> {
+            constexpr static binaryOperationKind value = binaryOperationKind::SUM;
+        };
+        template <typename T>
+        struct extractBinaryOperationKind<std::multiplies<T>> {
+            constexpr static binaryOperationKind value = binaryOperationKind::MULTIPLICATION;
+        };
+        template <typename T>
+        struct extractBinaryOperationKind<std::less<T>> {
+            constexpr static binaryOperationKind value = binaryOperationKind::MIN;
+        };
+        template <typename T>
+        struct extractBinaryOperationKind<std::greater<T>> {
+            constexpr static binaryOperationKind value = binaryOperationKind::MAX;
+        };
+
         template <class>
         struct is_ippl_mpi_type : std::false_type {};
+        struct dummy {};
 
-        template <class Op>
-        MPI_Op get_mpi_op(Op op) {
-            static_assert(is_ippl_mpi_type<Op>::value, "type not supported");
-            return get_mpi_op(op);
-        }
+        template <typename CppOpType, typename Datatype_IfNotTrivial>
+        struct getMpiOpImpl {
+            constexpr MPI_Op operator()() const noexcept {
+                static_assert(false, "This optype is not supported");
+                return 0;  // wtf
+            }
+        };
 
-#define IPPL_MPI_OP(CppOp, MPIOp)            \
-    template <>                              \
-    inline MPI_Op get_mpi_op<CppOp>(CppOp) { \
-        return MPIOp;                        \
-    }                                        \
-                                             \
-    template <>                              \
+        template <class Op, typename Type>
+        // requires (!is_ippl_mpi_type<Op>::value)
+        struct getNontrivialMpiOpImpl /*<Op, Type>*/ {
+            MPI_Op operator()() {
+                constexpr binaryOperationKind opKind = extractBinaryOperationKind<Op>::value;
+                MPI_Op ret;
+                MPI_Op_create(
+                    [](void* inputBuffer, void* outputBuffer, int* len, MPI_Datatype*) {
+                        Type* input = (Type*)inputBuffer;
+
+                        Type* output = (Type*)outputBuffer;
+
+                        for (int i = 0; i < *len; i++) {
+                            if constexpr (opKind == binaryOperationKind::SUM) {
+                                output[i] += input[i];
+                            }
+                            if constexpr (opKind == binaryOperationKind::MIN) {
+                                output[i] = min(output[i], input[i]);
+                            }
+                            if constexpr (opKind == binaryOperationKind::MAX) {
+                                output[i] = max(output[i], input[i]);
+                            }
+                            if constexpr (opKind == binaryOperationKind::MULTIPLICATION) {
+                                output[i] *= input[i];
+                            }
+                        }
+                    },
+                    1, &ret);
+                // static_assert(is_ippl_mpi_type<Op>::value, "type not supported");
+                return ret;
+                // return get_mpi_op(op);
+            }
+        };
+
+#define IPPL_MPI_OP(CppOp, MPIOp)                       \
+    template <typename Datatype_IfNotTrivial>           \
+    struct getMpiOpImpl<CppOp, Datatype_IfNotTrivial> { \
+        constexpr MPI_Op operator()() const noexcept {  \
+            return MPIOp;                               \
+        }                                               \
+    };                                                  \
+    template <>                                         \
     struct is_ippl_mpi_type<CppOp> : std::true_type {};
 
         /* with C++14 we should be able
@@ -52,10 +116,10 @@ namespace ippl {
         IPPL_MPI_OP(std::plus<double>, MPI_SUM);
         IPPL_MPI_OP(std::plus<long double>, MPI_SUM);
 
-        IPPL_MPI_OP(std::plus<std::complex<float> >, MPI_SUM);
-        IPPL_MPI_OP(std::plus<std::complex<double> >, MPI_SUM);
-        IPPL_MPI_OP(std::plus<Kokkos::complex<float> >, MPI_SUM);
-        IPPL_MPI_OP(std::plus<Kokkos::complex<double> >, MPI_SUM);
+        IPPL_MPI_OP(std::plus<std::complex<float>>, MPI_SUM);
+        IPPL_MPI_OP(std::plus<std::complex<double>>, MPI_SUM);
+        IPPL_MPI_OP(std::plus<Kokkos::complex<float>>, MPI_SUM);
+        IPPL_MPI_OP(std::plus<Kokkos::complex<double>>, MPI_SUM);
 
         IPPL_MPI_OP(std::less<char>, MPI_MIN);
         IPPL_MPI_OP(std::less<short>, MPI_MIN);
@@ -99,6 +163,17 @@ namespace ippl {
 
         IPPL_MPI_OP(std::logical_or<bool>, MPI_LOR);
         IPPL_MPI_OP(std::logical_and<bool>, MPI_LAND);
+
+        template <typename Op, typename Datatype>
+        MPI_Op get_mpi_op(Op op) {
+            (void)op;
+            if constexpr (is_ippl_mpi_type<Op>::value) {
+                return getMpiOpImpl<Op, Datatype>{}();
+            }
+            else {
+                return getNontrivialMpiOpImpl<Op, Datatype>{}();
+            }
+        }
     }  // namespace mpi
 }  // namespace ippl
 

--- a/src/Field/BareField.hpp
+++ b/src/Field/BareField.hpp
@@ -17,12 +17,46 @@
 namespace Kokkos {
     template <typename T, unsigned Dim>
     struct reduction_identity<ippl::Vector<T, Dim>> {
-        KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> sum() { return ippl::Vector<T, Dim>(0); }
-        KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> prod() { return ippl::Vector<T, Dim>(1); }
-        KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> min() { return ippl::Vector<T, Dim>( std::numeric_limits<T>::max()); }
-        KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> max() { return ippl::Vector<T, Dim>(-std::numeric_limits<T>::max()); }
+        KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> sum() {
+            return ippl::Vector<T, Dim>(0);
+        }
+        KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> prod() {
+            return ippl::Vector<T, Dim>(1);
+        }
+        KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> min() {
+            return ippl::Vector<T, Dim>(std::numeric_limits<T>::infinity());
+        }
+        KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> max() {
+            return ippl::Vector<T, Dim>(-std::numeric_limits<T>::infinity());
+        }
     };
 }  // namespace Kokkos
+namespace KokkosCorrection {
+    template <typename Scalar, class Space = Kokkos::HostSpace>
+    struct Max : Kokkos::Max<Scalar, Space> {
+        using Super      = Kokkos::Max<Scalar, Space>;
+        using value_type = Super::value_type;
+        KOKKOS_INLINE_FUNCTION void join(value_type& dest, const value_type& src) const {
+            using ippl::max;
+            using Kokkos::max;
+            dest = max(dest, src);
+        }
+    };
+    template <typename Scalar, class Space = Kokkos::HostSpace>
+    struct Min : Kokkos::Min<Scalar, Space> {
+        using Super      = Kokkos::Max<Scalar, Space>;
+        using value_type = Super::value_type;
+        KOKKOS_INLINE_FUNCTION void join(value_type& dest, const value_type& src) const {
+            using ippl::min;
+            using Kokkos::min;
+            dest = min(dest, src);
+        }
+    };
+    template <typename Scalar, class Space = Kokkos::HostSpace>
+    struct Sum : Kokkos::Sum<Scalar, Space> {};
+    template <typename Scalar, class Space = Kokkos::HostSpace>
+    struct Prod : Kokkos::Prod<Scalar, Space> {};
+}  // namespace KokkosCorrection
 namespace ippl {
     namespace detail {
         template <typename T, unsigned Dim, class... ViewArgs>
@@ -144,7 +178,7 @@ namespace ippl {
     template <typename T, unsigned Dim, class... ViewArgs>                                     \
     T BareField<T, Dim, ViewArgs...>::name(int nghost) const {                                 \
         PAssert_LE(nghost, nghost_m);                                                          \
-        T temp                 = 0.0;                                                          \
+        T temp                 = Kokkos::reduction_identity<T>::name();                        \
         using index_array_type = typename RangePolicy<Dim, execution_space>::index_array_type; \
         ippl::parallel_reduce(                                                                 \
             "fun", getRangePolicy(dview_m, nghost_m - nghost),                                 \
@@ -152,15 +186,15 @@ namespace ippl {
                 T myVal = apply(dview_m, args);                                                \
                 op;                                                                            \
             },                                                                                 \
-            Kokkos::fun<T>(temp));                                                             \
+            KokkosCorrection::fun<T>(temp));                                                   \
         T globaltemp = 0.0;                                                                    \
         layout_m->comm.allreduce(temp, globaltemp, 1, MPI_Op<T>());                            \
         return globaltemp;                                                                     \
     }
 
     DefineReduction(Sum, sum, valL += myVal, std::plus)
-    DefineReduction(Max, max, using Kokkos::max;valL = max(valL, myVal), std::greater)
-    DefineReduction(Min, min, using Kokkos::min;valL = min(valL, myVal), std::less)
+    DefineReduction(Max, max, using Kokkos::max; valL = max(valL, myVal), std::greater)
+    DefineReduction(Min, min, using Kokkos::min; valL = min(valL, myVal), std::less)
     DefineReduction(Prod, prod, valL *= myVal, std::multiplies)
 
 }  // namespace ippl

--- a/src/Types/Vector.h
+++ b/src/Types/Vector.h
@@ -45,7 +45,7 @@ namespace ippl {
         
         Vector(const std::array<T, Dim>& a);
 
-	Vector(const std::array<std::vector<T>, Dim>& a);
+	    Vector(const std::array<std::vector<T>, Dim>& a);
 
         /*!
          * @param list of values
@@ -98,9 +98,15 @@ namespace ippl {
 
         KOKKOS_INLINE_FUNCTION T dot(const Vector<T, Dim>& rhs) const;
 
-    private:
+    //Needs to be public to be a standard-layout type
+    //private:
         T data_m[Dim];
     };
+    
+    template<typename T, unsigned Dim>
+    KOKKOS_INLINE_FUNCTION Vector<T, Dim> min(const Vector<T, Dim>& a, const Vector<T, Dim>& b);
+    template<typename T, unsigned Dim>
+    KOKKOS_INLINE_FUNCTION Vector<T, Dim> max(const Vector<T, Dim>& a, const Vector<T, Dim>& b);
 }  // namespace ippl
 
 #include "Vector.hpp"

--- a/src/Types/Vector.hpp
+++ b/src/Types/Vector.hpp
@@ -203,6 +203,24 @@ namespace ippl {
         }
         return out;
     }
+    template<typename T, unsigned Dim>
+    KOKKOS_INLINE_FUNCTION Vector<T, Dim> min(const Vector<T, Dim>& a, const Vector<T, Dim>& b){
+        using Kokkos::min;
+        Vector<T, Dim> ret;
+        for(unsigned d = 0; d < Dim;d++){
+            ret[d] = min(a[d], b[d]);
+        }
+        return ret;
+    }
+    template<typename T, unsigned Dim>
+    KOKKOS_INLINE_FUNCTION Vector<T, Dim> max(const Vector<T, Dim>& a, const Vector<T, Dim>& b){
+        using Kokkos::max;
+        Vector<T, Dim> ret;
+        for(unsigned d = 0; d < Dim;d++){
+            ret[d] = max(a[d], b[d]);
+        }
+        return ret;
+    }
 }  // namespace ippl
 
 // vi: set et ts=4 sw=4 sts=4:


### PR DESCRIPTION
- Implement sum,prod,min,max for VFields with MPI
- unittests pass
- Cache MPI Datatypes and Ops in global maps
Currently, every Op & Type combo gets its own MPI_Op, not sure if that's optimal
