### PR TITLE
Changing Template variable in PicManager

### DIFF
--- a/alpine/AlpineManager.h
+++ b/alpine/AlpineManager.h
@@ -8,6 +8,7 @@
 #include "LoadBalancer.hpp"
 #include "Manager/BaseManager.h"
 #include "Manager/PicManager.h"
+#include "Manager/FieldSolverBase.h"
 #include "ParticleContainer.hpp"
 #include "Random/Distribution.h"
 #include "Random/InverseTransformSampling.h"
@@ -19,7 +20,7 @@ using view_type = typename ippl::detail::ViewType<ippl::Vector<double, Dim>, 1>:
 template <typename T, unsigned Dim>
 class AlpineManager
     : public ippl::PicManager<T, Dim, ParticleContainer<T, Dim>, FieldContainer<T, Dim>,
-                              LoadBalancer<T, Dim>> {
+                              LoadBalancer<T, Dim>, ippl::FieldSolverBase<T, Dim>> {
 public:
     using ParticleContainer_t = ParticleContainer<T, Dim>;
     using FieldContainer_t = FieldContainer<T, Dim>;
@@ -35,7 +36,7 @@ protected:
     std::string stepMethod_m;
 public:
     AlpineManager(size_type totalP_, int nt_, Vector_t<int, Dim>& nr_, double lbt_, std::string& solver_, std::string& stepMethod_)
-        : ippl::PicManager<T, Dim, ParticleContainer<T, Dim>, FieldContainer<T, Dim>, LoadBalancer<T, Dim>>()
+        : ippl::PicManager<T, Dim, ParticleContainer<T, Dim>, FieldContainer<T, Dim>, LoadBalancer<T, Dim>, ippl::FieldSolverBase<T, Dim>>()
         , totalP_m(totalP_)
         , nt_m(nt_)
         , nr_m(nr_)

--- a/src/Manager/PicManager.h
+++ b/src/Manager/PicManager.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include "Manager/BaseManager.h"
 #include "Decomposition/OrthogonalRecursiveBisection.h"
-#include "Manager/FieldSolverBase.h"
 
  namespace ippl {
 
@@ -21,8 +20,9 @@
     * @tparam pc The particle container type.
     * @tparam fc The field container type.
     * @tparam orb The load balancer type.
+    * @tparam fs The field solver type.
     */
-    template <typename T, unsigned Dim, class pc, class fc, class orb>
+    template <typename T, unsigned Dim, class pc, class fc, class orb, class fs>
     class PicManager : public BaseManager {
     public:
         PicManager()
@@ -60,11 +60,11 @@
             fcontainer_m = fcontainer;
         }
 
-        std::shared_ptr<ippl::FieldSolverBase<T, Dim>> getFieldSolver() {
+        std::shared_ptr<fs> getFieldSolver() {
             return fsolver_m;
         }
 
-        void setFieldSolver(std::shared_ptr<ippl::FieldSolverBase<T, Dim>> fsolver) {
+        void setFieldSolver(std::shared_ptr<fs> fsolver) {
             fsolver_m = fsolver;
         }
 
@@ -83,7 +83,7 @@
 
         std::shared_ptr<orb> loadbalancer_m;
 
-        std::shared_ptr<ippl::FieldSolverBase<T, Dim>> fsolver_m;
+        std::shared_ptr<fs> fsolver_m;
 
     };
 }  // namespace ippl


### PR DESCRIPTION
I changed the template variable of the field solver class to be more generic. One needs this to for example run multiple solvers in one step. I don't see a reason why this is not generic, I also updated the alpine manager and the simulations ran without problem.