### PR TITLE
Nvidia Nsight System CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,19 @@ else()
     # Handle unknown or unsupported platform
 endif()
 
+# Profiler Section
+option (IPPL_ENABLE_NSYS_PROFILER "Enable Nvidia Nsys Profiler" OFF)
+
+if (IPPL_ENABLE_NSYS_PROFILER)
+  if ("${IPPL_PLATFORMS}" STREQUAL "CUDA" OR "${IPPL_PLATFORMS}" STREQUAL "CUDA;OPENMP" OR "${IPPL_PLATFORMS}" STREQUAL "OPENMP;CUDA")
+    message (STATUS "Enabling Nsys Profiler")
+    add_compile_definitions(-DIPPL_ENABLE_NSYS_PROFILER)    
+    else()
+      message (FATAL_ERROR "Cannot enable Nvidia Nsys Profiler since platform is not CUDA")
+    endif()
+endif()
+
+
 if(NOT Kokkos_VERSION)
     set(Kokkos_VERSION "4.1.00")
     message(STATUS "${Green}Selecting default Kokkos version: ${Kokkos_VERSION} ${ColourReset}")
@@ -264,15 +277,6 @@ if (ENABLE_UNIT_TESTS)
 
     add_subdirectory (unit_tests)
 endif ()
-
-option (IPPL_ENABLE_NSYS_PROFILER "Enable Nsight Systems Profiler" OFF)
-if (IPPL_ENABLE_NSYS_PROFILER)
-    if (NOT "${IPPL_PLATFORMS}" STREQUAL "CUDA")
-        message (FATAL_ERROR "Cannot enable Nsight Systems Profiler since platform is not CUDA")
-    endif()
-    message (STATUS "Enabling Nsys Profiler")
-    add_compile_definitions(-DIPPL_ENABLE_NSYS_PROFILER)    
-endif()
 
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config_install.cmake )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,15 @@ if (ENABLE_UNIT_TESTS)
     add_subdirectory (unit_tests)
 endif ()
 
+option (IPPL_ENABLE_NSYS_PROFILER "Enable Nsight Systems Profiler" OFF)
+if (IPPL_ENABLE_NSYS_PROFILER)
+    if (NOT "${IPPL_PLATFORMS}" STREQUAL "CUDA")
+        message (FATAL_ERROR "Cannot enable Nsight Systems Profiler since platform is not CUDA")
+    endif()
+    message (STATUS "Enabling Nsys Profiler")
+    add_compile_definitions(-DIPPL_ENABLE_NSYS_PROFILER)    
+endif()
+
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config_install.cmake )
 

--- a/src/Utility/IpplTimings.cpp
+++ b/src/Utility/IpplTimings.cpp
@@ -92,8 +92,7 @@ void Timing::startTimer(TimerRef t) {
         return;
 #ifdef IPPL_ENABLE_NSYS_PROFILER
     PUSH_RANGE(TimerList[t]->name.c_str(), (int)t);
-    //nvtxRangePush(TimerList[t]->name.c_str());
-#endif // ENABLE_PROFILER
+#endif
     TimerList[t]->start();
 }
 
@@ -104,7 +103,7 @@ void Timing::stopTimer(TimerRef t) {
     TimerList[t]->stop();
 #ifdef IPPL_ENABLE_NSYS_PROFILER
     nvtxRangePop();
-#endif // ENABLE_PROFILER
+#endif
 }
 
 // clear a timer, by turning it off and throwing away its time

--- a/src/Utility/IpplTimings.cpp
+++ b/src/Utility/IpplTimings.cpp
@@ -33,6 +33,26 @@
 #include "Utility/Inform.h"
 #include "Utility/IpplInfo.h"
 
+#ifdef IPPL_ENABLE_NSYS_PROFILER
+
+#include "nvtx3/nvToolsExt.h"
+const uint32_t colors[] = { 0xff00ff00, 0xff0000ff, 0xffffff00, 0xffff00ff, 0xff00ffff, 0xffff0000, 0xffffffff };
+const int num_colors = sizeof(colors)/sizeof(uint32_t);
+#define PUSH_RANGE(name,cid) { \
+    int color_id = cid; \
+    color_id = color_id%num_colors;\
+    nvtxEventAttributes_t eventAttrib = {0}; \
+    eventAttrib.version = NVTX_VERSION; \
+    eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE; \
+    eventAttrib.colorType = NVTX_COLOR_ARGB; \
+    eventAttrib.color = colors[color_id]; \
+    eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII; \
+    eventAttrib.message.ascii = name; \
+    nvtxRangePushEx(&eventAttrib); \
+}
+
+#endif // ENABLE_PROFILER
+
 Timing* IpplTimings::instance = new Timing();
 std::stack<Timing*> IpplTimings::stashedInstance;
 
@@ -70,6 +90,10 @@ Timing::TimerRef Timing::getTimer(const char* nm) {
 void Timing::startTimer(TimerRef t) {
     if (t >= TimerList.size())
         return;
+#ifdef IPPL_ENABLE_NSYS_PROFILER
+    PUSH_RANGE(TimerList[t]->name.c_str(), (int)t);
+    //nvtxRangePush(TimerList[t]->name.c_str());
+#endif // ENABLE_PROFILER
     TimerList[t]->start();
 }
 
@@ -78,6 +102,9 @@ void Timing::stopTimer(TimerRef t) {
     if (t >= TimerList.size())
         return;
     TimerList[t]->stop();
+#ifdef IPPL_ENABLE_NSYS_PROFILER
+    nvtxRangePop();
+#endif // ENABLE_PROFILER
 }
 
 // clear a timer, by turning it off and throwing away its time


### PR DESCRIPTION
Added a CMake option to enable Nvidia Nsight Systems profiler.
Macro-level option in `src/Utility/IpplTimings.cpp` depending on the CMake flag `IPPL_ENABLE_NSYS_PROFILER`.
Adding `-DIPPL_ENABLE_NSYS_PROFILER=ON` enables the profiler.
[IPPL_Nsys_Profiler_Settings.pdf](https://github.com/user-attachments/files/19322578/IPPL_Nsys_Profiler_Settings.pdf)
