### PR TITLE
Fix compilation issues + add FFT warmup function

### DIFF
--- a/src/FFT/FFT.h
+++ b/src/FFT/FFT.h
@@ -177,6 +177,12 @@ namespace ippl {
         using typename Base::heffteBackend, typename Base::workspace_t, typename Base::Layout_t;
 
         /*!
+         * Warmup the FFT object by forward & backward FFT on an empty field
+         * @param f Field whose transformation to compute (and overwrite)
+         */
+        void warmup(ComplexField& f);
+
+        /*!
          * Perform in-place FFT
          * @param direction Forward or backward transformation
          * @param f Field whose transformation to compute (and overwrite)
@@ -210,6 +216,13 @@ namespace ippl {
         FFT(const Layout_t& layoutInput, const Layout_t& layoutOutput, const ParameterList& params);
 
         /*!
+         * Warmup the FFT object by forward & backward FFT on an empty field
+         * @param f Field whose transformation to compute
+         * @param g Field in which to store the transformation
+         */
+        void warmup(RealField& f, ComplexField& g);
+
+        /*!
          * Perform FFT
          * @param direction Forward or backward transformation
          * @param f Field whose transformation to compute
@@ -234,6 +247,12 @@ namespace ippl {
         using typename Base::heffteBackend, typename Base::workspace_t, typename Base::Layout_t;
 
         /*!
+         * Warmup the FFT object by forward & backward FFT on an empty field
+         * @param f Field whose transformation to compute (and overwrite)
+         */
+        void warmup(Field& f);
+
+        /*!
          * Perform in-place FFT
          * @param direction Forward or backward transformation
          * @param f Field whose transformation to compute (and overwrite)
@@ -253,6 +272,12 @@ namespace ippl {
         using typename Base::heffteBackend, typename Base::workspace_t, typename Base::Layout_t;
 
         /*!
+         * Warmup the FFT object by forward & backward FFT on an empty field
+         * @param f Field whose transformation to compute (and overwrite)
+         */
+        void warmup(Field& f);
+
+        /*!
          * Perform in-place FFT
          * @param direction Forward or backward transformation
          * @param f Field whose transformation to compute (and overwrite)
@@ -270,6 +295,12 @@ namespace ippl {
     public:
         using Base::Base;
         using typename Base::heffteBackend, typename Base::workspace_t, typename Base::Layout_t;
+
+        /*!
+         * Warmup the FFT object by forward & backward FFT on an empty field
+         * @param f Field whose transformation to compute (and overwrite)
+         */
+        void warmup(Field& f);
 
         /*!
          * Perform in-place FFT

--- a/src/FFT/FFT.hpp
+++ b/src/FFT/FFT.hpp
@@ -109,6 +109,12 @@ namespace ippl {
     }
 
     template <typename ComplexField>
+    void FFT<CCTransform, ComplexField>::warmup(ComplexField& f) {
+        this->transform(FORWARD, f);
+        this->transform(BACKWARD, f);
+    }
+
+    template <typename ComplexField>
     void FFT<CCTransform, ComplexField>::transform(TransformDirection direction, ComplexField& f) {
         static_assert(Dim == 2 || Dim == 3, "heFFTe only supports 2D and 3D");
 
@@ -188,6 +194,12 @@ namespace ippl {
     }
 
     template <typename RealField>
+    void FFT<RCTransform, RealField>::warmup(RealField& f, ComplexField& g) {
+        this->transform(FORWARD, f, g);
+        this->transform(BACKWARD, f, g);
+    }
+
+    template <typename RealField>
     void FFT<RCTransform, RealField>::transform(TransformDirection direction, RealField& f,
                                                 ComplexField& g) {
         static_assert(Dim == 2 || Dim == 3, "heFFTe only supports 2D and 3D");
@@ -251,13 +263,19 @@ namespace ippl {
     }
 
     template <typename Field>
+    void FFT<SineTransform, Field>::warmup(Field& f) {
+        this->transform(FORWARD, f);
+        this->transform(BACKWARD, f);
+    }
+
+    template <typename Field>
     void FFT<SineTransform, Field>::transform(TransformDirection direction, Field& f) {
         static_assert(Dim == 2 || Dim == 3, "heFFTe only supports 2D and 3D");
-        #ifdef Heffte_ENABLE_FFTW
-                if (direction == FORWARD) {
-                    f = f / 8.0;
-                }
-        #endif
+#ifdef Heffte_ENABLE_FFTW
+        if (direction == FORWARD) {
+            f = f / 8.0;
+        }
+#endif
 
         auto fview       = f.getView();
         const int nghost = f.getNghost();
@@ -296,21 +314,27 @@ namespace ippl {
             KOKKOS_LAMBDA(const index_array_type& args) {
                 apply(fview, args) = apply(tempField, args - nghost);
             });
-        #ifdef Heffte_ENABLE_FFTW
-                if (direction == BACKWARD) {
-                    f = f * 8.0;
-                }
-        #endif
+#ifdef Heffte_ENABLE_FFTW
+        if (direction == BACKWARD) {
+            f = f * 8.0;
+        }
+#endif
+    }
+
+    template <typename Field>
+    void FFT<CosTransform, Field>::warmup(Field& f) {
+        this->transform(FORWARD, f);
+        this->transform(BACKWARD, f);
     }
 
     template <typename Field>
     void FFT<CosTransform, Field>::transform(TransformDirection direction, Field& f) {
         static_assert(Dim == 2 || Dim == 3, "heFFTe only supports 2D and 3D");
-        #ifdef Heffte_ENABLE_FFTW
-                if (direction == FORWARD) {
-                    f = f / 8.0;
-                }
-        #endif
+#ifdef Heffte_ENABLE_FFTW
+        if (direction == FORWARD) {
+            f = f / 8.0;
+        }
+#endif
 
         auto fview       = f.getView();
         const int nghost = f.getNghost();
@@ -349,26 +373,32 @@ namespace ippl {
             KOKKOS_LAMBDA(const index_array_type& args) {
                 apply(fview, args) = apply(tempField, args - nghost);
             });
-        #ifdef Heffte_ENABLE_FFTW
-                if (direction == BACKWARD) {
-                    f = f * 8.0;
-                }
-        #endif
+#ifdef Heffte_ENABLE_FFTW
+        if (direction == BACKWARD) {
+            f = f * 8.0;
+        }
+#endif
+    }
+
+    template <typename Field>
+    void FFT<Cos1Transform, Field>::warmup(Field& f) {
+        this->transform(FORWARD, f);
+        this->transform(BACKWARD, f);
     }
 
     template <typename Field>
     void FFT<Cos1Transform, Field>::transform(TransformDirection direction, Field& f) {
         static_assert(Dim == 2 || Dim == 3, "heFFTe only supports 2D and 3D");
 
-        /**
-         * This rescaling is needed to match the normalization constant
-         * between fftw and the other gpu interfaces. fftw rescales with an extra factor of 8.
-         */
-        #ifdef Heffte_ENABLE_FFTW
-                if (direction == FORWARD) {
-                    f = f / 8.0;
-                }
-        #endif
+/**
+ * This rescaling is needed to match the normalization constant
+ * between fftw and the other gpu interfaces. fftw rescales with an extra factor of 8.
+ */
+#ifdef Heffte_ENABLE_FFTW
+        if (direction == FORWARD) {
+            f = f / 8.0;
+        }
+#endif
 
         auto fview       = f.getView();
         const int nghost = f.getNghost();
@@ -408,15 +438,15 @@ namespace ippl {
                 apply(fview, args) = apply(tempField, args - nghost);
             });
 
