### PR TITLE
Add step method to alpine headers

### DIFF
--- a/alpine/BumponTailInstability.cpp
+++ b/alpine/BumponTailInstability.cpp
@@ -1,8 +1,8 @@
 // Bump on Tail Instability Test Case
 //   Usage:
 //     srun ./BumponTailInstability
-//                  <nx> [<ny>...] <Np> <Nt> <stype>
-//                  <lbthres> --overallocate <ovfactor> --info 10
+//                  <nx> [<ny>...] <Np> <Nt> <stype> <lbthres>
+//                  <t_method> --overallocate <ovfactor> --info 10
 //     nx       = No. cell-centered points in the x-direction
 //     ny...    = No. cell-centered points in the y-, z-, ...-direction
 //     Np       = Total no. of macro-particles in the simulation
@@ -12,14 +12,18 @@
 //                percentage which can be tolerated and beyond which
 //                particle load balancing occurs. A value of 0.01 is good for many typical
 //                simulations.
+//     t_method = Time-stepping method used e.g. Leapfrog
 //     ovfactor = Over-allocation factor for the buffers used in the communication. Typical
 //                values are 1.0, 2.0. Value 1.0 means no over-allocation.
 //     Example:
-//     srun ./BumponTailInstability 128 128 128 10000 10 FFT 0.01 LeapFrog --overallocate 2.0 --info 10
+//     srun ./BumponTailInstability 128 128 128 10000 10 FFT 0.01 LeapFrog --overallocate 2.0 --info
+//     10
 
 constexpr unsigned Dim = 3;
-using T = double;
-const char* TestName = "BumponTailInstability";
+using T                = double;
+const char* TestName   = "BumponTailInstability";
+
+#include "Ippl.h"
 
 #include <Kokkos_MathematicalConstants.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
@@ -31,11 +35,12 @@ const char* TestName = "BumponTailInstability";
 #include <string>
 #include <vector>
 
-#include "Ippl.h"
-#include "Utility/IpplTimings.h"
-#include "Manager/PicManager.h"
 #include "datatypes.h"
+
+#include "Utility/IpplTimings.h"
+
 #include "BumponTailInstabilityManager.h"
