### PR TITLE
Increase time out in unit tests to be able to build

### DIFF
--- a/unit_tests/BareField/CMakeLists.txt
+++ b/unit_tests/BareField/CMakeLists.txt
@@ -12,7 +12,7 @@ link_directories (
 )
 
 add_executable (BareField BareField.cpp)
-gtest_discover_tests (BareField)
+gtest_discover_tests (BareField PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     BareField

--- a/unit_tests/FFT/CMakeLists.txt
+++ b/unit_tests/FFT/CMakeLists.txt
@@ -12,7 +12,7 @@ link_directories (
 )
 
 add_executable (FFT FFT.cpp)
-gtest_discover_tests(FFT)
+gtest_discover_tests(FFT PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     FFT

--- a/unit_tests/Field/CMakeLists.txt
+++ b/unit_tests/Field/CMakeLists.txt
@@ -12,7 +12,7 @@ link_directories (
 )
 
 add_executable (Field Field.cpp)
-gtest_discover_tests(Field)
+gtest_discover_tests(Field PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     Field
@@ -23,7 +23,7 @@ target_link_libraries (
 )
 
 add_executable (FieldBC FieldBC.cpp)
-gtest_discover_tests(FieldBC)
+gtest_discover_tests(FieldBC PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     FieldBC
@@ -34,7 +34,7 @@ target_link_libraries (
 )
 
 add_executable (Halo Halo.cpp)
-gtest_discover_tests(Halo)
+gtest_discover_tests(Halo PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     Halo

--- a/unit_tests/Meshes/CMakeLists.txt
+++ b/unit_tests/Meshes/CMakeLists.txt
@@ -12,7 +12,7 @@ link_directories (
 )
 
 add_executable (UniformCartesian UniformCartesian.cpp)
-gtest_discover_tests (UniformCartesian)
+gtest_discover_tests (UniformCartesian PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     UniformCartesian

--- a/unit_tests/PIC/CMakeLists.txt
+++ b/unit_tests/PIC/CMakeLists.txt
@@ -12,7 +12,7 @@ link_directories (
 )
 
 add_executable (PIC PIC.cpp)
-gtest_discover_tests(PIC)
+gtest_discover_tests(PIC PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     PIC
@@ -22,7 +22,7 @@ target_link_libraries (
 )
 
 add_executable (ORB ORB.cpp)
-gtest_discover_tests(ORB)
+gtest_discover_tests(ORB PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     ORB

--- a/unit_tests/Particle/CMakeLists.txt
+++ b/unit_tests/Particle/CMakeLists.txt
@@ -12,7 +12,7 @@ link_directories (
 )
 
 add_executable (ParticleBase ParticleBase.cpp)
-gtest_discover_tests(ParticleBase)
+gtest_discover_tests(ParticleBase PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     ParticleBase
@@ -22,7 +22,7 @@ target_link_libraries (
 )
 
 add_executable (ParticleBC ParticleBC.cpp)
-gtest_discover_tests(ParticleBC)
+gtest_discover_tests(ParticleBC PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     ParticleBC
@@ -32,7 +32,7 @@ target_link_libraries (
 )
 
 add_executable (ParticleSendRecv ParticleSendRecv.cpp)
-gtest_discover_tests(ParticleSendRecv)
+gtest_discover_tests(ParticleSendRecv PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     ParticleSendRecv

--- a/unit_tests/Utility/CMakeLists.txt
+++ b/unit_tests/Utility/CMakeLists.txt
@@ -11,7 +11,7 @@ link_directories (
 )
 
 add_executable (ParameterList ParameterList.cpp)
-gtest_discover_tests (ParameterList)
+gtest_discover_tests (ParameterList PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
 
 target_link_libraries (
     ParameterList


### PR DESCRIPTION
The unit tests do not build because they time out. I added an option in the CMakeLists.txt of the unit tests to increase the time out. Now they compile for openmp using the new purely cmake build, but not for cuda (there are some issues with Kokkos).