### PR TITLE
Fixed PIC and ORB Unit Test

### DIFF
--- a/unit_tests/PIC/ORB.cpp
+++ b/unit_tests/PIC/ORB.cpp
@@ -71,8 +71,8 @@ public:
         layout                   = flayout_type(MPI_COMM_WORLD, owned, isParallel, isAllPeriodic);
         mesh                     = mesh_type(owned, hx, origin);
         field                    = std::make_shared<field_type>(mesh, layout);
-        playout                  = playout_type(layout, mesh);
-        bunch                    = std::make_shared<bunch_type>(playout);
+        playout_ptr              = std::make_shared<playout_type>(layout, mesh);
+        bunch                    = std::make_shared<bunch_type>(*playout_ptr);
 
         int nRanks = ippl::Comm->size();
         if (nParticles % nRanks > 0) {
@@ -118,7 +118,7 @@ public:
 
     flayout_type layout;
     mesh_type mesh;
-    playout_type playout;
+    std::shared_ptr<playout_type> playout_ptr;
     ORB orb;
 };
 

--- a/unit_tests/PIC/PIC.cpp
+++ b/unit_tests/PIC/PIC.cpp
@@ -66,9 +66,9 @@ public:
 
         field = std::make_unique<field_type>(mesh, layout);
 
-        playout = playout_type(layout, mesh);
+        playout_ptr = std::make_shared<playout_type>(layout,mesh);
 
-        bunch = std::make_unique<bunch_type>(playout);
+        bunch = std::make_shared<bunch_type>(*playout_ptr);
 
         int nRanks = ippl::Comm->size();
         if (nParticles % nRanks > 0) {
@@ -101,8 +101,8 @@ public:
     size_t nParticles = 32;
     std::array<size_t, Dim> nPoints;
     std::array<double, Dim> domain;
-    playout_type playout;
 
+    std::shared_ptr<playout_type> playout_ptr;
     flayout_type layout;
     mesh_type mesh;
 };

--- a/unit_tests/Particle/ParticleSendRecv.cpp
+++ b/unit_tests/Particle/ParticleSendRecv.cpp
@@ -66,8 +66,8 @@ public:
 
         layout  = flayout_type(MPI_COMM_WORLD, owned, isParallel);
         mesh    = mesh_type(owned, hx, origin);
-        playout = playout_type(layout, mesh);
-        bunch   = std::make_shared<bunch_type>(playout);
+        playout_ptr = std::make_shared<playout_type>(layout, mesh);
+        bunch = std::make_shared<bunch_type>(*playout_ptr);
 
         using BC = ippl::BC;
 
@@ -108,7 +108,7 @@ public:
         using size_type    = typename RegionLayout_t::view_type::size_type;
         using mdrange_type = Kokkos::MDRangePolicy<Kokkos::Rank<2>, ExecSpace>;
 
-        RegionLayout_t RLayout           = playout.getRegionLayout();
+        RegionLayout_t RLayout           = playout_ptr->getRegionLayout();
         auto& positions                  = bunch->R.getView();
         region_view Regions              = RLayout.getdLocalRegions();
         typename rank_type::view_type ER = bunch->expectedRank.getView();
@@ -132,7 +132,7 @@ public:
     const unsigned int nParticles = 128;
     std::array<size_t, Dim> nPoints;
     std::array<T, Dim> domain;
-    playout_type playout;
+    std::shared_ptr<playout_type> playout_ptr;
 
     flayout_type layout;
     mesh_type mesh;


### PR DESCRIPTION
`PICTest`,`ORBTest` and `ParticleSendRecv` classes have `ParticleSpatialLayout playout` as a member that is copy assigned to in the       constructor: `playout  = playout_type(layout, mesh);`

This is no longer possible since the new `ParticleSpatialLayout` has `FieldLayout flayout` as a reference and thus implicitly deletes the copy-assignment operator. 

A simple fix is to use a pointer to playout in the ORB and PIC unit test. Unit test now pass locally and on Daint.Alps
