### PR TITLE
Fix bug with using CG in alpine

### DIFF
--- a/src/PoissonSolvers/PoissonCG.h
+++ b/src/PoissonSolvers/PoissonCG.h
@@ -148,6 +148,7 @@ namespace ippl {
         void setDefaultParameters() override {
             this->params_m.add("max_iterations", 2000);
             this->params_m.add("tolerance", (Tlhs)1e-13);
+            this->params_m.add("solver", "non-preconditioned");
         }
     };
 


### PR DESCRIPTION
The CG solver cannot be used currently in Alpine as a possible solver choice due to an error in the parameter list. 
The problem was in there being a parameter trying to be accessed ("solver") to know whether the CG solver is preconditioned or not. 
The solution is to add a default "solver" parameter as "non-preconditioned" in the setDefaulyParameters() of the CG solver.