### PR TITLE
Add warmup to FFT periodic solver and P3M

### DIFF
--- a/src/PoissonSolvers/FFTPeriodicPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTPeriodicPoissonSolver.hpp
@@ -46,6 +46,7 @@ namespace ippl {
         }
 
         fft_mp = std::make_shared<FFT_t>(layout_r, *layoutComplex_mp, this->params_m);
+        fft_mp->warmup(*this->rhs_mp, fieldComplex_m); // warmup the FFT object
     }
 
     template <typename FieldLHS, typename FieldRHS>

--- a/src/PoissonSolvers/P3MSolver.hpp
+++ b/src/PoissonSolvers/P3MSolver.hpp
@@ -114,6 +114,7 @@ namespace ippl {
 
         // create the FFT object
         fft_m = std::make_unique<FFT_t>(*layout_mp, *layoutComplex_m, this->params_m);
+        fft_m->warmup(grn_m, grntr_m); // warmup the FFT object
 
         // these are fields that are used for calculating the Green's function
         for (unsigned int d = 0; d < Dim; ++d) {


### PR DESCRIPTION
The FFT warmup step in the FFTPeriodicPoissonSolver and the P3MSolver was missing from the initialization, causing the first call to FFT in the solve() step to take long (as no empty FFT was done to warmup the FFT object). I added this in the initialization.