+#include "Manager/PicManager.h"
 
 int main(int argc, char* argv[]) {
     ippl::initialize(argc, argv);
@@ -53,10 +58,10 @@ int main(int argc, char* argv[]) {
             nr[d] = std::atoi(argv[arg++]);
         }
 
-        size_type totalP = std::atoll(argv[arg++]);
-        int nt  = std::atoi(argv[arg++]);
-        std::string solver = argv[arg++];
-        double lbt = std::atof(argv[arg++]);
+        size_type totalP        = std::atoll(argv[arg++]);
+        int nt                  = std::atoi(argv[arg++]);
+        std::string solver      = argv[arg++];
+        double lbt              = std::atof(argv[arg++]);
         std::string step_method = argv[arg++];
 
         // Create an instance of a manger for the considered application

--- a/alpine/LandauDamping.cpp
+++ b/alpine/LandauDamping.cpp
@@ -1,8 +1,8 @@
 // Landau Damping Test
 //   Usage:
 //     srun ./LandauDamping
-//                  <nx> [<ny>...] <Np> <Nt> <stype>
-//                  <lbthres> --overallocate <ovfactor> --info 10
+//                  <nx> [<ny>...] <Np> <Nt> <stype> <lbthres>
+//                  <t_method> --overallocate <ovfactor> --info 10
 //     nx       = No. cell-centered points in the x-direction
 //     ny...    = No. cell-centered points in the y-, z-, ...-direction
 //     Np       = Total no. of macro-particles in the simulation
@@ -12,14 +12,17 @@
 //                percentage which can be tolerated and beyond which
 //                particle load balancing occurs. A value of 0.01 is good for many typical
 //                simulations.
+//     t_method = Time-stepping method used e.g. Leapfrog
 //     ovfactor = Over-allocation factor for the buffers used in the communication. Typical
 //                values are 1.0, 2.0. Value 1.0 means no over-allocation.
 //     Example:
 //     srun ./LandauDamping 128 128 128 10000 10 FFT 0.01 LeapFrog --overallocate 2.0 --info 10
 
 constexpr unsigned Dim = 3;
-using T = double;
-const char* TestName = "LandauDamping";
+using T                = double;
+const char* TestName   = "LandauDamping";
+
+#include "Ippl.h"
 
 #include <Kokkos_MathematicalConstants.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
@@ -31,11 +34,12 @@ const char* TestName = "LandauDamping";
 #include <string>
 #include <vector>
 
-#include "Ippl.h"
-#include "Utility/IpplTimings.h"
-#include "Manager/PicManager.h"
 #include "datatypes.h"
+
+#include "Utility/IpplTimings.h"
+
 #include "LandauDampingManager.h"
+#include "Manager/PicManager.h"
 
 int main(int argc, char* argv[]) {
     ippl::initialize(argc, argv);
@@ -53,11 +57,11 @@ int main(int argc, char* argv[]) {
             nr[d] = std::atoi(argv[arg++]);
         }
 
-        size_type totalP = std::atoll(argv[arg++]);
-        int nt  = std::atoi(argv[arg++]);
+        size_type totalP   = std::atoll(argv[arg++]);
+        int nt             = std::atoi(argv[arg++]);
         std::string solver = argv[arg++];
 
-        double lbt = std::atof(argv[arg++]);
+        double lbt              = std::atof(argv[arg++]);
         std::string step_method = argv[arg++];
 
         // Create an instance of a manger for the considered application

--- a/alpine/PenningTrap.cpp
+++ b/alpine/PenningTrap.cpp
@@ -1,8 +1,8 @@
 // Penning Trap
 //   Usage:
 //     srun ./PenningTrap
-//                  <nx> [<ny>...] <Np> <Nt> <stype>
-//                  <lbthres> --overallocate <ovfactor> --info 10
+//                  <nx> [<ny>...] <Np> <Nt> <stype> <lbthres>
+//                  <t_method> --overallocate <ovfactor> --info 10
 //     nx       = No. cell-centered points in the x-direction
 //     ny       = No. cell-centered points in the y-direction
 //     nz       = No. cell-centered points in the z-direction
@@ -13,14 +13,17 @@
 //                percentage which can be tolerated and beyond which
 //                particle load balancing occurs. A value of 0.01 is good for many typical
 //                simulations.
+//     t_method = Time-stepping method used e.g. Leapfrog
 //     ovfactor = Over-allocation factor for the buffers used in the communication. Typical
 //                values are 1.0, 2.0. Value 1.0 means no over-allocation.
 //     Example:
 //     srun ./PenningTrap 128 128 128 10000 300 FFT 0.01 LeapFrog --overallocate 1.0 --info 10
 
 constexpr unsigned Dim = 3;
-using T = double;
-const char* TestName = "PenningTrap";
+using T                = double;
+const char* TestName   = "PenningTrap";
+
+#include "Ippl.h"
 
 #include <Kokkos_MathematicalConstants.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
@@ -32,10 +35,11 @@ const char* TestName = "PenningTrap";
 #include <string>
 #include <vector>
 
-#include "Ippl.h"
-#include "Utility/IpplTimings.h"
-#include "Manager/PicManager.h"
 #include "datatypes.h"
+
+#include "Utility/IpplTimings.h"
+
+#include "Manager/PicManager.h"
 #include "PenningTrapManager.h"
 
 int main(int argc, char* argv[]) {
@@ -54,10 +58,10 @@ int main(int argc, char* argv[]) {
         for (unsigned d = 0; d < Dim; d++) {
             nr[d] = std::atoi(argv[arg++]);
         }
-        size_type totalP = std::atoll(argv[arg++]);
-        int nt  = std::atoi(argv[arg++]);
-        std::string solver = argv[arg++];
-        double lbt = std::atof(argv[arg++]);
+        size_type totalP        = std::atoll(argv[arg++]);
+        int nt                  = std::atoi(argv[arg++]);
+        std::string solver      = argv[arg++];
+        double lbt              = std::atof(argv[arg++]);
         std::string step_method = argv[arg++];
 
         // Create an instance of a manger for the considered application


### PR DESCRIPTION
In the Alpine tests there is the step_method missing from the argument list in the headers.