-        /**
-         * This rescaling is needed to match the normalization constant
-         * between fftw and the other gpu interfaces. fftw rescales with an extra factor of 8.
-         */
-        #ifdef Heffte_ENABLE_FFTW
-                if (direction == BACKWARD) {
-                    f = f * 8.0;
-                }
-        #endif
+/**
+ * This rescaling is needed to match the normalization constant
+ * between fftw and the other gpu interfaces. fftw rescales with an extra factor of 8.
+ */
+#ifdef Heffte_ENABLE_FFTW
+        if (direction == BACKWARD) {
+            f = f * 8.0;
+        }
+#endif
     }
 
 }  // namespace ippl

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
@@ -464,12 +464,12 @@ namespace ippl {
         IpplTimings::startTimer(warmup);
 
         // "empty" transforms to warmup all the FFTs
-        fft_m->transform(FORWARD, rho2_mr, rho2tr_m);
+        fft_m->warmup(rho2_mr, rho2tr_m);
         if (alg == Algorithm::VICO || alg == Algorithm::BIHARMONIC) {
-            fft4n_m->transform(FORWARD, grnL_m);
+            fft4n_m->warmup(grnL_m);
         }
         if (alg == Algorithm::DCT_VICO) {
-            fft2n1_m->transform(FORWARD, grn2n1_m);
+            fft2n1_m->warmup(grn2n1_m);
         }
 
         IpplTimings::stopTimer(warmup);

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
@@ -555,7 +555,6 @@ namespace ippl {
 
                     solver_send(IPPL_SOLVER_SEND, OPEN_SOLVER_TAG, 0, i, intersection, ldom1,
                                 nghost1, view1, fd_m, requests);
-
                 }
             }
 
