### PR TITLE
Remove aggr. init. for Apple Clang

### DIFF
--- a/src/Types/Tuple.h
+++ b/src/Types/Tuple.h
@@ -105,6 +105,11 @@ namespace ippl {
         KOKKOS_INLINE_FUNCTION const auto& get() const noexcept {
             return val;
         }
+        TupleImpl<i, N, T>()
+            requires(std::is_default_constructible_v<T>)
+         = default;
+        TupleImpl<i, N, T>(const T& t) : val(t){}
+        TupleImpl<i, N, T>(T&& t) : val(std::forward<T>(t)){}
     };
     /*!
      * @class Tuple


### PR DESCRIPTION
Explicitly add constructors to TupleImpl<i, N, T>
```cpp
        TupleImpl<i, N, T>()
            requires(std::is_default_constructible_v<T>)
         = default;
        TupleImpl<i, N, T>(const T& t) : val(t){}
        TupleImpl<i, N, T>(T&& t) : val(std::forward<T>(t)){}
```
in order not to rely on C++20's aggregate initialization since apple clang [doesn't implement that feature](https://en.cppreference.com/w/cpp/compiler_support/20)
The red cell is Apple Clang's support for this feature.
![image](https://github.com/IPPL-framework/ippl/assets/5041338/642f7b15-a4da-4ff7-bf94-4aec66724236)
