### PR TITLE
Variant patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g ")
 set (CMAKE_CXX_FLAGS_RELEASE "-O3")
 set (CMAKE_CXX_FLAGS_DEBUG  "-O0 -g")
 if ("${Kokkos_DEVICES}" MATCHES "CUDA")
-    set (CMAKE_CXX_FLAGS_DEBUG "-O0 -g -G")
+    set (CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -G")
 endif()
 
 # Resolve all library dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,13 @@ if ("${Kokkos_DEVICES}" MATCHES "CUDA")
     set (CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -G")
 endif()
 
+# Suppress erroneous buffer overflow warnings when compiling under GCC 12
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" MATCHES "12*")
+    add_compile_options (-Wno-stringop-overflow)
+    add_compile_options (-Wno-array-bounds)
+    add_compile_options (-Wno-restrict)
+endif()
+
 # Resolve all library dependencies
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeModules")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,9 @@ message (STATUS "The C++ compiler version is: ${CMAKE_CXX_COMPILER_VERSION}")
 message (STATUS "The MPI C++ compiler is: ${MPI_CXX_COMPILER}")
 message (STATUS "The underlying C++ compiler is: ${CMAKE_CXX_COMPILER}")
 
-option(USE_ALTERNATE_VARIANT "Use modified variant implementation (required for CUDA 12.2 + GCC 12.3.0)" OFF)
-if (USE_ALTERNATE_VARIANT)
-    add_definitions (-DUSE_ALTERNATE_VARIANT)
+option(USE_ALTERNATIVE_VARIANT "Use modified variant implementation (required for CUDA 12.2 + GCC 12.3.0)" OFF)
+if (USE_ALTERNATIVE_VARIANT)
+    add_definitions (-DUSE_ALTERNATIVE_VARIANT)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,16 @@ message (STATUS "The C++ compiler version is: ${CMAKE_CXX_COMPILER_VERSION}")
 message (STATUS "The MPI C++ compiler is: ${MPI_CXX_COMPILER}")
 message (STATUS "The underlying C++ compiler is: ${CMAKE_CXX_COMPILER}")
 
+option(USE_ALTERNATE_VARIANT "Use modified variant implementation (required for CUDA 12.2 + GCC 12.3.0)" OFF)
+if (USE_ALTERNATE_VARIANT)
+    add_definitions (-DUSE_ALTERNATE_VARIANT)
+endif()
+
+
 option (ENABLE_FFT "Enable FFT transform" OFF)
 if (ENABLE_FFT)
     add_definitions (-DENABLE_FFT)
-    find_package(Heffte 2.2.0 REQUIRED)
+    find_package (Heffte 2.2.0 REQUIRED)
     message (STATUS "Found Heffte_DIR: ${Heffte_DIR}")
 endif ()
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,674 @@
-BSD 3-Clause License
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (c) 2023, IPPL
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+                            Preamble
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
 
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Independent Parallel Particle Layer (IPPL)
 Independent Parallel Particle Layer (IPPL) is a performance portable C++ library for Particle-Mesh methods. IPPL makes use of Kokkos (https://github.com/kokkos/kokkos), HeFFTe (https://github.com/icl-utk-edu/heffte), and MPI (Message Passing Interface) to deliver a portable, massively parallel toolkit for particle-mesh methods. IPPL supports simulations in one to six dimensions, mixed precision, and asynchronous execution in different execution spaces (e.g. CPUs and GPUs). 
 
-IPPL is available under the BSD 3-clause license. This repository includes a modified version of the `variant` header by GNU, created to support compilation under CUDA 12.2 with GCC 12.3.0. This header file is available under the same terms as the [GNU Standard Library](https://github.com/gcc-mirror/gcc); note the GNU runtime library exception.
+All IPPL releases (< 3.2.0) are available under the BSD 3-clause license. Since version 3.2.0, this repository includes a modified version of the `variant` header by GNU, created to support compilation under CUDA 12.2 with GCC 12.3.0. This header file is available under the same terms as the [GNU Standard Library](https://github.com/gcc-mirror/gcc); note the GNU runtime library exception. As long as this file is not removed, IPPL is available under GNU GPL version 3.
 
 ## Installing IPPL and its dependencies
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 # Independent Parallel Particle Layer (IPPL)
 Independent Parallel Particle Layer (IPPL) is a performance portable C++ library for Particle-Mesh methods. IPPL makes use of Kokkos (https://github.com/kokkos/kokkos), HeFFTe (https://github.com/icl-utk-edu/heffte), and MPI (Message Passing Interface) to deliver a portable, massively parallel toolkit for particle-mesh methods. IPPL supports simulations in one to six dimensions, mixed precision, and asynchronous execution in different execution spaces (e.g. CPUs and GPUs). 
 
+IPPL is available under the BSD 3-clause license. This repository includes a modified version of the `variant` header by GNU, created to support compilation under CUDA 12.2 with GCC 12.3.0. This header file is available under the same terms as the [GNU Standard Library](https://github.com/gcc-mirror/gcc); note the GNU runtime library exception.
+
 ## Installing IPPL and its dependencies
 
 ### Requirements

--- a/src/Communicate/Communicate.h
+++ b/src/Communicate/Communicate.h
@@ -10,7 +10,8 @@
 // For message size check; see below
 #include <climits>
 #include <cstdlib>
-#include <variant>
+
+#include "Types/Variant.h"
 
 #include "Utility/TypeUtils.h"
 

--- a/src/Types/CMakeLists.txt
+++ b/src/Types/CMakeLists.txt
@@ -2,6 +2,7 @@ set (_SRCS
     )
 
 set (_HDRS
+    Variant.h
     Vector.h
     Vector.hpp
     ViewTypes.h

--- a/src/Types/Variant.h
+++ b/src/Types/Variant.h
@@ -1,0 +1,1679 @@
+#ifdef USE_ALTERNATE_VARIANT
+// <variant> -*- C++ -*-
+
+// Copyright (C) 2016-2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+/** @file variant
+ *  This is the `<variant>` C++ Library header.
+ */
+
+#ifndef _GLIBCXX_VARIANT
+#define _GLIBCXX_VARIANT 1
+
+#pragma GCC system_header
+
+#if __cplusplus >= 201703L
+
+#include <bits/enable_special_members.h>
+#include <bits/exception_defines.h>
+#include <bits/functional_hash.h>
+#include <bits/invoke.h>
+#include <bits/parse_numbers.h>
+#include <bits/stl_construct.h>
+#include <bits/stl_iterator_base_funcs.h>
+#include <bits/utility.h>  // in_place_index_t
+#include <initializer_list>
+#include <type_traits>
+#if __cplusplus >= 202002L
+#include <compare>
+#endif
+
+#if __cpp_concepts >= 202002L && __cpp_constexpr >= 201811L
+// P2231R1 constexpr needs constexpr unions and constrained destructors.
+#define __cpp_lib_variant 202106L
+#else
+#include <ext/aligned_buffer.h>  // Use __aligned_membuf instead of union.
+#define __cpp_lib_variant 202102L
+#endif
+
+namespace std _GLIBCXX_VISIBILITY(default) {
+    _GLIBCXX_BEGIN_NAMESPACE_VERSION
+
+    template <typename... _Types>
+    class tuple;
+    template <typename... _Types>
+    class variant;
+    template <typename>
+    struct hash;
+
+    template <typename _Variant>
+    struct variant_size;
+
+    template <typename _Variant>
+    struct variant_size<const _Variant> : variant_size<_Variant> {};
+
+    template <typename _Variant>
+    struct variant_size<volatile _Variant> : variant_size<_Variant> {};
+
+    template <typename _Variant>
+    struct variant_size<const volatile _Variant> : variant_size<_Variant> {};
+
+    template <typename... _Types>
+    struct variant_size<variant<_Types...>> : std::integral_constant<size_t, sizeof...(_Types)> {};
+
+    template <typename _Variant>
+    inline constexpr size_t variant_size_v = variant_size<_Variant>::value;
+
+    template <typename... _Types>
+    inline constexpr size_t variant_size_v<variant<_Types...>> = sizeof...(_Types);
+
+    template <typename... _Types>
+    inline constexpr size_t variant_size_v<const variant<_Types...>> = sizeof...(_Types);
+
+    template <size_t _Np, typename _Variant>
+    struct variant_alternative;
+
+    template <size_t _Np, typename... _Types>
+    struct variant_alternative<_Np, variant<_Types...>> {
+        static_assert(_Np < sizeof...(_Types));
+
+        using type = typename _Nth_type<_Np, _Types...>::type;
+    };
+
+    template <size_t _Np, typename _Variant>
+    using variant_alternative_t = typename variant_alternative<_Np, _Variant>::type;
+
+    template <size_t _Np, typename _Variant>
+    struct variant_alternative<_Np, const _Variant> {
+        using type = const variant_alternative_t<_Np, _Variant>;
+    };
+
+    template <size_t _Np, typename _Variant>
+    struct variant_alternative<_Np, volatile _Variant> {
+        using type = volatile variant_alternative_t<_Np, _Variant>;
+    };
+
+    template <size_t _Np, typename _Variant>
+    struct variant_alternative<_Np, const volatile _Variant> {
+        using type = const volatile variant_alternative_t<_Np, _Variant>;
+    };
+
+    inline constexpr size_t variant_npos = -1;
+
+    template <size_t _Np, typename... _Types>
+    constexpr variant_alternative_t<_Np, variant<_Types...>>& get(variant<_Types...>&);
+
+    template <size_t _Np, typename... _Types>
+    constexpr variant_alternative_t<_Np, variant<_Types...>>&& get(variant<_Types...>&&);
+
+    template <size_t _Np, typename... _Types>
+    constexpr variant_alternative_t<_Np, variant<_Types...>> const& get(const variant<_Types...>&);
+
+    template <size_t _Np, typename... _Types>
+    constexpr variant_alternative_t<_Np, variant<_Types...>> const&& get(
+        const variant<_Types...>&&);
+
+    template <typename _Result_type, typename _Visitor, typename... _Variants>
+    constexpr decltype(auto) __do_visit(_Visitor&& __visitor, _Variants&&... __variants);
+
+    template <typename... _Types, typename _Tp>
+    _GLIBCXX20_CONSTEXPR decltype(auto) __variant_cast(_Tp&& __rhs) {
+        if constexpr (is_lvalue_reference_v<_Tp>) {
+            if constexpr (is_const_v<remove_reference_t<_Tp>>)
+                return static_cast<const variant<_Types...>&>(__rhs);
+            else
+                return static_cast<variant<_Types...>&>(__rhs);
+        } else
+            return static_cast<variant<_Types...>&&>(__rhs);
+    }
+
+    namespace __detail {
+        namespace __variant {
+            // used for raw visitation
+            struct __variant_cookie {};
+            // used for raw visitation with indices passed in
+            struct __variant_idx_cookie {
+                using type = __variant_idx_cookie;
+            };
+            // Used to enable deduction (and same-type checking) for std::visit:
+            template <typename _Tp>
+            struct __deduce_visit_result {
+                using type = _Tp;
+            };
+
+            // Visit variants that might be valueless.
+            template <typename _Visitor, typename... _Variants>
+            constexpr void __raw_visit(_Visitor&& __visitor, _Variants&&... __variants) {
+                std::__do_visit<__variant_cookie>(std::forward<_Visitor>(__visitor),
+                                                  std::forward<_Variants>(__variants)...);
+            }
+
+            // Visit variants that might be valueless, passing indices to the visitor.
+            template <typename _Visitor, typename... _Variants>
+            constexpr void __raw_idx_visit(_Visitor&& __visitor, _Variants&&... __variants) {
+                std::__do_visit<__variant_idx_cookie>(std::forward<_Visitor>(__visitor),
+                                                      std::forward<_Variants>(__variants)...);
+            }
+
+            // The __as function templates implement the exposition-only "as-variant"
+
+            template <typename... _Types>
+            constexpr std::variant<_Types...>& __as(std::variant<_Types...>& __v) noexcept {
+                return __v;
+            }
+
+            template <typename... _Types>
+            constexpr const std::variant<_Types...>& __as(
+                const std::variant<_Types...>& __v) noexcept {
+                return __v;
+            }
+
+            template <typename... _Types>
+            constexpr std::variant<_Types...>&& __as(std::variant<_Types...>&& __v) noexcept {
+                return std::move(__v);
+            }
+
+            template <typename... _Types>
+            constexpr const std::variant<_Types...>&& __as(
+                const std::variant<_Types...>&& __v) noexcept {
+                return std::move(__v);
+            }
+
+            // For C++17:
+            // _Uninitialized<T> is guaranteed to be a trivially destructible type,
+            // even if T is not.
+            // For C++20:
+            // _Uninitialized<T> is trivially destructible iff T is, so _Variant_union
+            // needs a constrained non-trivial destructor.
+            template <typename _Type, bool = std::is_trivially_destructible_v<_Type>>
+            struct _Uninitialized;
+
+            template <typename _Type>
+            struct _Uninitialized<_Type, true> {
+                template <typename... _Args>
+                constexpr _Uninitialized(in_place_index_t<0>, _Args&&... __args)
+                    : _M_storage(std::forward<_Args>(__args)...) {}
+
+                constexpr const _Type& _M_get() const& noexcept { return _M_storage; }
+
+                constexpr _Type& _M_get() & noexcept { return _M_storage; }
+
+                constexpr const _Type&& _M_get() const&& noexcept { return std::move(_M_storage); }
+
+                constexpr _Type&& _M_get() && noexcept { return std::move(_M_storage); }
+
+                _Type _M_storage;
+            };
+
+            template <typename _Type>
+            struct _Uninitialized<_Type, false> {
+#if __cpp_lib_variant >= 202106L
+                template <typename... _Args>
+                constexpr _Uninitialized(in_place_index_t<0>, _Args&&... __args)
+                    : _M_storage(std::forward<_Args>(__args)...) {}
+
+                constexpr ~_Uninitialized() {}
+
+                _Uninitialized(const _Uninitialized&)            = default;
+                _Uninitialized(_Uninitialized&&)                 = default;
+                _Uninitialized& operator=(const _Uninitialized&) = default;
+                _Uninitialized& operator=(_Uninitialized&&)      = default;
+
+                constexpr const _Type& _M_get() const& noexcept { return _M_storage; }
+
+                constexpr _Type& _M_get() & noexcept { return _M_storage; }
+
+                constexpr const _Type&& _M_get() const&& noexcept { return std::move(_M_storage); }
+
+                constexpr _Type&& _M_get() && noexcept { return std::move(_M_storage); }
+
+                struct _Empty_byte {};
+
+                union {
+                    _Empty_byte _M_empty;
+                    _Type _M_storage;
+                };
+#else
+                template <typename... _Args>
+                constexpr _Uninitialized(in_place_index_t<0>, _Args&&... __args) {
+                    ::new ((void*)std::addressof(_M_storage)) _Type(std::forward<_Args>(__args)...);
+                }
+
+                const _Type& _M_get() const& noexcept { return *_M_storage._M_ptr(); }
+
+                _Type& _M_get() & noexcept { return *_M_storage._M_ptr(); }
+
+                const _Type&& _M_get() const&& noexcept { return std::move(*_M_storage._M_ptr()); }
+
+                _Type&& _M_get() && noexcept { return std::move(*_M_storage._M_ptr()); }
+
+                __gnu_cxx::__aligned_membuf<_Type> _M_storage;
+#endif
+            };
+
+            template <size_t _Np, typename _Union>
+            constexpr decltype(auto) __get_n(_Union&& __u) noexcept {
+                if constexpr (_Np == 0)
+                    return std::forward<_Union>(__u)._M_first._M_get();
+                else if constexpr (_Np == 1)
+                    return std::forward<_Union>(__u)._M_rest._M_first._M_get();
+                else if constexpr (_Np == 2)
+                    return std::forward<_Union>(__u)._M_rest._M_rest._M_first._M_get();
+                else
+                    return __variant::__get_n<_Np - 3>(
+                        std::forward<_Union>(__u)._M_rest._M_rest._M_rest);
+            }
+
+            // Returns the typed storage for __v.
+            template <size_t _Np, typename _Variant>
+            constexpr decltype(auto) __get(_Variant&& __v) noexcept {
+                return __variant::__get_n<_Np>(std::forward<_Variant>(__v)._M_u);
+            }
+
+            template <typename... _Types>
+            struct _Traits {
+                static constexpr bool _S_default_ctor =
+                    is_default_constructible_v<typename _Nth_type<0, _Types...>::type>;
+                static constexpr bool _S_copy_ctor = (is_copy_constructible_v<_Types> && ...);
+                static constexpr bool _S_move_ctor = (is_move_constructible_v<_Types> && ...);
+                static constexpr bool _S_copy_assign =
+                    _S_copy_ctor && (is_copy_assignable_v<_Types> && ...);
+                static constexpr bool _S_move_assign =
+                    _S_move_ctor && (is_move_assignable_v<_Types> && ...);
+
+                static constexpr bool _S_trivial_dtor =
+                    (is_trivially_destructible_v<_Types> && ...);
+                static constexpr bool _S_trivial_copy_ctor =
+                    (is_trivially_copy_constructible_v<_Types> && ...);
+                static constexpr bool _S_trivial_move_ctor =
+                    (is_trivially_move_constructible_v<_Types> && ...);
+                static constexpr bool _S_trivial_copy_assign =
+                    _S_trivial_dtor && _S_trivial_copy_ctor
+                    && (is_trivially_copy_assignable_v<_Types> && ...);
+                static constexpr bool _S_trivial_move_assign =
+                    _S_trivial_dtor && _S_trivial_move_ctor
+                    && (is_trivially_move_assignable_v<_Types> && ...);
+
+                // The following nothrow traits are for non-trivial SMFs. Trivial SMFs
+                // are always nothrow.
+                static constexpr bool _S_nothrow_default_ctor =
+                    is_nothrow_default_constructible_v<typename _Nth_type<0, _Types...>::type>;
+                static constexpr bool _S_nothrow_copy_ctor = false;
+                static constexpr bool _S_nothrow_move_ctor =
+                    (is_nothrow_move_constructible_v<_Types> && ...);
+                static constexpr bool _S_nothrow_copy_assign = false;
+                static constexpr bool _S_nothrow_move_assign =
+                    _S_nothrow_move_ctor && (is_nothrow_move_assignable_v<_Types> && ...);
+            };
+
+            // Defines members and ctors.
+            template <typename... _Types>
+            union _Variadic_union {
+                _Variadic_union() = default;
+
+                template <size_t _Np, typename... _Args>
+                _Variadic_union(in_place_index_t<_Np>, _Args&&...) = delete;
+            };
+
+            template <typename _First, typename... _Rest>
+            union _Variadic_union<_First, _Rest...> {
+                constexpr _Variadic_union()
+                    : _M_rest() {}
+
+                template <typename... _Args>
+                constexpr _Variadic_union(in_place_index_t<0>, _Args&&... __args)
+                    : _M_first(in_place_index<0>, std::forward<_Args>(__args)...) {}
+
+                template <size_t _Np, typename... _Args>
+                constexpr _Variadic_union(in_place_index_t<_Np>, _Args&&... __args)
+                    : _M_rest(in_place_index<_Np - 1>, std::forward<_Args>(__args)...) {}
+
+#if __cpp_lib_variant >= 202106L
+                _Variadic_union(const _Variadic_union&)            = default;
+                _Variadic_union(_Variadic_union&&)                 = default;
+                _Variadic_union& operator=(const _Variadic_union&) = default;
+                _Variadic_union& operator=(_Variadic_union&&)      = default;
+
+                ~_Variadic_union(){};
+
+                constexpr ~_Variadic_union()
+                    requires(!__has_trivial_destructor(_First))
+                            || (!__has_trivial_destructor(_Variadic_union<_Rest...>))
+                {}
+#endif
+
+                _Uninitialized<_First> _M_first;
+                _Variadic_union<_Rest...> _M_rest;
+            };
+
+            // _Never_valueless_alt is true for variant alternatives that can
+            // always be placed in a variant without it becoming valueless.
+
+            // For suitably-small, trivially copyable types we can create temporaries
+            // on the stack and then memcpy them into place.
+            template <typename _Tp>
+            struct _Never_valueless_alt
+                : __and_<bool_constant<sizeof(_Tp) <= 256>, is_trivially_copyable<_Tp>> {};
+
+            // Specialize _Never_valueless_alt for other types which have a
+            // non-throwing and cheap move construction and move assignment operator,
+            // so that emplacing the type will provide the strong exception-safety
+            // guarantee, by creating and moving a temporary.
+            // Whether _Never_valueless_alt<T> is true or not affects the ABI of a
+            // variant using that alternative, so we can't change the value later!
+
+            // True if every alternative in _Types... can be emplaced in a variant
+            // without it becoming valueless. If this is true, variant<_Types...>
+            // can never be valueless, which enables some minor optimizations.
+            template <typename... _Types>
+            constexpr bool __never_valueless() {
+                return _Traits<_Types...>::_S_move_assign
+                       && (_Never_valueless_alt<_Types>::value && ...);
+            }
+
+            // Defines index and the dtor, possibly trivial.
+            template <bool __trivially_destructible, typename... _Types>
+            struct _Variant_storage;
+
+            template <typename... _Types>
+            using __select_index =
+                typename __select_int::_Select_int_base<sizeof...(_Types), unsigned char,
+                                                        unsigned short>::type::value_type;
+
+            template <typename... _Types>
+            struct _Variant_storage<false, _Types...> {
+                constexpr _Variant_storage()
+                    : _M_index(static_cast<__index_type>(variant_npos)) {}
+
+                template <size_t _Np, typename... _Args>
+                constexpr _Variant_storage(in_place_index_t<_Np>, _Args&&... __args)
+                    : _M_u(in_place_index<_Np>, std::forward<_Args>(__args)...)
+                    , _M_index{_Np} {}
+
+                constexpr void _M_reset() {
+                    if (!_M_valid()) [[unlikely]]
+                        return;
+
+                    std::__do_visit<void>(
+                        [](auto&& __this_mem) mutable {
+                            std::_Destroy(std::__addressof(__this_mem));
+                        },
+                        __variant_cast<_Types...>(*this));
+
+                    _M_index = static_cast<__index_type>(variant_npos);
+                }
+
+                _GLIBCXX20_CONSTEXPR
+                ~_Variant_storage() { _M_reset(); }
+
+                constexpr bool _M_valid() const noexcept {
+                    if constexpr (__variant::__never_valueless<_Types...>())
+                        return true;
+                    return this->_M_index != __index_type(variant_npos);
+                }
+
+                _Variadic_union<_Types...> _M_u;
+                using __index_type = __select_index<_Types...>;
+                __index_type _M_index;
+            };
+
+            template <typename... _Types>
+            struct _Variant_storage<true, _Types...> {
+                constexpr _Variant_storage()
+                    : _M_index(static_cast<__index_type>(variant_npos)) {}
+
+                template <size_t _Np, typename... _Args>
+                constexpr _Variant_storage(in_place_index_t<_Np>, _Args&&... __args)
+                    : _M_u(in_place_index<_Np>, std::forward<_Args>(__args)...)
+                    , _M_index{_Np} {}
+
+                constexpr void _M_reset() noexcept {
+                    _M_index = static_cast<__index_type>(variant_npos);
+                }
+
+                constexpr bool _M_valid() const noexcept {
+                    if constexpr (__variant::__never_valueless<_Types...>())
+                        return true;
+                    // It would be nice if we could just return true for -fno-exceptions.
+                    // It's possible (but inadvisable) that a std::variant could become
+                    // valueless in a translation unit compiled with -fexceptions and then
+                    // be passed to functions compiled with -fno-exceptions. We would need
+                    // some #ifdef _GLIBCXX_NO_EXCEPTIONS_GLOBALLY property to elide all
+                    // checks for valueless_by_exception().
+                    return this->_M_index != static_cast<__index_type>(variant_npos);
+                }
+
+                _Variadic_union<_Types...> _M_u;
+                using __index_type = __select_index<_Types...>;
+                __index_type _M_index;
+            };
+
+            // Implementation of v.emplace<N>(args...).
+            template <size_t _Np, bool _Triv, typename... _Types, typename... _Args>
+            _GLIBCXX20_CONSTEXPR inline void __emplace(_Variant_storage<_Triv, _Types...>& __v,
+                                                       _Args&&... __args) {
+                __v._M_reset();
+                auto* __addr = std::__addressof(__variant::__get_n<_Np>(__v._M_u));
+                std::_Construct(__addr, std::forward<_Args>(__args)...);
+                // Construction didn't throw, so can set the new index now:
+                __v._M_index = _Np;
+            }
+
+            template <typename... _Types>
+            using _Variant_storage_alias =
+                _Variant_storage<_Traits<_Types...>::_S_trivial_dtor, _Types...>;
+
+            // The following are (Copy|Move) (ctor|assign) layers for forwarding
+            // triviality and handling non-trivial SMF behaviors.
+
+            template <bool, typename... _Types>
+            struct _Copy_ctor_base : _Variant_storage_alias<_Types...> {
+                using _Base = _Variant_storage_alias<_Types...>;
+                using _Base::_Base;
+
+                _GLIBCXX20_CONSTEXPR
+                _Copy_ctor_base(const _Copy_ctor_base& __rhs) noexcept(
+                    _Traits<_Types...>::_S_nothrow_copy_ctor) {
+                    __variant::__raw_idx_visit(
+                        [this](auto&& __rhs_mem, auto __rhs_index) mutable {
+                            constexpr size_t __j = __rhs_index;
+                            if constexpr (__j != variant_npos)
+                                std::_Construct(std::__addressof(this->_M_u), in_place_index<__j>,
+                                                __rhs_mem);
+                        },
+                        __variant_cast<_Types...>(__rhs));
+                    this->_M_index = __rhs._M_index;
+                }
+
+                _Copy_ctor_base(_Copy_ctor_base&&)                 = default;
+                _Copy_ctor_base& operator=(const _Copy_ctor_base&) = default;
+                _Copy_ctor_base& operator=(_Copy_ctor_base&&)      = default;
+            };
+
+            template <typename... _Types>
+            struct _Copy_ctor_base<true, _Types...> : _Variant_storage_alias<_Types...> {
+                using _Base = _Variant_storage_alias<_Types...>;
+                using _Base::_Base;
+            };
+
+            template <typename... _Types>
+            using _Copy_ctor_alias =
+                _Copy_ctor_base<_Traits<_Types...>::_S_trivial_copy_ctor, _Types...>;
+
+            template <bool, typename... _Types>
+            struct _Move_ctor_base : _Copy_ctor_alias<_Types...> {
+                using _Base = _Copy_ctor_alias<_Types...>;
+                using _Base::_Base;
+
+                _GLIBCXX20_CONSTEXPR
+                _Move_ctor_base(_Move_ctor_base&& __rhs) noexcept(
+                    _Traits<_Types...>::_S_nothrow_move_ctor) {
+                    __variant::__raw_idx_visit(
+                        [this](auto&& __rhs_mem, auto __rhs_index) mutable {
+                            constexpr size_t __j = __rhs_index;
+                            if constexpr (__j != variant_npos)
+                                std::_Construct(std::__addressof(this->_M_u), in_place_index<__j>,
+                                                std::forward<decltype(__rhs_mem)>(__rhs_mem));
+                        },
+                        __variant_cast<_Types...>(std::move(__rhs)));
+                    this->_M_index = __rhs._M_index;
+                }
+
+                _Move_ctor_base(const _Move_ctor_base&)            = default;
+                _Move_ctor_base& operator=(const _Move_ctor_base&) = default;
+                _Move_ctor_base& operator=(_Move_ctor_base&&)      = default;
+            };
+
+            template <typename... _Types>
+            struct _Move_ctor_base<true, _Types...> : _Copy_ctor_alias<_Types...> {
+                using _Base = _Copy_ctor_alias<_Types...>;
+                using _Base::_Base;
+            };
+
+            template <typename... _Types>
+            using _Move_ctor_alias =
+                _Move_ctor_base<_Traits<_Types...>::_S_trivial_move_ctor, _Types...>;
+
+            template <bool, typename... _Types>
+            struct _Copy_assign_base : _Move_ctor_alias<_Types...> {
+                using _Base = _Move_ctor_alias<_Types...>;
+                using _Base::_Base;
+
+                _GLIBCXX20_CONSTEXPR
+                _Copy_assign_base& operator=(const _Copy_assign_base& __rhs) noexcept(
+                    _Traits<_Types...>::_S_nothrow_copy_assign) {
+                    __variant::__raw_idx_visit(
+                        [this](auto&& __rhs_mem, auto __rhs_index) mutable {
+                            constexpr size_t __j = __rhs_index;
+                            if constexpr (__j == variant_npos)
+                                this->_M_reset();  // Make *this valueless.
+                            else if (this->_M_index == __j)
+                                __variant::__get<__j>(*this) = __rhs_mem;
+                            else {
+                                using _Tj = typename _Nth_type<__j, _Types...>::type;
+                                if constexpr (is_nothrow_copy_constructible_v<_Tj>
+                                              || !is_nothrow_move_constructible_v<_Tj>)
+                                    __variant::__emplace<__j>(*this, __rhs_mem);
+                                else {
+                                    using _Variant   = variant<_Types...>;
+                                    _Variant& __self = __variant_cast<_Types...>(*this);
+                                    __self           = _Variant(in_place_index<__j>, __rhs_mem);
+                                }
+                            }
+                        },
+                        __variant_cast<_Types...>(__rhs));
+                    return *this;
+                }
+
+                _Copy_assign_base(const _Copy_assign_base&)       = default;
+                _Copy_assign_base(_Copy_assign_base&&)            = default;
+                _Copy_assign_base& operator=(_Copy_assign_base&&) = default;
+            };
+
+            template <typename... _Types>
+            struct _Copy_assign_base<true, _Types...> : _Move_ctor_alias<_Types...> {
+                using _Base = _Move_ctor_alias<_Types...>;
+                using _Base::_Base;
+            };
+
+            template <typename... _Types>
+            using _Copy_assign_alias =
+                _Copy_assign_base<_Traits<_Types...>::_S_trivial_copy_assign, _Types...>;
+
+            template <bool, typename... _Types>
+            struct _Move_assign_base : _Copy_assign_alias<_Types...> {
+                using _Base = _Copy_assign_alias<_Types...>;
+                using _Base::_Base;
+
+                _GLIBCXX20_CONSTEXPR
+                _Move_assign_base& operator=(_Move_assign_base&& __rhs) noexcept(
+                    _Traits<_Types...>::_S_nothrow_move_assign) {
+                    __variant::__raw_idx_visit(
+                        [this](auto&& __rhs_mem, auto __rhs_index) mutable {
+                            constexpr size_t __j = __rhs_index;
+                            if constexpr (__j != variant_npos) {
+                                if (this->_M_index == __j)
+                                    __variant::__get<__j>(*this) = std::move(__rhs_mem);
+                                else {
+                                    using _Tj = typename _Nth_type<__j, _Types...>::type;
+                                    if constexpr (is_nothrow_move_constructible_v<_Tj>)
+                                        __variant::__emplace<__j>(*this, std::move(__rhs_mem));
+                                    else {
+                                        using _Variant   = variant<_Types...>;
+                                        _Variant& __self = __variant_cast<_Types...>(*this);
+                                        __self.template emplace<__j>(std::move(__rhs_mem));
+                                    }
+                                }
+                            } else
+                                this->_M_reset();
+                        },
+                        __variant_cast<_Types...>(__rhs));
+                    return *this;
+                }
+
+                _Move_assign_base(const _Move_assign_base&)            = default;
+                _Move_assign_base(_Move_assign_base&&)                 = default;
+                _Move_assign_base& operator=(const _Move_assign_base&) = default;
+            };
+
+            template <typename... _Types>
+            struct _Move_assign_base<true, _Types...> : _Copy_assign_alias<_Types...> {
+                using _Base = _Copy_assign_alias<_Types...>;
+                using _Base::_Base;
+            };
+
+            template <typename... _Types>
+            using _Move_assign_alias =
+                _Move_assign_base<_Traits<_Types...>::_S_trivial_move_assign, _Types...>;
+
+            template <typename... _Types>
+            struct _Variant_base : _Move_assign_alias<_Types...> {
+                using _Base = _Move_assign_alias<_Types...>;
+
+                constexpr _Variant_base() noexcept(_Traits<_Types...>::_S_nothrow_default_ctor)
+                    : _Variant_base(in_place_index<0>) {}
+
+                template <size_t _Np, typename... _Args>
+                constexpr explicit _Variant_base(in_place_index_t<_Np> __i, _Args&&... __args)
+                    : _Base(__i, std::forward<_Args>(__args)...) {}
+
+                _Variant_base(const _Variant_base&)            = default;
+                _Variant_base(_Variant_base&&)                 = default;
+                _Variant_base& operator=(const _Variant_base&) = default;
+                _Variant_base& operator=(_Variant_base&&)      = default;
+            };
+
+            template <typename _Tp, typename... _Types>
+            inline constexpr bool __exactly_once =
+                std::__find_uniq_type_in_pack<_Tp, _Types...>() < sizeof...(_Types);
+
+            // Helper used to check for valid conversions that don't involve narrowing.
+            template <typename _Ti>
+            struct _Arr {
+                _Ti _M_x[1];
+            };
+
+            // "Build an imaginary function FUN(Ti) for each alternative type Ti"
+            template <size_t _Ind, typename _Tp, typename _Ti, typename = void>
+            struct _Build_FUN {
+                // This function means 'using _Build_FUN<I, T, Ti>::_S_fun;' is valid,
+                // but only static functions will be considered in the call below.
+                void _S_fun() = delete;
+            };
+
+            // "... for which Ti x[] = {std::forward<T>(t)}; is well-formed."
+            template <size_t _Ind, typename _Tp, typename _Ti>
+            struct _Build_FUN<_Ind, _Tp, _Ti, void_t<decltype(_Arr<_Ti>{{std::declval<_Tp>()}})>> {
+                // This is the FUN function for type _Ti, with index _Ind
+                static integral_constant<size_t, _Ind> _S_fun(_Ti);
+            };
+
+            template <typename _Tp, typename _Variant,
+                      typename = make_index_sequence<variant_size_v<_Variant>>>
+            struct _Build_FUNs;
+
+            template <typename _Tp, typename... _Ti, size_t... _Ind>
+            struct _Build_FUNs<_Tp, variant<_Ti...>, index_sequence<_Ind...>>
+                : _Build_FUN<_Ind, _Tp, _Ti>... {
+                using _Build_FUN<_Ind, _Tp, _Ti>::_S_fun...;
+            };
+
+            // The index j of the overload FUN(Tj) selected by overload resolution
+            // for FUN(std::forward<_Tp>(t))
+            template <typename _Tp, typename _Variant>
+            using _FUN_type = decltype(_Build_FUNs<_Tp, _Variant>::_S_fun(std::declval<_Tp>()));
+
+            // The index selected for FUN(std::forward<T>(t)), or variant_npos if none.
+            template <typename _Tp, typename _Variant, typename = void>
+            inline constexpr size_t __accepted_index = variant_npos;
+
+            template <typename _Tp, typename _Variant>
+            inline constexpr size_t
+                __accepted_index<_Tp, _Variant, void_t<_FUN_type<_Tp, _Variant>>> =
+                    _FUN_type<_Tp, _Variant>::value;
+
+            template <typename _Maybe_variant_cookie, typename _Variant,
+                      typename = __remove_cvref_t<_Variant>>
+            inline constexpr bool __extra_visit_slot_needed = false;
+
+            template <typename _Var, typename... _Types>
+            inline constexpr bool
+                __extra_visit_slot_needed<__variant_cookie, _Var, variant<_Types...>> =
+                    !__variant::__never_valueless<_Types...>();
+
+            template <typename _Var, typename... _Types>
+            inline constexpr bool
+                __extra_visit_slot_needed<__variant_idx_cookie, _Var, variant<_Types...>> =
+                    !__variant::__never_valueless<_Types...>();
+
+            // Used for storing a multi-dimensional vtable.
+            template <typename _Tp, size_t... _Dimensions>
+            struct _Multi_array;
+
+            // Partial specialization with rank zero, stores a single _Tp element.
+            template <typename _Tp>
+            struct _Multi_array<_Tp> {
+                template <typename>
+                struct __untag_result : false_type {
+                    using element_type = _Tp;
+                };
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+                template <typename... _Args>
+                struct __untag_result<const void (*)(_Args...)> : false_type {
+                    using element_type = void (*)(_Args...);
+                };
+#pragma GCC diagnostic pop
+
+                template <typename... _Args>
+                struct __untag_result<__variant_cookie (*)(_Args...)> : false_type {
+                    using element_type = void (*)(_Args...);
+                };
+
+                template <typename... _Args>
+                struct __untag_result<__variant_idx_cookie (*)(_Args...)> : false_type {
+                    using element_type = void (*)(_Args...);
+                };
+
+                template <typename _Res, typename... _Args>
+                struct __untag_result<__deduce_visit_result<_Res> (*)(_Args...)> : true_type {
+                    using element_type = _Res (*)(_Args...);
+                };
+
+                using __result_is_deduced = __untag_result<_Tp>;
+
+                constexpr const typename __untag_result<_Tp>::element_type& _M_access() const {
+                    return _M_data;
+                }
+
+                typename __untag_result<_Tp>::element_type _M_data;
+            };
+
+            // Partial specialization with rank >= 1.
+            template <typename _Ret, typename _Visitor, typename... _Variants, size_t __first,
+                      size_t... __rest>
+            struct _Multi_array<_Ret (*)(_Visitor, _Variants...), __first, __rest...> {
+                static constexpr size_t __index = sizeof...(_Variants) - sizeof...(__rest) - 1;
+
+                using _Variant = typename _Nth_type<__index, _Variants...>::type;
+
+                static constexpr int __do_cookie =
+                    __extra_visit_slot_needed<_Ret, _Variant> ? 1 : 0;
+
+                using _Tp = _Ret (*)(_Visitor, _Variants...);
+
+                template <typename... _Args>
+                constexpr decltype(auto) _M_access(size_t __first_index,
+                                                   _Args... __rest_indices) const {
+                    return _M_arr[__first_index + __do_cookie]._M_access(__rest_indices...);
+                }
+
+                _Multi_array<_Tp, __rest...> _M_arr[__first + __do_cookie];
+            };
+
+            // Creates a multi-dimensional vtable recursively.
+            //
+            // For example,
+            // visit([](auto, auto){},
+            //       variant<int, char>(),  // typedef'ed as V1
+            //       variant<float, double, long double>())  // typedef'ed as V2
+            // will trigger instantiations of:
+            // __gen_vtable_impl<_Multi_array<void(*)(V1&&, V2&&), 2, 3>,
+            //                   tuple<V1&&, V2&&>, std::index_sequence<>>
+            //   __gen_vtable_impl<_Multi_array<void(*)(V1&&, V2&&), 3>,
+            //                     tuple<V1&&, V2&&>, std::index_sequence<0>>
+            //     __gen_vtable_impl<_Multi_array<void(*)(V1&&, V2&&)>,
+            //                       tuple<V1&&, V2&&>, std::index_sequence<0, 0>>
+            //     __gen_vtable_impl<_Multi_array<void(*)(V1&&, V2&&)>,
+            //                       tuple<V1&&, V2&&>, std::index_sequence<0, 1>>
+            //     __gen_vtable_impl<_Multi_array<void(*)(V1&&, V2&&)>,
+            //                       tuple<V1&&, V2&&>, std::index_sequence<0, 2>>
+            //   __gen_vtable_impl<_Multi_array<void(*)(V1&&, V2&&), 3>,
+            //                     tuple<V1&&, V2&&>, std::index_sequence<1>>
+            //     __gen_vtable_impl<_Multi_array<void(*)(V1&&, V2&&)>,
+            //                       tuple<V1&&, V2&&>, std::index_sequence<1, 0>>
+            //     __gen_vtable_impl<_Multi_array<void(*)(V1&&, V2&&)>,
+            //                       tuple<V1&&, V2&&>, std::index_sequence<1, 1>>
+            //     __gen_vtable_impl<_Multi_array<void(*)(V1&&, V2&&)>,
+            //                       tuple<V1&&, V2&&>, std::index_sequence<1, 2>>
+            // The returned multi-dimensional vtable can be fast accessed by the visitor
+            // using index calculation.
+            template <typename _Array_type, typename _Index_seq>
+            struct __gen_vtable_impl;
+
+            // Defines the _S_apply() member that returns a _Multi_array populated
+            // with function pointers that perform the visitation expressions e(m)
+            // for each valid pack of indexes into the variant types _Variants.
+            //
+            // This partial specialization builds up the index sequences by recursively
+            // calling _S_apply() on the next specialization of __gen_vtable_impl.
+            // The base case of the recursion defines the actual function pointers.
+            template <typename _Result_type, typename _Visitor, size_t... __dimensions,
+                      typename... _Variants, size_t... __indices>
+            struct __gen_vtable_impl<
+                _Multi_array<_Result_type (*)(_Visitor, _Variants...), __dimensions...>,
+                std::index_sequence<__indices...>> {
+                using _Next = remove_reference_t<
+                    typename _Nth_type<sizeof...(__indices), _Variants...>::type>;
+                using _Array_type =
+                    _Multi_array<_Result_type (*)(_Visitor, _Variants...), __dimensions...>;
+
+                static constexpr _Array_type _S_apply() {
+                    _Array_type __vtable{};
+                    _S_apply_all_alts(__vtable, make_index_sequence<variant_size_v<_Next>>());
+                    return __vtable;
+                }
+
+                template <size_t... __var_indices>
+                static constexpr void _S_apply_all_alts(_Array_type& __vtable,
+                                                        std::index_sequence<__var_indices...>) {
+                    if constexpr (__extra_visit_slot_needed<_Result_type, _Next>)
+                        (_S_apply_single_alt<true, __var_indices>(
+                             __vtable._M_arr[__var_indices + 1], &(__vtable._M_arr[0])),
+                         ...);
+                    else
+                        (_S_apply_single_alt<false, __var_indices>(__vtable._M_arr[__var_indices]),
+                         ...);
+                }
+
+                template <bool __do_cookie, size_t __index, typename _Tp>
+                static constexpr void _S_apply_single_alt(_Tp& __element,
+                                                          _Tp* __cookie_element = nullptr) {
+                    if constexpr (__do_cookie) {
+                        __element = __gen_vtable_impl<
+                            _Tp, std::index_sequence<__indices..., __index>>::_S_apply();
+                        *__cookie_element = __gen_vtable_impl<
+                            _Tp, std::index_sequence<__indices..., variant_npos>>::_S_apply();
+                    } else {
+                        auto __tmp_element = __gen_vtable_impl<
+                            remove_reference_t<decltype(__element)>,
+                            std::index_sequence<__indices..., __index>>::_S_apply();
+                        static_assert(is_same_v<_Tp, decltype(__tmp_element)>,
+                                      "std::visit requires the visitor to have the same "
+                                      "return type for all alternatives of a variant");
+                        __element = __tmp_element;
+                    }
+                }
+            };
+
+            // This partial specialization is the base case for the recursion.
+            // It populates a _Multi_array element with the address of a function
+            // that invokes the visitor with the alternatives specified by __indices.
+            template <typename _Result_type, typename _Visitor, typename... _Variants,
+                      size_t... __indices>
+            struct __gen_vtable_impl<_Multi_array<_Result_type (*)(_Visitor, _Variants...)>,
+                                     std::index_sequence<__indices...>> {
+                using _Array_type = _Multi_array<_Result_type (*)(_Visitor, _Variants...)>;
+
+                template <size_t __index, typename _Variant>
+                static constexpr decltype(auto) __element_by_index_or_cookie(
+                    _Variant&& __var) noexcept {
+                    if constexpr (__index != variant_npos)
+                        return __variant::__get<__index>(std::forward<_Variant>(__var));
+                    else
+                        return __variant_cookie{};
+                }
+
+                static constexpr decltype(auto) __visit_invoke(_Visitor&& __visitor,
+                                                               _Variants... __vars) {
+                    if constexpr (is_same_v<_Result_type, __variant_idx_cookie>)
+                        // For raw visitation using indices, pass the indices to the visitor
+                        // and discard the return value:
+                        std::__invoke(std::forward<_Visitor>(__visitor),
+                                      __element_by_index_or_cookie<__indices>(
+                                          std::forward<_Variants>(__vars))...,
+                                      integral_constant<size_t, __indices>()...);
+                    else if constexpr (is_same_v<_Result_type, __variant_cookie>)
+                        // For raw visitation without indices, and discard the return value:
+                        std::__invoke(std::forward<_Visitor>(__visitor),
+                                      __element_by_index_or_cookie<__indices>(
+                                          std::forward<_Variants>(__vars))...);
+                    else if constexpr (_Array_type::__result_is_deduced::value)
+                        // For the usual std::visit case deduce the return value:
+                        return std::__invoke(std::forward<_Visitor>(__visitor),
+                                             __element_by_index_or_cookie<__indices>(
+                                                 std::forward<_Variants>(__vars))...);
+                    else  // for std::visit<R> use INVOKE<R>
+                        return std::__invoke_r<_Result_type>(
+                            std::forward<_Visitor>(__visitor),
+                            __variant::__get<__indices>(std::forward<_Variants>(__vars))...);
+                }
+
+                static constexpr auto _S_apply() {
+                    if constexpr (_Array_type::__result_is_deduced::value) {
+                        constexpr bool __visit_ret_type_mismatch =
+                            !is_same_v<typename _Result_type::type,
+                                       decltype(__visit_invoke(std::declval<_Visitor>(),
+                                                               std::declval<_Variants>()...))>;
+                        if constexpr (__visit_ret_type_mismatch) {
+                            struct __cannot_match {};
+                            return __cannot_match{};
+                        } else
+                            return _Array_type{&__visit_invoke};
+                    } else
+                        return _Array_type{&__visit_invoke};
+                }
+            };
+
+            template <typename _Result_type, typename _Visitor, typename... _Variants>
+            struct __gen_vtable {
+                using _Array_type = _Multi_array<_Result_type (*)(_Visitor, _Variants...),
+                                                 variant_size_v<remove_reference_t<_Variants>>...>;
+
+                static constexpr _Array_type _S_vtable =
+                    __gen_vtable_impl<_Array_type, std::index_sequence<>>::_S_apply();
+            };
+
+            template <size_t _Np, typename _Tp>
+            struct _Base_dedup : public _Tp {};
+
+            template <typename _Variant, typename __indices>
+            struct _Variant_hash_base;
+
+            template <typename... _Types, size_t... __indices>
+            struct _Variant_hash_base<variant<_Types...>, std::index_sequence<__indices...>>
+                : _Base_dedup<__indices, __poison_hash<remove_const_t<_Types>>>... {};
+
+            // Equivalent to decltype(get<_Np>(as-variant(declval<_Variant>())))
+            template <size_t _Np, typename _Variant,
+                      typename _AsV = decltype(__variant::__as(std::declval<_Variant>())),
+                      typename _Tp  = variant_alternative_t<_Np, remove_reference_t<_AsV>>>
+            using __get_t = __conditional_t<is_lvalue_reference_v<_Variant>, _Tp&, _Tp&&>;
+
+            // Return type of std::visit.
+            template <typename _Visitor, typename... _Variants>
+            using __visit_result_t = invoke_result_t<_Visitor, __get_t<0, _Variants>...>;
+
+            template <typename _Tp, typename... _Types>
+            constexpr inline bool __same_types = (is_same_v<_Tp, _Types> && ...);
+
+            template <typename _Visitor, typename _Variant, size_t... _Idxs>
+            constexpr bool __check_visitor_results(std::index_sequence<_Idxs...>) {
+                return __same_types<invoke_result_t<_Visitor, __get_t<_Idxs, _Variant>>...>;
+            }
+
+        }  // namespace __variant
+    }      // namespace __detail
+
+    template <typename _Tp, typename... _Types>
+    constexpr bool holds_alternative(const variant<_Types...>& __v) noexcept {
+        static_assert(__detail::__variant::__exactly_once<_Tp, _Types...>,
+                      "T must occur exactly once in alternatives");
+        return __v.index() == std::__find_uniq_type_in_pack<_Tp, _Types...>();
+    }
+
+    template <typename _Tp, typename... _Types>
+    constexpr _Tp& get(variant<_Types...>& __v) {
+        static_assert(__detail::__variant::__exactly_once<_Tp, _Types...>,
+                      "T must occur exactly once in alternatives");
+        static_assert(!is_void_v<_Tp>, "_Tp must not be void");
+        constexpr size_t __n = std::__find_uniq_type_in_pack<_Tp, _Types...>();
+        return std::get<__n>(__v);
+    }
+
+    template <typename _Tp, typename... _Types>
+    constexpr _Tp&& get(variant<_Types...>&& __v) {
+        static_assert(__detail::__variant::__exactly_once<_Tp, _Types...>,
+                      "T must occur exactly once in alternatives");
+        static_assert(!is_void_v<_Tp>, "_Tp must not be void");
+        constexpr size_t __n = std::__find_uniq_type_in_pack<_Tp, _Types...>();
+        return std::get<__n>(std::move(__v));
+    }
+
+    template <typename _Tp, typename... _Types>
+    constexpr const _Tp& get(const variant<_Types...>& __v) {
+        static_assert(__detail::__variant::__exactly_once<_Tp, _Types...>,
+                      "T must occur exactly once in alternatives");
+        static_assert(!is_void_v<_Tp>, "_Tp must not be void");
+        constexpr size_t __n = std::__find_uniq_type_in_pack<_Tp, _Types...>();
+        return std::get<__n>(__v);
+    }
+
+    template <typename _Tp, typename... _Types>
+    constexpr const _Tp&& get(const variant<_Types...>&& __v) {
+        static_assert(__detail::__variant::__exactly_once<_Tp, _Types...>,
+                      "T must occur exactly once in alternatives");
+        static_assert(!is_void_v<_Tp>, "_Tp must not be void");
+        constexpr size_t __n = std::__find_uniq_type_in_pack<_Tp, _Types...>();
+        return std::get<__n>(std::move(__v));
+    }
+
+    template <size_t _Np, typename... _Types>
+    constexpr add_pointer_t<variant_alternative_t<_Np, variant<_Types...>>> get_if(
+        variant<_Types...>* __ptr) noexcept {
+        using _Alternative_type = variant_alternative_t<_Np, variant<_Types...>>;
+        static_assert(_Np < sizeof...(_Types), "The index must be in [0, number of alternatives)");
+        static_assert(!is_void_v<_Alternative_type>, "_Tp must not be void");
+        if (__ptr && __ptr->index() == _Np)
+            return std::addressof(__detail::__variant::__get<_Np>(*__ptr));
+        return nullptr;
+    }
+
+    template <size_t _Np, typename... _Types>
+    constexpr add_pointer_t<const variant_alternative_t<_Np, variant<_Types...>>> get_if(
+        const variant<_Types...>* __ptr) noexcept {
+        using _Alternative_type = variant_alternative_t<_Np, variant<_Types...>>;
+        static_assert(_Np < sizeof...(_Types), "The index must be in [0, number of alternatives)");
+        static_assert(!is_void_v<_Alternative_type>, "_Tp must not be void");
+        if (__ptr && __ptr->index() == _Np)
+            return std::addressof(__detail::__variant::__get<_Np>(*__ptr));
+        return nullptr;
+    }
+
+    template <typename _Tp, typename... _Types>
+    constexpr add_pointer_t<_Tp> get_if(variant<_Types...>* __ptr) noexcept {
+        static_assert(__detail::__variant::__exactly_once<_Tp, _Types...>,
+                      "T must occur exactly once in alternatives");
+        static_assert(!is_void_v<_Tp>, "_Tp must not be void");
+        constexpr size_t __n = std::__find_uniq_type_in_pack<_Tp, _Types...>();
+        return std::get_if<__n>(__ptr);
+    }
+
+    template <typename _Tp, typename... _Types>
+    constexpr add_pointer_t<const _Tp> get_if(const variant<_Types...>* __ptr) noexcept {
+        static_assert(__detail::__variant::__exactly_once<_Tp, _Types...>,
+                      "T must occur exactly once in alternatives");
+        static_assert(!is_void_v<_Tp>, "_Tp must not be void");
+        constexpr size_t __n = std::__find_uniq_type_in_pack<_Tp, _Types...>();
+        return std::get_if<__n>(__ptr);
+    }
+
+    struct monostate {};
+
+#define _VARIANT_RELATION_FUNCTION_TEMPLATE(__OP, __NAME)                  \
+    template <typename... _Types>                                          \
+    constexpr bool operator __OP(const variant<_Types...>& __lhs,          \
+                                 const variant<_Types...>& __rhs) {        \
+        bool __ret = true;                                                 \
+        __detail::__variant::__raw_idx_visit(                              \
+            [&__ret, &__lhs](auto&& __rhs_mem, auto __rhs_index) mutable { \
+                if constexpr (__rhs_index != variant_npos) {               \
+                    if (__lhs.index() == __rhs_index) {                    \
+                        auto& __this_mem = std::get<__rhs_index>(__lhs);   \
+                        __ret            = __this_mem __OP __rhs_mem;      \
+                    } else                                                 \
+                        __ret = (__lhs.index() + 1) __OP(__rhs_index + 1); \
+                } else                                                     \
+                    __ret = (__lhs.index() + 1) __OP(__rhs_index + 1);     \
+            },                                                             \
+            __rhs);                                                        \
+        return __ret;                                                      \
+    }
+
+    _VARIANT_RELATION_FUNCTION_TEMPLATE(<, less)
+    _VARIANT_RELATION_FUNCTION_TEMPLATE(<=, less_equal)
+    _VARIANT_RELATION_FUNCTION_TEMPLATE(==, equal)
+    _VARIANT_RELATION_FUNCTION_TEMPLATE(!=, not_equal)
+    _VARIANT_RELATION_FUNCTION_TEMPLATE(>=, greater_equal)
+    _VARIANT_RELATION_FUNCTION_TEMPLATE(>, greater)
+
+#undef _VARIANT_RELATION_FUNCTION_TEMPLATE
+
+    constexpr bool operator==(monostate, monostate) noexcept {
+        return true;
+    }
+
+#ifdef __cpp_lib_three_way_comparison
+    template <typename... _Types>
+        requires(three_way_comparable<_Types> && ...)
+    constexpr common_comparison_category_t<compare_three_way_result_t<_Types>...> operator<=>(
+        const variant<_Types...>& __v, const variant<_Types...>& __w) {
+        common_comparison_category_t<compare_three_way_result_t<_Types>...> __ret =
+            strong_ordering::equal;
+
+        __detail::__variant::__raw_idx_visit(
+            [&__ret, &__v](auto&& __w_mem, auto __w_index) mutable {
+                if constexpr (__w_index != variant_npos) {
+                    if (__v.index() == __w_index) {
+                        auto& __this_mem = std::get<__w_index>(__v);
+                        __ret            = __this_mem <=> __w_mem;
+                        return;
+                    }
+                }
+                __ret = (__v.index() + 1) <=> (__w_index + 1);
+            },
+            __w);
+        return __ret;
+    }
+
+    constexpr strong_ordering operator<=>(monostate, monostate) noexcept {
+        return strong_ordering::equal;
+    }
+#else
+    constexpr bool operator!=(monostate, monostate) noexcept {
+        return false;
+    }
+    constexpr bool operator<(monostate, monostate) noexcept {
+        return false;
+    }
+    constexpr bool operator>(monostate, monostate) noexcept {
+        return false;
+    }
+    constexpr bool operator<=(monostate, monostate) noexcept {
+        return true;
+    }
+    constexpr bool operator>=(monostate, monostate) noexcept {
+        return true;
+    }
+#endif
+
+    template <typename _Visitor, typename... _Variants>
+    constexpr __detail::__variant::__visit_result_t<_Visitor, _Variants...> visit(_Visitor&&,
+                                                                                  _Variants&&...);
+
+    template <typename... _Types>
+    _GLIBCXX20_CONSTEXPR inline enable_if_t<(is_move_constructible_v<_Types> && ...)
+                                            && (is_swappable_v<_Types> && ...)>
+    swap(variant<_Types...>& __lhs,
+         variant<_Types...>& __rhs) noexcept(noexcept(__lhs.swap(__rhs))) {
+        __lhs.swap(__rhs);
+    }
+
+    template <typename... _Types>
+    enable_if_t<!((is_move_constructible_v<_Types> && ...) && (is_swappable_v<_Types> && ...))>
+    swap(variant<_Types...>&, variant<_Types...>&) = delete;
+
+    class bad_variant_access : public exception {
+    public:
+        bad_variant_access() noexcept {}
+
+        const char* what() const noexcept override { return _M_reason; }
+
+    private:
+        bad_variant_access(const char* __reason) noexcept
+            : _M_reason(__reason) {}
+
+        // Must point to a string with static storage duration:
+        const char* _M_reason = "bad variant access";
+
+        friend void __throw_bad_variant_access(const char* __what);
+    };
+
+    // Must only be called with a string literal
+    inline void __throw_bad_variant_access(const char* __what) {
+        _GLIBCXX_THROW_OR_ABORT(bad_variant_access(__what));
+    }
+
+    inline void __throw_bad_variant_access(bool __valueless) {
+        if (__valueless) [[__unlikely__]]
+            __throw_bad_variant_access("std::get: variant is valueless");
+        else
+            __throw_bad_variant_access("std::get: wrong index for variant");
+    }
+
+    template <typename... _Types>
+    class variant
+        : private __detail::__variant::_Variant_base<_Types...>,
+          private _Enable_default_constructor<
+              __detail::__variant::_Traits<_Types...>::_S_default_ctor, variant<_Types...>>,
+          private _Enable_copy_move<__detail::__variant::_Traits<_Types...>::_S_copy_ctor,
+                                    __detail::__variant::_Traits<_Types...>::_S_copy_assign,
+                                    __detail::__variant::_Traits<_Types...>::_S_move_ctor,
+                                    __detail::__variant::_Traits<_Types...>::_S_move_assign,
+                                    variant<_Types...>> {
+    private:
+        template <typename... _UTypes, typename _Tp>
+        friend _GLIBCXX20_CONSTEXPR decltype(auto) __variant_cast(_Tp&&);
+
+        static_assert(sizeof...(_Types) > 0, "variant must have at least one alternative");
+        static_assert(!(std::is_reference_v<_Types> || ...),
+                      "variant must have no reference alternative");
+        static_assert(!(std::is_void_v<_Types> || ...), "variant must have no void alternative");
+
+        using _Base = __detail::__variant::_Variant_base<_Types...>;
+        using _Default_ctor_enabler =
+            _Enable_default_constructor<__detail::__variant::_Traits<_Types...>::_S_default_ctor,
+                                        variant<_Types...>>;
+
+        template <typename _Tp>
+        static constexpr bool __not_self = !is_same_v<__remove_cvref_t<_Tp>, variant>;
+
+        template <typename _Tp>
+        static constexpr bool __exactly_once = __detail::__variant::__exactly_once<_Tp, _Types...>;
+
+        template <typename _Tp>
+        static constexpr size_t __accepted_index =
+            __detail::__variant::__accepted_index<_Tp, variant>;
+
+        template <size_t _Np, typename = enable_if_t<(_Np < sizeof...(_Types))>>
+        using __to_type = typename _Nth_type<_Np, _Types...>::type;
+
+        template <typename _Tp, typename = enable_if_t<__not_self<_Tp>>>
+        using __accepted_type = __to_type<__accepted_index<_Tp>>;
+
+        template <typename _Tp>
+        static constexpr size_t __index_of = std::__find_uniq_type_in_pack<_Tp, _Types...>();
+
+        using _Traits = __detail::__variant::_Traits<_Types...>;
+
+        template <typename _Tp>
+        struct __is_in_place_tag : false_type {};
+        template <typename _Tp>
+        struct __is_in_place_tag<in_place_type_t<_Tp>> : true_type {};
+        template <size_t _Np>
+        struct __is_in_place_tag<in_place_index_t<_Np>> : true_type {};
+
+        template <typename _Tp>
+        static constexpr bool __not_in_place_tag = !__is_in_place_tag<__remove_cvref_t<_Tp>>::value;
+
+    public:
+        variant()                          = default;
+        variant(const variant& __rhs)      = default;
+        variant(variant&&)                 = default;
+        variant& operator=(const variant&) = default;
+        variant& operator=(variant&&)      = default;
+        _GLIBCXX20_CONSTEXPR ~variant()    = default;
+
+        template <typename _Tp, typename = enable_if_t<sizeof...(_Types) != 0>,
+                  typename     = enable_if_t<__not_in_place_tag<_Tp>>,
+                  typename _Tj = __accepted_type<_Tp&&>,
+                  typename     = enable_if_t<__exactly_once<_Tj> && is_constructible_v<_Tj, _Tp>>>
+        constexpr variant(_Tp&& __t) noexcept(is_nothrow_constructible_v<_Tj, _Tp>)
+            : variant(in_place_index<__accepted_index<_Tp>>, std::forward<_Tp>(__t)) {}
+
+        template <typename _Tp, typename... _Args,
+                  typename = enable_if_t<__exactly_once<_Tp> && is_constructible_v<_Tp, _Args...>>>
+        constexpr explicit variant(in_place_type_t<_Tp>, _Args&&... __args)
+            : variant(in_place_index<__index_of<_Tp>>, std::forward<_Args>(__args)...) {}
+
+        template <
+            typename _Tp, typename _Up, typename... _Args,
+            typename = enable_if_t<__exactly_once<_Tp>
+                                   && is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>>>
+        constexpr explicit variant(in_place_type_t<_Tp>, initializer_list<_Up> __il,
+                                   _Args&&... __args)
+            : variant(in_place_index<__index_of<_Tp>>, __il, std::forward<_Args>(__args)...) {}
+
+        template <size_t _Np, typename... _Args, typename _Tp = __to_type<_Np>,
+                  typename = enable_if_t<is_constructible_v<_Tp, _Args...>>>
+        constexpr explicit variant(in_place_index_t<_Np>, _Args&&... __args)
+            : _Base(in_place_index<_Np>, std::forward<_Args>(__args)...)
+            , _Default_ctor_enabler(_Enable_default_constructor_tag{}) {}
+
+        template <size_t _Np, typename _Up, typename... _Args, typename _Tp = __to_type<_Np>,
+                  typename = enable_if_t<is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>>>
+        constexpr explicit variant(in_place_index_t<_Np>, initializer_list<_Up> __il,
+                                   _Args&&... __args)
+            : _Base(in_place_index<_Np>, __il, std::forward<_Args>(__args)...)
+            , _Default_ctor_enabler(_Enable_default_constructor_tag{}) {}
+
+        template <typename _Tp>
+        _GLIBCXX20_CONSTEXPR enable_if_t<__exactly_once<__accepted_type<_Tp&&>>
+                                             && is_constructible_v<__accepted_type<_Tp&&>, _Tp>
+                                             && is_assignable_v<__accepted_type<_Tp&&>&, _Tp>,
+                                         variant&>
+        operator=(_Tp&& __rhs) noexcept(
+            is_nothrow_assignable_v<__accepted_type<_Tp&&>&, _Tp>&&
+                is_nothrow_constructible_v<__accepted_type<_Tp&&>, _Tp>) {
+            constexpr auto __index = __accepted_index<_Tp>;
+            if (index() == __index)
+                std::get<__index>(*this) = std::forward<_Tp>(__rhs);
+            else {
+                using _Tj = __accepted_type<_Tp&&>;
+                if constexpr (is_nothrow_constructible_v<_Tj, _Tp>
+                              || !is_nothrow_move_constructible_v<_Tj>)
+                    this->emplace<__index>(std::forward<_Tp>(__rhs));
+                else
+                    // _GLIBCXX_RESOLVE_LIB_DEFECTS
+                    // 3585. converting assignment with immovable alternative
+                    this->emplace<__index>(_Tj(std::forward<_Tp>(__rhs)));
+            }
+            return *this;
+        }
+
+        template <typename _Tp, typename... _Args>
+        _GLIBCXX20_CONSTEXPR
+            enable_if_t<is_constructible_v<_Tp, _Args...> && __exactly_once<_Tp>, _Tp&>
+            emplace(_Args&&... __args) {
+            constexpr size_t __index = __index_of<_Tp>;
+            return this->emplace<__index>(std::forward<_Args>(__args)...);
+        }
+
+        template <typename _Tp, typename _Up, typename... _Args>
+        _GLIBCXX20_CONSTEXPR enable_if_t<
+            is_constructible_v<_Tp, initializer_list<_Up>&, _Args...> && __exactly_once<_Tp>, _Tp&>
+        emplace(initializer_list<_Up> __il, _Args&&... __args) {
+            constexpr size_t __index = __index_of<_Tp>;
+            return this->emplace<__index>(__il, std::forward<_Args>(__args)...);
+        }
+
+        template <size_t _Np, typename... _Args>
+        _GLIBCXX20_CONSTEXPR
+            enable_if_t<is_constructible_v<__to_type<_Np>, _Args...>, __to_type<_Np>&>
+            emplace(_Args&&... __args) {
+            namespace __variant = std::__detail::__variant;
+            using type          = typename _Nth_type<_Np, _Types...>::type;
+            // Provide the strong exception-safety guarantee when possible,
+            // to avoid becoming valueless.
+            if constexpr (is_nothrow_constructible_v<type, _Args...>) {
+                __variant::__emplace<_Np>(*this, std::forward<_Args>(__args)...);
+            } else if constexpr (is_scalar_v<type>) {
+                // This might invoke a potentially-throwing conversion operator:
+                const type __tmp(std::forward<_Args>(__args)...);
+                // But this won't throw:
+                __variant::__emplace<_Np>(*this, __tmp);
+            } else if constexpr (__variant::_Never_valueless_alt<type>()
+                                 && _Traits::_S_move_assign) {
+                // This construction might throw:
+                variant __tmp(in_place_index<_Np>, std::forward<_Args>(__args)...);
+                // But _Never_valueless_alt<type> means this won't:
+                *this = std::move(__tmp);
+            } else {
+                // This case only provides the basic exception-safety guarantee,
+                // i.e. the variant can become valueless.
+                __variant::__emplace<_Np>(*this, std::forward<_Args>(__args)...);
+            }
+            return std::get<_Np>(*this);
+        }
+
+        template <size_t _Np, typename _Up, typename... _Args>
+        _GLIBCXX20_CONSTEXPR enable_if_t<
+            is_constructible_v<__to_type<_Np>, initializer_list<_Up>&, _Args...>, __to_type<_Np>&>
+        emplace(initializer_list<_Up> __il, _Args&&... __args) {
+            namespace __variant = std::__detail::__variant;
+            using type          = typename _Nth_type<_Np, _Types...>::type;
+            // Provide the strong exception-safety guarantee when possible,
+            // to avoid becoming valueless.
+            if constexpr (is_nothrow_constructible_v<type, initializer_list<_Up>&, _Args...>) {
+                __variant::__emplace<_Np>(*this, __il, std::forward<_Args>(__args)...);
+            } else if constexpr (__variant::_Never_valueless_alt<type>()
+                                 && _Traits::_S_move_assign) {
+                // This construction might throw:
+                variant __tmp(in_place_index<_Np>, __il, std::forward<_Args>(__args)...);
+                // But _Never_valueless_alt<type> means this won't:
+                *this = std::move(__tmp);
+            } else {
+                // This case only provides the basic exception-safety guarantee,
+                // i.e. the variant can become valueless.
+                __variant::__emplace<_Np>(*this, __il, std::forward<_Args>(__args)...);
+            }
+            return std::get<_Np>(*this);
+        }
+
+        template <size_t _Np, typename... _Args>
+        enable_if_t<!(_Np < sizeof...(_Types))> emplace(_Args&&...) = delete;
+
+        template <typename _Tp, typename... _Args>
+        enable_if_t<!__exactly_once<_Tp>> emplace(_Args&&...) = delete;
+
+        constexpr bool valueless_by_exception() const noexcept { return !this->_M_valid(); }
+
+        constexpr size_t index() const noexcept {
+            using __index_type = typename _Base::__index_type;
+            if constexpr (__detail::__variant::__never_valueless<_Types...>())
+                return this->_M_index;
+            else if constexpr (sizeof...(_Types) <= __index_type(-1) / 2)
+                return make_signed_t<__index_type>(this->_M_index);
+            else
+                return size_t(__index_type(this->_M_index + 1)) - 1;
+        }
+
+        _GLIBCXX20_CONSTEXPR
+        void swap(variant& __rhs) noexcept((__is_nothrow_swappable<_Types>::value && ...)
+                                           && is_nothrow_move_constructible_v<variant>) {
+            static_assert((is_move_constructible_v<_Types> && ...));
+
+            // Handle this here to simplify the visitation.
+            if (__rhs.valueless_by_exception()) [[__unlikely__]] {
+                if (!this->valueless_by_exception()) [[__likely__]]
+                    __rhs.swap(*this);
+                return;
+            }
+
+            namespace __variant = __detail::__variant;
+
+            __variant::__raw_idx_visit(
+                [this, &__rhs](auto&& __rhs_mem, auto __rhs_index) mutable {
+                    constexpr size_t __j = __rhs_index;
+                    if constexpr (__j != variant_npos) {
+                        if (this->index() == __j) {
+                            using std::swap;
+                            swap(std::get<__j>(*this), __rhs_mem);
+                        } else {
+                            auto __tmp(std::move(__rhs_mem));
+
+                            if constexpr (_Traits::_S_trivial_move_assign)
+                                __rhs = std::move(*this);
+                            else
+                                __variant::__raw_idx_visit(
+                                    [&__rhs](auto&& __this_mem, auto __this_index) mutable {
+                                        constexpr size_t __k = __this_index;
+                                        if constexpr (__k != variant_npos)
+                                            __variant::__emplace<__k>(__rhs, std::move(__this_mem));
+                                    },
+                                    *this);
+
+                            __variant::__emplace<__j>(*this, std::move(__tmp));
+                        }
+                    }
+                },
+                __rhs);
+        }
+
+#if defined(__clang__) && __clang_major__ <= 7
+    public:
+        using _Base::_M_u;  // See https://bugs.llvm.org/show_bug.cgi?id=31852
+#endif
+
+    private:
+        template <size_t _Np, typename _Vp>
+        friend constexpr decltype(auto) __detail::__variant::__get(_Vp&& __v) noexcept;
+
+#define _VARIANT_RELATION_FUNCTION_TEMPLATE(__OP)                     \
+    template <typename... _Tp>                                        \
+    friend constexpr bool operator __OP(const variant<_Tp...>& __lhs, \
+                                        const variant<_Tp...>& __rhs);
+
+        _VARIANT_RELATION_FUNCTION_TEMPLATE(<)
+        _VARIANT_RELATION_FUNCTION_TEMPLATE(<=)
+        _VARIANT_RELATION_FUNCTION_TEMPLATE(==)
+        _VARIANT_RELATION_FUNCTION_TEMPLATE(!=)
+        _VARIANT_RELATION_FUNCTION_TEMPLATE(>=)
+        _VARIANT_RELATION_FUNCTION_TEMPLATE(>)
+
+#undef _VARIANT_RELATION_FUNCTION_TEMPLATE
+    };
+
+    template <size_t _Np, typename... _Types>
+    constexpr variant_alternative_t<_Np, variant<_Types...>>& get(variant<_Types...>& __v) {
+        static_assert(_Np < sizeof...(_Types), "The index must be in [0, number of alternatives)");
+        if (__v.index() != _Np)
+            __throw_bad_variant_access(__v.valueless_by_exception());
+        return __detail::__variant::__get<_Np>(__v);
+    }
+
+    template <size_t _Np, typename... _Types>
+    constexpr variant_alternative_t<_Np, variant<_Types...>>&& get(variant<_Types...>&& __v) {
+        static_assert(_Np < sizeof...(_Types), "The index must be in [0, number of alternatives)");
+        if (__v.index() != _Np)
+            __throw_bad_variant_access(__v.valueless_by_exception());
+        return __detail::__variant::__get<_Np>(std::move(__v));
+    }
+
+    template <size_t _Np, typename... _Types>
+    constexpr const variant_alternative_t<_Np, variant<_Types...>>& get(
+        const variant<_Types...>& __v) {
+        static_assert(_Np < sizeof...(_Types), "The index must be in [0, number of alternatives)");
+        if (__v.index() != _Np)
+            __throw_bad_variant_access(__v.valueless_by_exception());
+        return __detail::__variant::__get<_Np>(__v);
+    }
+
+    template <size_t _Np, typename... _Types>
+    constexpr const variant_alternative_t<_Np, variant<_Types...>>&& get(
+        const variant<_Types...>&& __v) {
+        static_assert(_Np < sizeof...(_Types), "The index must be in [0, number of alternatives)");
+        if (__v.index() != _Np)
+            __throw_bad_variant_access(__v.valueless_by_exception());
+        return __detail::__variant::__get<_Np>(std::move(__v));
+    }
+
+    /// @cond undocumented
+    template <typename _Result_type, typename _Visitor, typename... _Variants>
+    constexpr decltype(auto) __do_visit(_Visitor&& __visitor, _Variants&&... __variants) {
+        // Get the silly case of visiting no variants out of the way first.
+        if constexpr (sizeof...(_Variants) == 0) {
+            if constexpr (is_void_v<_Result_type>)
+                return (void)std::forward<_Visitor>(__visitor)();
+            else
+                return std::forward<_Visitor>(__visitor)();
+        } else {
+            constexpr size_t __max = 11;  // "These go to eleven."
+
+            // The type of the first variant in the pack.
+            using _V0 = typename _Nth_type<0, _Variants...>::type;
+            // The number of alternatives in that first variant.
+            constexpr auto __n = variant_size_v<remove_reference_t<_V0>>;
+
+            if constexpr (sizeof...(_Variants) > 1 || __n > __max) {
+                // Use a jump table for the general case.
+                constexpr auto& __vtable =
+                    __detail::__variant::__gen_vtable<_Result_type, _Visitor&&,
+                                                      _Variants&&...>::_S_vtable;
+
+                auto __func_ptr = __vtable._M_access(__variants.index()...);
+                return (*__func_ptr)(std::forward<_Visitor>(__visitor),
+                                     std::forward<_Variants>(__variants)...);
+            } else  // We have a single variant with a small number of alternatives.
+            {
+                // A name for the first variant in the pack.
+                _V0& __v0 = [](_V0& __v, ...) -> _V0& {
+                    return __v;
+                }(__variants...);
+
+                using __detail::__variant::__gen_vtable_impl;
+                using __detail::__variant::_Multi_array;
+                using _Ma = _Multi_array<_Result_type (*)(_Visitor&&, _V0&&)>;
+
+#ifdef _GLIBCXX_DEBUG
+#define _GLIBCXX_VISIT_UNREACHABLE __builtin_trap
+#else
+#define _GLIBCXX_VISIT_UNREACHABLE __builtin_unreachable
+#endif
+
+#define _GLIBCXX_VISIT_CASE(N)                                                \
+    case N: {                                                                 \
+        if constexpr (N < __n) {                                              \
+            return __gen_vtable_impl<_Ma, index_sequence<N>>::__visit_invoke( \
+                std::forward<_Visitor>(__visitor), std::forward<_V0>(__v0));  \
+        } else                                                                \
+            _GLIBCXX_VISIT_UNREACHABLE();                                     \
+    }
+
+                switch (__v0.index()) {
+                    _GLIBCXX_VISIT_CASE(0)
+                    _GLIBCXX_VISIT_CASE(1)
+                    _GLIBCXX_VISIT_CASE(2)
+                    _GLIBCXX_VISIT_CASE(3)
+                    _GLIBCXX_VISIT_CASE(4)
+                    _GLIBCXX_VISIT_CASE(5)
+                    _GLIBCXX_VISIT_CASE(6)
+                    _GLIBCXX_VISIT_CASE(7)
+                    _GLIBCXX_VISIT_CASE(8)
+                    _GLIBCXX_VISIT_CASE(9)
+                    _GLIBCXX_VISIT_CASE(10)
+                    case variant_npos:
+                        using __detail::__variant::__variant_cookie;
+                        using __detail::__variant::__variant_idx_cookie;
+                        if constexpr (is_same_v<_Result_type, __variant_idx_cookie>
+                                      || is_same_v<_Result_type, __variant_cookie>) {
+                            using _Npos = index_sequence<variant_npos>;
+                            return __gen_vtable_impl<_Ma, _Npos>::__visit_invoke(
+                                std::forward<_Visitor>(__visitor), std::forward<_V0>(__v0));
+                        } else
+                            _GLIBCXX_VISIT_UNREACHABLE();
+                    default:
+                        _GLIBCXX_VISIT_UNREACHABLE();
+                }
+#undef _GLIBCXX_VISIT_CASE
+#undef _GLIBCXX_VISIT_UNREACHABLE
+            }
+        }
+    }
+    /// @endcond
+
+    template <typename _Visitor, typename... _Variants>
+    constexpr __detail::__variant::__visit_result_t<_Visitor, _Variants...> visit(
+        _Visitor&& __visitor, _Variants&&... __variants) {
+        namespace __variant = std::__detail::__variant;
+
+        if ((__variant::__as(__variants).valueless_by_exception() || ...))
+            __throw_bad_variant_access("std::visit: variant is valueless");
+
+        using _Result_type = __detail::__variant::__visit_result_t<_Visitor, _Variants...>;
+
+        using _Tag = __detail::__variant::__deduce_visit_result<_Result_type>;
+
+        if constexpr (sizeof...(_Variants) == 1) {
+            using _Vp = decltype(__variant::__as(std::declval<_Variants>()...));
+
+            constexpr bool __visit_rettypes_match =
+                __detail::__variant::__check_visitor_results<_Visitor, _Vp>(
+                    make_index_sequence<variant_size_v<remove_reference_t<_Vp>>>());
+            if constexpr (!__visit_rettypes_match) {
+                static_assert(__visit_rettypes_match,
+                              "std::visit requires the visitor to have the same "
+                              "return type for all alternatives of a variant");
+                return;
+            } else
+                return std::__do_visit<_Tag>(std::forward<_Visitor>(__visitor),
+                                             static_cast<_Vp>(__variants)...);
+        } else
+            return std::__do_visit<_Tag>(std::forward<_Visitor>(__visitor),
+                                         __variant::__as(std::forward<_Variants>(__variants))...);
+    }
+
+#if __cplusplus > 201703L
+    template <typename _Res, typename _Visitor, typename... _Variants>
+    constexpr _Res visit(_Visitor&& __visitor, _Variants&&... __variants) {
+        namespace __variant = std::__detail::__variant;
+
+        if ((__variant::__as(__variants).valueless_by_exception() || ...))
+            __throw_bad_variant_access("std::visit<R>: variant is valueless");
+
+        return std::__do_visit<_Res>(std::forward<_Visitor>(__visitor),
+                                     __variant::__as(std::forward<_Variants>(__variants))...);
+    }
+#endif
+
+    /// @cond undocumented
+    template <bool, typename... _Types>
+    struct __variant_hash_call_base_impl {
+        size_t operator()(const variant<_Types...>& __t) const
+            noexcept((is_nothrow_invocable_v<hash<decay_t<_Types>>, _Types> && ...)) {
+            size_t __ret;
+            __detail::__variant::__raw_visit(
+                [&__t, &__ret](auto&& __t_mem) mutable {
+                    using _Type = __remove_cvref_t<decltype(__t_mem)>;
+                    if constexpr (!is_same_v<_Type, __detail::__variant::__variant_cookie>)
+                        __ret = std::hash<size_t>{}(__t.index()) + std::hash<_Type>{}(__t_mem);
+                    else
+                        __ret = std::hash<size_t>{}(__t.index());
+                },
+                __t);
+            return __ret;
+        }
+    };
+
+    template <typename... _Types>
+    struct __variant_hash_call_base_impl<false, _Types...> {};
+
+    template <typename... _Types>
+    using __variant_hash_call_base = __variant_hash_call_base_impl<
+        (__poison_hash<remove_const_t<_Types>>::__enable_hash_call && ...), _Types...>;
+    /// @endcond
+
+    template <typename... _Types>
+    struct hash<variant<_Types...>>
+        : private __detail::__variant::_Variant_hash_base<variant<_Types...>,
+                                                          std::index_sequence_for<_Types...>>,
+          public __variant_hash_call_base<_Types...> {
+        using result_type [[__deprecated__]]   = size_t;
+        using argument_type [[__deprecated__]] = variant<_Types...>;
+    };
+
+    template <>
+    struct hash<monostate> {
+        using result_type [[__deprecated__]]   = size_t;
+        using argument_type [[__deprecated__]] = monostate;
+
+        size_t operator()(const monostate&) const noexcept {
+            constexpr size_t __magic_monostate_hash = -7777;
+            return __magic_monostate_hash;
+        }
+    };
+
+    template <typename... _Types>
+    struct __is_fast_hash<hash<variant<_Types...>>>
+        : bool_constant<(__is_fast_hash<_Types>::value && ...)> {};
+
+    _GLIBCXX_END_NAMESPACE_VERSION
+}  // namespace std _GLIBCXX_VISIBILITY(default)
+
+#endif  // C++17
+
+#endif  // _GLIBCXX_VARIANT
+#else
+#include <variant>
+#endif

--- a/src/Types/Variant.h
+++ b/src/Types/Variant.h
@@ -1,4 +1,4 @@
-#ifdef USE_ALTERNATE_VARIANT
+#ifdef USE_ALTERNATIVE_VARIANT
 // <variant> -*- C++ -*-
 
 // Copyright (C) 2016-2023 Free Software Foundation, Inc.

--- a/src/Utility/ParameterList.h
+++ b/src/Utility/ParameterList.h
@@ -15,7 +15,8 @@
 #include <map>
 #include <string>
 #include <utility>
-#include <variant>
+
+#include "Types/Variant.h"
 
 #include "Utility/IpplException.h"
 
@@ -160,13 +161,13 @@ namespace ippl {
 
             return os;
         }
-     ParameterList& operator=(const ParameterList& other) {
-        if (this != &other) {
-            // Copy members from 'other' to 'this'
-            params_m = other.params_m;
+        ParameterList& operator=(const ParameterList& other) {
+            if (this != &other) {
+                // Copy members from 'other' to 'this'
+                params_m = other.params_m;
+            }
+            return *this;
         }
-        return *this;
-    }
 
     protected:
         std::map<std::string, variant_t> params_m;

--- a/src/Utility/TypeUtils.h
+++ b/src/Utility/TypeUtils.h
@@ -8,7 +8,7 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <variant>
+#include "Types/Variant.h"
 
 #include "Utility/IpplException.h"
 


### PR DESCRIPTION
Adds an alternative implementation of `std::variant` that works under CUDA 12.2 with GCC 12.3.0. The alternative implementation is activating by configuring `-DUSE_ALTERNATIVE_VARIANT=ON` during CMake setup.

Closes #249, because there's no reason not to.