@@ -584,7 +583,6 @@ namespace ippl {
             if (requests.size() > 0) {
                 MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
             }
-            Comm->barrier();
 
         } else {
             Kokkos::parallel_for(
@@ -654,8 +652,9 @@ namespace ippl {
                     case Algorithm::DCT_VICO:
                         rho2_mr = rho2_mr * (1.0 / 4.0);
                         break;
-                    default: 
-                        throw IpplException("FFTOpenPoissonSolver::initializeFields()",
+                    default:
+                        throw IpplException(
+                            "FFTOpenPoissonSolver::initializeFields()",
                             "Currently only HOCKNEY, VICO, DCT_VICO, and BIHARMONIC are "
                             "supported for open BCs");
                 }
@@ -682,7 +681,6 @@ namespace ippl {
 
                         solver_send(IPPL_SOLVER_SEND, OPEN_SOLVER_TAG, 0, i, intersection, ldom2,
                                     nghost2, view2, fd_m, requests);
-
                     }
                 }
 
@@ -712,7 +710,6 @@ namespace ippl {
                 if (requests.size() > 0) {
                     MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
                 }
-                Comm->barrier();
 
             } else {
                 Kokkos::parallel_for(
@@ -813,8 +810,9 @@ namespace ippl {
                         case Algorithm::DCT_VICO:
                             rho2_mr = rho2_mr * (1.0 / 4.0);
                             break;
-                        default: 
-                            throw IpplException("FFTOpenPoissonSolver::initializeFields()",
+                        default:
+                            throw IpplException(
+                                "FFTOpenPoissonSolver::initializeFields()",
                                 "Currently only HOCKNEY, VICO, DCT_VICO, and BIHARMONIC are "
                                 "supported for open BCs");
                     }
@@ -840,7 +838,6 @@ namespace ippl {
 
                             solver_send(IPPL_SOLVER_SEND, OPEN_SOLVER_TAG, 0, i, intersection,
                                         ldom2, nghost2, view2, fd_m, requests);
-
                         }
                     }
 
@@ -870,7 +867,6 @@ namespace ippl {
                     if (requests.size() > 0) {
                         MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
                     }
-                    Comm->barrier();
 
                 } else {
                     Kokkos::parallel_for(
@@ -972,8 +968,9 @@ namespace ippl {
                             case Algorithm::DCT_VICO:
                                 rho2_mr = rho2_mr * (1.0 / 4.0);
                                 break;
-                            default: 
-                                throw IpplException("FFTOpenPoissonSolver::initializeFields()",
+                            default:
+                                throw IpplException(
+                                    "FFTOpenPoissonSolver::initializeFields()",
                                     "Currently only HOCKNEY, VICO, DCT_VICO, and BIHARMONIC are "
                                     "supported for open BCs");
                         }
@@ -999,7 +996,6 @@ namespace ippl {
 
                                 solver_send(IPPL_SOLVER_SEND, OPEN_SOLVER_TAG, 0, i, intersection,
                                             ldom2, nghost2, view2, fd_m, requests);
-
                             }
                         }
 
@@ -1029,7 +1025,6 @@ namespace ippl {
                         if (requests.size() > 0) {
                             MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
                         }
-                        Comm->barrier();
 
                     } else {
                         Kokkos::parallel_for(
@@ -1448,7 +1443,6 @@ namespace ippl {
 
                     solver_send(IPPL_VICO_SEND, VICO_SOLVER_TAG, 0, i, intersection, ldom_g,
                                 nghost_g, view_g, fd_m, requests);
-
                 }
             }
 
@@ -1467,7 +1461,6 @@ namespace ippl {
 
                     solver_send(IPPL_VICO_SEND, VICO_SOLVER_TAG, 1, i, intersection, ldom_g,
                                 nghost_g, view_g, fd_m, requests);
-
                 }
             }
 
@@ -1486,7 +1479,6 @@ namespace ippl {
 
                     solver_send(IPPL_VICO_SEND, VICO_SOLVER_TAG, 2, i, intersection, ldom_g,
                                 nghost_g, view_g, fd_m, requests);
-
                 }
             }
 
@@ -1505,7 +1497,6 @@ namespace ippl {
 
                     solver_send(IPPL_VICO_SEND, VICO_SOLVER_TAG, 3, i, intersection, ldom_g,
                                 nghost_g, view_g, fd_m, requests);
-
                 }
             }
 
@@ -1526,7 +1517,6 @@ namespace ippl {
 
                     solver_send(IPPL_VICO_SEND, VICO_SOLVER_TAG, 4, i, intersection, ldom_g,
                                 nghost_g, view_g, fd_m, requests);
-
                 }
             }
 
@@ -1546,7 +1536,6 @@ namespace ippl {
                     intersection = ldom_g.intersect(domain4);
                     solver_send(IPPL_VICO_SEND, VICO_SOLVER_TAG, 5, i, intersection, ldom_g,
                                 nghost_g, view_g, fd_m, requests);
-
                 }
             }
 
@@ -1566,7 +1555,6 @@ namespace ippl {
                     intersection = ldom_g.intersect(domain4);
                     solver_send(IPPL_VICO_SEND, VICO_SOLVER_TAG, 6, i, intersection, ldom_g,
                                 nghost_g, view_g, fd_m, requests);
-
                 }
             }
 
@@ -1588,7 +1576,6 @@ namespace ippl {
                     intersection = ldom_g.intersect(domain4);
                     solver_send(IPPL_VICO_SEND, VICO_SOLVER_TAG, 7, i, intersection, ldom_g,
                                 nghost_g, view_g, fd_m, requests);
-
                 }
             }
         }
