### PR TITLE
Add Custom+Partial Iteration for Particle Scatter and Gather Operations

### DIFF
--- a/src/Particle/ParticleAttrib.h
+++ b/src/Particle/ParticleAttrib.h
@@ -119,12 +119,14 @@ namespace ippl {
 
         //     // scatter the data from this attribute onto the given Field, using
         //     // the given Position attribute
-        template <typename Field, typename P2>
+        template <typename Field, typename P2, typename policy_type>
         void scatter(Field& f,
-                     const ParticleAttrib<Vector<P2, Field::dim>, Properties...>& pp) const;
+                     const ParticleAttrib<Vector<P2, Field::dim>, Properties...>& pp,
+                     policy_type iteration_policy, hash_type hash_array = {}) const;
 
         template <typename Field, typename P2>
-        void gather(Field& f, const ParticleAttrib<Vector<P2, Field::dim>, Properties...>& pp);
+        void gather(Field& f, const ParticleAttrib<Vector<P2, Field::dim>, Properties...>& pp, 
+                    const bool addToAttribute = false);
 
         T sum();
         T max();

--- a/src/Particle/ParticleAttrib.h
+++ b/src/Particle/ParticleAttrib.h
@@ -117,13 +117,55 @@ namespace ippl {
         // KOKKOS_INLINE_FUNCTION
         ParticleAttrib<T, Properties...>& operator=(detail::Expression<E, N> const& expr);
 
-        //     // scatter the data from this attribute onto the given Field, using
-        //     // the given Position attribute
+        /**
+         * @brief Scatter particle attribute data onto a field.
+         *
+         * This function scatters data from this attribute onto the given field,
+         * using the given position attribute.
+         * The function can be used together with a custom iteration policy to iterate
+         * over a specified range and, optionally, an `ippl::hash_type` array to remap 
+         * iteration indices.
+         *
+         * When a non-empty `hash_array` is provided, the function:
+         *  - Checks that the iteration policy's range does not exceed the size of `hash_array`.
+         *  - Maps the current index to the appropriate index using the `hash_array`.
+         *  - Careful: access pattern optimization might be lost when using `hash_array`.
+         *
+         * @note This custom iteration functionality is needed to support energy binning 
+         * in the field solver of OPAL-X, allowing only particles within a specific bin
+         * to be scattered.
+         *
+         * @tparam Field The type of the field.
+         * @tparam P2 The type for the position attribute.
+         * @tparam policy_type The type of the Kokkos iteration policy when using `hash_array`.
+         * @param f The field onto which the particle data is scattered.
+         * @param pp The ParticleAttrib representing particle positions.
+         * @param iteration_policy A custom `Kokkos::range_policy` defining the iteration range.
+         * @param hash_array An optional `ippl::hash_type` array for index mapping. If empty, no map is used.
+         */
         template <typename Field, typename P2, typename policy_type>
         void scatter(Field& f,
                      const ParticleAttrib<Vector<P2, Field::dim>, Properties...>& pp,
                      policy_type iteration_policy, hash_type hash_array = {}) const;
 
+        /**
+         * @brief Gather field data into the particle attribute.
+         *
+         * This function gathers data from the given field into the particle attribute
+         * by iterating over all particles. Depending on the parameter @p addToAttribute,
+         * the gathered field value is either added to the existing attribute value (using "+=")
+         * or used to overwrite the attribute value.
+         *
+         * @note This behavior exists to give the OPAL-X field solver the ablity to gather field data
+         * per "energy bin".
+         *
+         * @tparam Field The type of the field.
+         * @tparam P2 The particle type for the position attribute.
+         * @param f The field from which data is gathered.
+         * @param pp The ParticleAttrib representing particle positions.
+         * @param addToAttribute If `true`, the gathered value is added to the current attribute value;
+         *                       otherwise, the attribute value is overwritten.
+         */
         template <typename Field, typename P2>
         void gather(Field& f, const ParticleAttrib<Vector<P2, Field::dim>, Properties...>& pp, 
                     const bool addToAttribute = false);

--- a/test/particle/CMakeLists.txt
+++ b/test/particle/CMakeLists.txt
@@ -25,6 +25,9 @@ target_link_libraries (PICnd ${IPPL_LIBS})
 add_executable (benchmarkParticleUpdate benchmarkParticleUpdate.cpp)
 target_link_libraries (benchmarkParticleUpdate ${IPPL_LIBS})
 
+add_executable (TestHashedScatter TestHashedScatter.cpp)
+target_link_libraries (TestHashedScatter ${IPPL_LIBS})
+
 # vi: set et ts=4 sw=4 sts=4:
 
 # Local Variables:

--- a/test/particle/TestGather.cpp
+++ b/test/particle/TestGather.cpp
@@ -23,6 +23,8 @@ int main(int argc, char* argv[]) {
         using Mesh_t      = ippl::UniformCartesian<double, 3>;
         using Centering_t = Mesh_t::DefaultCentering;
 
+        Inform msg("TestGather");
+
         int pt = 512;
         ippl::Index I(pt);
         ippl::NDIndex<3> owned(I, I, I);
@@ -68,8 +70,18 @@ int main(int argc, char* argv[]) {
 
         field = 1.0;
 
+        msg << "Testing addToAttribute=false. Expected output: 1" << endl;
         gather(bunch.Q, field, bunch.R);
+        
+        // Should printout 1.0 for each particle
+        bunch.Q.print();
 
+        ippl::Comm->barrier(); // so output of 1 and 2 is separated
+
+        msg << "Testing addToAttribute=true. Expected output: 2" << endl;
+        gather(bunch.Q, field, bunch.R, true);
+
+        // Should printout 2.0 for each particle
         bunch.Q.print();
     }
     ippl::finalize();

--- a/test/particle/TestHashedScatter.cpp
+++ b/test/particle/TestHashedScatter.cpp
@@ -1,0 +1,178 @@
+#include "Ippl.h"
+
+#include <random>
+
+template <class PLayout>
+struct Bunch : public ippl::ParticleBase<PLayout> {
+    Bunch(PLayout& playout)
+        : ippl::ParticleBase<PLayout>(playout) {
+        this->addAttribute(Q);
+    }
+
+    ~Bunch() {}
+
+    typedef ippl::ParticleAttrib<double> charge_container_type;
+    charge_container_type Q;
+};
+
+int main(int argc, char* argv[]) {
+    ippl::initialize(argc, argv);
+    {
+        typedef ippl::ParticleSpatialLayout<double, 3> playout_type;
+        typedef Bunch<playout_type> bunch_type;
+        using Mesh_t      = ippl::UniformCartesian<double, 3>;
+        using Centering_t = Mesh_t::DefaultCentering;
+
+        int pt = 512;
+        ippl::Index I(pt);
+        ippl::NDIndex<3> owned(I, I, I);
+
+        std::array<bool, 3> isParallel;
+        isParallel.fill(true);
+
+        // all parallel layout, standard domain, normal axis order
+        ippl::FieldLayout<3> layout(MPI_COMM_WORLD, owned, isParallel);
+
+        double dx                      = 1.0 / double(pt);
+        ippl::Vector<double, 3> hx     = {dx, dx, dx};
+        ippl::Vector<double, 3> origin = {0, 0, 0};
+        Mesh_t mesh(owned, hx, origin);
+
+        playout_type pl(layout, mesh);
+
+        bunch_type bunch(pl);
+        typedef ippl::Field<double, 3, Mesh_t, Centering_t> field_type;
+
+        field_type field;
+
+        field.initialize(mesh, layout);
+
+        bunch.setParticleBC(ippl::BC::PERIODIC);
+
+        int nRanks              = ippl::Comm->size();
+        unsigned int nParticles = std::pow(256, 3);
+
+        if (nParticles % nRanks > 0) {
+            if (ippl::Comm->rank() == 0) {
+                std::cerr << nParticles << " not a multiple of " << nRanks << std::endl;
+            }
+            return 0;
+        }
+
+        unsigned int nLoc = nParticles / nRanks;
+
+        bunch.create(nLoc);
+
+        std::mt19937_64 eng;
+        eng.seed(42);
+        eng.discard(nLoc * ippl::Comm->rank());
+        std::uniform_real_distribution<double> unif(hx[0] / 2, 1 - (hx[0] / 2));
+
+        typename bunch_type::particle_position_type::HostMirror R_host = bunch.R.getHostMirror();
+        double sum_coord                                               = 0.0;
+        for (unsigned int i = 0; i < nLoc; ++i) {
+            ippl::Vector<double, 3> r = {unif(eng), unif(eng), unif(eng)};
+            R_host(i)                 = r;
+            sum_coord += r[0] + r[1] + r[2];
+        }
+        Kokkos::deep_copy(bunch.R.getView(), R_host);
+
+        double global_sum_coord = 0.0;
+        ippl::Comm->reduce(sum_coord, global_sum_coord, 1, std::plus<double>());
+
+        if (ippl::Comm->rank() == 0) {
+            std::cout << "Sum coord: " << global_sum_coord << std::endl;
+        }
+
+        Inform msg("TestHashedScatter");
+        Inform msg2All("TestHashedScatter", INFORM_ALL_NODES);
+
+        /*
+        First test for custom range policy: Only scatter pt/2 particles and compare to the 
+        total sum of the field.
+        For this test, charges need to be all the same. 
+        */
+        {
+            bunch.Q = 1.0;
+            bunch.update();
+            field = 0.0;
+            int NScatterred = nLoc / 2 + ippl::Comm->rank();
+            
+            double Q_total = 1.0 * NScatterred;
+            ippl::Comm->allreduce(Q_total, 1, std::plus<double>());
+            
+            Kokkos::RangePolicy<> policy(0, NScatterred);
+            scatter(bunch.Q, field, bunch.R, policy);
+
+            msg << "---- Testing scatter with custom range policy ----" << endl;
+            ippl::Comm->barrier();
+
+            double Total_charge_field = field.sum();
+
+            msg2All << "Total charge in the field:     " << Total_charge_field << endl;
+            msg2All << "Total charge of the particles: " << Q_total << endl;
+            msg2All << "Error:                         --> " << std::fabs(Q_total - Total_charge_field) << endl;
+        }
+        ippl::Comm->barrier();
+        
+        
+        /*
+        Second test for custom hash_type: Assign random charges, create an index array, shuffle it 
+        and scatter the first half of the particles. Then compute the total charge in a loop and compare
+        it to the sum from the field. 
+         */
+        using hash_type = typename bunch_type::charge_container_type::hash_type;
+        {
+            // Sample random charges uniformly (use the same eng from before)
+            std::uniform_real_distribution<double> unif_charge(0.5, 1.5);
+            typename bunch_type::charge_container_type::HostMirror Q_host = bunch.Q.getHostMirror();
+            for (unsigned int i = 0; i < nLoc; ++i) { Q_host(i) = unif_charge(eng); }
+            Kokkos::deep_copy(bunch.Q.getView(), Q_host);
+            
+            bunch.update();
+            
+            // Reset the field
+            int NScatterred = nLoc / 2 + ippl::Comm->rank();
+            field = 0.0;
+
+            // Create index array using hash_type
+            std::vector<int> host_indices(nLoc);
+            std::iota(host_indices.begin(), host_indices.end(), 0);
+            std::shuffle(host_indices.begin(), host_indices.end(), eng);
+
+            hash_type hash("indexArray", nLoc);
+            auto hash_host = Kokkos::create_mirror_view(hash);                          // Create a host mirror of the hash array
+            for (unsigned int i = 0; i < nLoc; ++i) { hash_host(i) = host_indices[i]; } // Fill the host mirror with the shuffled index array
+            Kokkos::deep_copy(hash, hash_host);                                         // Copy the shuffled host mirror back to the device 
+
+            // The custom range policy
+            Kokkos::RangePolicy<> policy(0, NScatterred);
+
+            // Compute total scattered charge manually
+            double Q_total = 0.0;
+            auto viewQ = bunch.Q.getView();
+            Kokkos::parallel_reduce("computeTotalCharge", policy, KOKKOS_LAMBDA(const size_t i, double& val) {
+                val += viewQ(hash(i));
+            }, Kokkos::Sum<double>(Q_total));
+            ippl::Comm->allreduce(Q_total, 1, std::plus<double>());
+            
+            std::cout << "Q_total: " << Q_total << std::endl;
+            std::cout << hash.extent(0) << std::endl;
+
+            // Perform the scatter over the custom hash_type
+            scatter(bunch.Q, field, bunch.R, policy, hash);
+
+            msg << "---- Testing scatter with custom range policy and hash_type ----" << endl;
+
+            double Total_charge_field = field.sum();
+
+            msg2All << "Total charge in the field:     " << Total_charge_field << endl;
+            msg2All << "Total charge of the particles: " << Q_total << endl;
+            msg2All << "Error:                         --> " << std::fabs(Q_total - Total_charge_field) << endl;
+        }
+
+    }
+    ippl::finalize();
+
+    return 0;
+}

--- a/unit_tests/Particle/CMakeLists.txt
+++ b/unit_tests/Particle/CMakeLists.txt
@@ -41,6 +41,16 @@ target_link_libraries (
     ${MPI_CXX_LIBRARIES}
 )
 
+add_executable (GatherScatterTest GatherScatterTest.cpp)
+gtest_discover_tests(GatherScatterTest PROPERTIES TEST_DISCOVERY_TIMEOUT 600)
+
+target_link_libraries (
+    GatherScatterTest
+    ippl
+    GTest::gtest_main
+    ${MPI_CXX_LIBRARIES}
+)
+
 # vi: set et ts=4 sw=4 sts=4:
 
 # Local Variables:

--- a/unit_tests/Particle/GatherScatterTest.cpp
+++ b/unit_tests/Particle/GatherScatterTest.cpp
@@ -1,0 +1,331 @@
+//
+// Unit tests for gather/scatter functionality (multi-rank compatible)
+//   Tests gather with addToAttribute = false and true,
+//   scatter with a custom range policy,
+//   and scatter with a custom hash_type.
+//
+// These tests extend the functionality tests from the original
+// TestHashedScatter.cpp and TestGather.cpp examples.
+//
+
+#include "Ippl.h"
+#include "TestUtils.h"
+#include "gtest/gtest.h"
+
+#include <random>
+#include <vector>
+#include <numeric>
+#include <algorithm>
+#include <iostream>
+
+// A simple bunch_type holding a charge attribute 
+template <class PLayout>
+struct Bunch : public ippl::ParticleBase<PLayout> {
+    Bunch(PLayout& playout)
+        : ippl::ParticleBase<PLayout>(playout) {
+        this->addAttribute(Q);
+    }
+    ~Bunch() {}
+
+    typedef ippl::ParticleAttrib<double> charge_container_type;
+    charge_container_type Q;
+};
+
+template <typename>
+class GatherScatterTest;
+
+template <typename T, typename ExecSpace, unsigned Dim>
+class GatherScatterTest<Parameters<T, ExecSpace, Rank<Dim>>> : public ::testing::Test {
+public:
+    using scalar_type    = T;
+    using exec_space     = ExecSpace;
+    static const unsigned dim = Dim;
+    using flayout_type   = ippl::FieldLayout<Dim>;
+    using mesh_type      = ippl::UniformCartesian<T, Dim>;
+    using playout_type   = ippl::ParticleSpatialLayout<T, Dim>;
+    using bunch_type     = Bunch<playout_type>;
+
+    // Domain parameters: use a high resolution grid so that cells are small.
+    std::array<size_t, Dim> nPoints;
+    std::array<T, Dim> domain;
+    flayout_type layout;
+    mesh_type mesh;
+    playout_type playout;
+    std::shared_ptr<bunch_type> bunch;
+
+    // Particle counts for the tests.
+    size_t nGather = 10;              // for gather test: local particles per rank
+    size_t nScatter = static_cast<unsigned int>(std::pow(64, Dim));  // for scatter tests
+
+    // Store cell sizes (hx) for use in generating positions.
+    T hx[Dim];
+
+    GatherScatterTest() { }
+
+    void SetUp() override {
+        // Use a high-resolution grid (e.g. 512 cells per dimension)
+        size_t gridPoints = 128;
+        for (size_t d = 0; d < Dim; d++) {
+            nPoints[d] = gridPoints;
+            domain[d]  = 1.0;
+        }
+        std::array<ippl::Index, Dim> owned;
+        for (size_t d = 0; d < Dim; d++) {
+            owned[d] = ippl::Index(nPoints[d]);
+        }
+        std::array<bool, Dim> isParallel;
+        isParallel.fill(true);
+        auto owned_tu = std::make_from_tuple<ippl::NDIndex<Dim>>(owned);
+        layout = flayout_type(MPI_COMM_WORLD, owned_tu, isParallel);
+
+        ippl::Vector<T, Dim> hx_vec;
+        ippl::Vector<T, Dim> origin;
+        for (size_t d = 0; d < Dim; d++) {
+            hx_vec[d] = domain[d] / nPoints[d];
+            hx[d] = hx_vec[d]; // store cell size for distribution
+            origin[d] = 0;
+        }
+        mesh    = mesh_type(owned_tu, hx_vec, origin);
+        playout = playout_type(layout, mesh);
+        bunch   = std::make_shared<bunch_type>(playout);
+
+        // Set periodic boundary conditions.
+        bunch->setParticleBC(ippl::BC::PERIODIC);
+    }
+
+    // Fill particle positions with random numbers in [hx/2, 1-hx/2] to ensure interior points.
+    void fillRandomPositions(size_t nParticles) {
+        bunch->create(nParticles);
+        std::mt19937_64 eng(ippl::Comm->rank());
+        std::uniform_real_distribution<T> unif(hx[0] / 2, 1 - (hx[0] / 2));
+        auto R_host = bunch->R.getHostMirror();
+        for (size_t i = 0; i < nParticles; ++i) {
+            ippl::Vector<T, Dim> r;
+            for (size_t d = 0; d < Dim; d++) {
+                r[d] = unif(eng);
+            }
+            R_host(i) = r;
+        }
+        Kokkos::deep_copy(bunch->R.getView(), R_host);
+        ippl::Comm->barrier();
+        Kokkos::fence();
+        bunch->update();
+    }
+
+    // Fill the Q attribute with a constant value using host mirror and deep copy.
+    void fillAttributeQ(T value) {
+        auto Q_host = bunch->Q.getHostMirror();
+        for (size_t i = 0; i < Q_host.size(); ++i) {
+            Q_host(i) = value;
+        }
+        Kokkos::deep_copy(bunch->Q.getView(), Q_host);
+        ippl::Comm->barrier();
+    }
+};
+
+using TestTypes = ::testing::Types<
+    Parameters<double, Kokkos::DefaultExecutionSpace, Rank<1>>,
+    Parameters<double, Kokkos::DefaultExecutionSpace, Rank<2>>,
+    Parameters<double, Kokkos::DefaultExecutionSpace, Rank<3>>//,
+    //Parameters<double, Kokkos::DefaultExecutionSpace, Rank<4>>,
+    //Parameters<double, Kokkos::DefaultExecutionSpace, Rank<5>>,
+    //Parameters<double, Kokkos::DefaultExecutionSpace, Rank<6>>
+>;
+TYPED_TEST_CASE(GatherScatterTest, TestTypes);
+
+//
+// GatherTest: 
+// First, set each local Q to 10.0.
+// Then, call gather with addToAttribute = false so that Q becomes 1.0 (should replace value with 1.0).
+// If Q != 0, then the values were 1. not replaced and 2. not correctly gathered from the field.
+// Note: for a constant field, there should not be an error during linear interpolation.
+//
+TYPED_TEST(GatherScatterTest, GatherTestReplace) {
+    const size_t n = this->nGather;
+    this->fillRandomPositions(n);
+    this->fillAttributeQ(10.0);
+
+    using Mesh_t   = typename TestFixture::mesh_type;
+    using FieldType = ippl::Field<typename TestFixture::scalar_type, TestFixture::dim, Mesh_t, typename Mesh_t::DefaultCentering>;
+    FieldType field;
+    field.initialize(this->mesh, this->layout);
+    field = 1.0;
+
+    // First gather call (no accumulation, replace attributes)
+    gather(this->bunch->Q, field, this->bunch->R);
+
+    // Check all charges
+    auto Q_host = this->bunch->Q.getHostMirror();
+    Kokkos::deep_copy(Q_host, this->bunch->Q.getView());
+    for (size_t i = 0; i < this->bunch->getLocalNum(); ++i) {
+        ASSERT_NEAR(Q_host(i), 1.0, 1e-6);
+    }
+}
+
+//
+// GatherTest: 
+// First, set each local Q to 1.0.
+// Then, call gather with addToAttribute = true so that Q becomes 2.0 (should add 1.0 per particle).
+//
+TYPED_TEST(GatherScatterTest, GatherTestIncrement) {
+    const size_t n = this->nGather;
+    this->fillRandomPositions(n);
+    this->fillAttributeQ(1.0);
+
+    using Mesh_t   = typename TestFixture::mesh_type;
+    using FieldType = ippl::Field<typename TestFixture::scalar_type, TestFixture::dim, Mesh_t, typename Mesh_t::DefaultCentering>;
+    FieldType field;
+    field.initialize(this->mesh, this->layout);
+    field = 1.0;
+
+    // Second gather call with addToAttribute=true should add another 1.0.
+    gather(this->bunch->Q, field, this->bunch->R, true);
+
+    // Check all charges
+    auto Q_host = this->bunch->Q.getHostMirror();
+    Kokkos::deep_copy(Q_host, this->bunch->Q.getView());
+    for (unsigned int i = 0; i < this->bunch->getLocalNum(); ++i) {
+        ASSERT_NEAR(Q_host(i), 2.0, 1e-6);
+    }
+}
+
+//
+// ScatterSimpleTest:
+// Set Q = 1.0 for all particles and scatter them to the field.
+// Then compare the total charge in the field to the total charge from the particles.
+// (adapted from test/particle/TestScatter.cpp)
+//
+TYPED_TEST(GatherScatterTest, ScatterSimpleTest) {
+    const unsigned int n = this->nScatter;
+    this->fillRandomPositions(n);
+    this->fillAttributeQ(1.0);
+
+    // Create and initialize a field/mesh.
+    using Mesh_t    = typename TestFixture::mesh_type;
+    using FieldType = ippl::Field<typename TestFixture::scalar_type, TestFixture::dim, Mesh_t, typename Mesh_t::DefaultCentering>;
+    FieldType field;
+    field.initialize(this->mesh, this->layout);
+    
+    field = 0.0;
+
+    // Perform the simple scatter operation (extended functionality is testes below).
+    scatter(this->bunch->Q, field, this->bunch->R);
+
+    // Compute the total charge in the field and from the particles.
+    double total_field = field.sum();
+    double total_particles = this->bunch->Q.sum();
+
+    // Check that the scattered field conserves charge.
+    ASSERT_NEAR(total_field, total_particles, 1e-6);
+}
+
+
+//
+// ScatterCustomRangeTest: 
+// Set Q = 1.0 for all particles and scatter only a subset defined by a custom range policy.
+// Then compare the total charge in the field to the expected value.
+//
+TYPED_TEST(GatherScatterTest, ScatterCustomRangeTest) {
+    const size_t n = this->nScatter;
+    if(n % ippl::Comm->size() != 0) {
+        GTEST_SKIP() << "nScatter not divisible by number of ranks.";
+    }
+    this->fillRandomPositions(n);
+    this->fillAttributeQ(1.0);
+
+    using Mesh_t   = typename TestFixture::mesh_type;
+    using FieldType = ippl::Field<typename TestFixture::scalar_type, TestFixture::dim, Mesh_t, typename Mesh_t::DefaultCentering>;
+    FieldType field;
+    field.initialize(this->mesh, this->layout);
+    field = 0.0;
+
+    size_t rank = ippl::Comm->rank();
+    size_t nLoc = this->bunch->getLocalNum();
+    size_t NScattered = nLoc / 2 + rank;
+
+    double Q_total = 1.0 * NScattered;
+    ippl::Comm->allreduce(Q_total, 1, std::plus<double>());
+
+    Kokkos::RangePolicy<typename TestFixture::exec_space> policy(0, NScattered);
+    scatter(this->bunch->Q, field, this->bunch->R, policy);
+
+    double Total_charge_field = field.sum();
+    ASSERT_NEAR(Q_total, Total_charge_field, 1e-6);
+}
+
+//
+// ScatterCustomHashTest: 
+// Assign random charges (in [0.5, 1.5]), create and shuffle an index array,
+// use it as a custom hash, scatter the first NScattered particles accordingly,
+// and compare the field’s total charge to the expected total.
+//
+TYPED_TEST(GatherScatterTest, ScatterCustomHashTest) {
+    const size_t n = this->nScatter / ippl::Comm->size();
+    if (this->nScatter % ippl::Comm->size() > 0) {
+        GTEST_SKIP() << "nScatter not divisible by number of ranks.";
+    }
+    this->fillRandomPositions(n);
+    
+    size_t rank = ippl::Comm->rank();
+    size_t nLoc = this->bunch->getLocalNum(); // since update() might change number of particles 
+    size_t NScattered = nLoc / 2 + rank; // can be anything
+
+    // Assign random charges to particles
+    std::mt19937_64 eng(42);
+    std::uniform_real_distribution<typename TestFixture::scalar_type> unif_charge(0.5, 1.5);
+    auto Q_host = this->bunch->Q.getHostMirror();
+    for (size_t i = 0; i < n; ++i) {
+        Q_host(i) = unif_charge(eng);
+    }
+    Kokkos::deep_copy(this->bunch->Q.getView(), Q_host);
+
+    // Create and initialize a field/mesh.
+    using Mesh_t   = typename TestFixture::mesh_type;
+    using FieldType = ippl::Field<typename TestFixture::scalar_type, TestFixture::dim, Mesh_t, typename Mesh_t::DefaultCentering>;
+    FieldType field;
+    field.initialize(this->mesh, this->layout);
+    field = 0.0;
+
+    // Create a custom hash using a shuffled index array
+    using hash_type = typename TestFixture::bunch_type::charge_container_type::hash_type;
+    hash_type hash("indexArray", nLoc);
+    std::vector<int> host_indices(nLoc);
+    std::iota(host_indices.begin(), host_indices.end(), 0);
+    std::shuffle(host_indices.begin(), host_indices.end(), eng);
+
+    // Copy shuffled index array to the hash_type
+    auto hash_host = Kokkos::create_mirror_view(hash);
+    for (size_t i = 0; i < nLoc; ++i) {
+        hash_host(i) = host_indices[i];
+    }
+    Kokkos::deep_copy(hash, hash_host);
+
+    // First compute the total charge of the first NScattered particles as determined by the hash map
+    double Q_total = 0.0;
+    auto viewQ = this->bunch->Q.getView();
+    Kokkos::parallel_reduce("computeTotalCharge", 
+        Kokkos::RangePolicy<typename TestFixture::exec_space>(0, NScattered),
+        KOKKOS_LAMBDA(const size_t i, double& val) {
+            val += viewQ(hash(i));
+        }, Q_total);
+    ippl::Comm->allreduce(Q_total, 1, std::plus<double>());
+
+    // Scatter the first NScattered particles using the custom hash
+    Kokkos::RangePolicy<typename TestFixture::exec_space> policy(0, NScattered);
+    scatter(this->bunch->Q, field, this->bunch->R, policy, hash);
+
+    // Check the total charge in the field and compare to the expected total
+    double Total_charge_field = field.sum();
+    ASSERT_NEAR(Q_total, Total_charge_field, 1e-6);
+}
+
+int main(int argc, char* argv[]) {
+    ippl::initialize(argc, argv);
+    int result = 1;
+    {
+        ::testing::InitGoogleTest(&argc, argv);
+        result = RUN_ALL_TESTS();
+    }
+    ippl::finalize();
+    return result;
+}


### PR DESCRIPTION
This pull request implements the following changes to resolve issue [#326](https://github.com/IPPL-framework/ippl/issues/326):

1. **Scatter Operation Enhancements**:
   - Modified `ParticleAttrib::scatter` to accept a custom range policy and hashing array, like `ippl::hash_type`.
   - Added a check to ensure the custom policy matches the number of available elements.
   - Introduced the usage of `mapped_idx` instead of `idx` for particle scattering.
   - Overloaded the non-class `scatter` interface to preserve old functionality while allowing custom range policies.

2. **Gather**:
   - Modified `ParticleAttrib::gather` to include a boolean parameter that determines whether to add to or overwrite the attribute's values.
   - Changed the non-class `gather` interface to maintain backward compatibility.

**Testing**:
- Added a new test file `test/particle/TestHashedScatter.cpp`.
- Modified the existing `TestGather` to validate the new functionality (use "+=" instead of "+").


closes #326 