@@ -1603,7 +1590,6 @@ namespace ippl {
 
                     solver_recv(IPPL_VICO_RECV, VICO_SOLVER_TAG, 0, i, intersection, ldom, nghost,
                                 view, fd_m);
-
                 }
             }
 
@@ -1627,7 +1613,6 @@ namespace ippl {
 
                     solver_recv(IPPL_VICO_RECV, VICO_SOLVER_TAG, 1, i, intersection, ldom, nghost,
                                 view, fd_m, true, false, false);
-
                 }
             }
 
@@ -1651,7 +1636,6 @@ namespace ippl {
 
                     solver_recv(IPPL_VICO_RECV, VICO_SOLVER_TAG, 2, i, intersection, ldom, nghost,
                                 view, fd_m, false, true, false);
-
                 }
             }
 
@@ -1675,7 +1659,6 @@ namespace ippl {
 
                     solver_recv(IPPL_VICO_RECV, VICO_SOLVER_TAG, 3, i, intersection, ldom, nghost,
                                 view, fd_m, false, false, true);
-
                 }
             }
 
@@ -1703,7 +1686,6 @@ namespace ippl {
 
                     solver_recv(IPPL_VICO_RECV, VICO_SOLVER_TAG, 4, i, intersection, ldom, nghost,
                                 view, fd_m, true, true, false);
-
                 }
             }
 
@@ -1731,7 +1713,6 @@ namespace ippl {
 
                     solver_recv(IPPL_VICO_RECV, VICO_SOLVER_TAG, 5, i, intersection, ldom, nghost,
                                 view, fd_m, false, true, true);
-
                 }
             }
 
@@ -1759,7 +1740,6 @@ namespace ippl {
 
                     solver_recv(IPPL_VICO_RECV, VICO_SOLVER_TAG, 6, i, intersection, ldom, nghost,
                                 view, fd_m, true, false, true);
-
                 }
             }
 
@@ -1798,7 +1778,6 @@ namespace ippl {
         if (requests.size() > 0) {
             MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
         }
-        Comm->barrier();
     };
 
     // CommunicateVico for DCT_VICO (2N+1 to 2N)
@@ -1809,7 +1788,6 @@ namespace ippl {
         const int nghost) {
         const auto& lDomains2   = layout2_m->getHostLocalDomains();
         const auto& lDomains2n1 = layout2n1_m->getHostLocalDomains();
-
 
         std::vector<MPI_Request> requests(0);
         const int ranks = ippl::Comm->size();
@@ -2205,6 +2183,5 @@ namespace ippl {
         if (requests.size() > 0) {
             MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
         }
-        ippl::Comm->barrier();
     };
 }  // namespace ippl

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
@@ -1086,6 +1086,7 @@ namespace ippl {
 
             // size of truncation window
             L_sum = std::sqrt(L_sum);
+            // we choose a window 10% larger than domain (arbitrary choice)
             L_sum = 1.1 * L_sum;
 
             // initialize grnL_m

--- a/test/FFT/TestCos1.cpp
+++ b/test/FFT/TestCos1.cpp
@@ -20,11 +20,10 @@ int main(int argc, char* argv[]) {
         ippl::Index K(pt[2]);
         ippl::NDIndex<dim> owned(I, J, K);
 
-        ippl::e_dim_tag allParallel[dim];  // Specifies SERIAL, PARALLEL dims
-        for (unsigned int d = 0; d < dim; d++)
-            allParallel[d] = ippl::PARALLEL;
+        std::array<bool, dim> isParallel;  // Specifies SERIAL, PARALLEL dims
+        isParallel.fill(true);
 
-        ippl::FieldLayout<dim> layout(owned, allParallel);
+        ippl::FieldLayout<dim> layout(MPI_COMM_WORLD, owned, isParallel);
 
         std::array<double, dim> dx = {
             1.0 / double(pt[0]),


### PR DESCRIPTION
This PR addresses the following:

- Compilation issues in test/FFT/TestCos1.cpp and in FFTOpenPoissonSolver.hpp after previous merge, due to some conflicts with changes in Communicate.
- Add a warmup() function in the FFT class which performs a dummy FORWARD and BACKWARD transform. Calling this will always ensure that the warmup step is done for both directions, which when not done causes performance issues.
- Add a comment explaining the windowing of the Green's function in the Vico-Greengard solver.
- Remove all MPI Barriers from FFTOpenPoissonSolver.hpp, which were unnecessary and causing slowdown. 