### PR TITLE
remove the Cuda/HIP backend macros for the HostSpace FFT definition

### DIFF
--- a/src/FFT/FFT.h
+++ b/src/FFT/FFT.h
@@ -123,7 +123,7 @@ namespace ippl {
 #endif
 #endif
 
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(Heffte_ENABLE_MKL) && !defined(Heffte_ENABLE_FFTW) && !defined(Heffte_ENABLE_ROCM)
+#if !defined(Heffte_ENABLE_MKL) && !defined(Heffte_ENABLE_FFTW)
         /**
          * Use heFFTe's inbuilt 1D fft computation on CPUs if no
          * vendor specific or optimized backend is found


### PR DESCRIPTION
Unit tests are not compiling because of a change in FFT.h when adding HIP/rocm support. 

This is because the Kokkos::HostSpace FFT needs to be defined even if we have Cuda or HIP (since these are on Kokkos::CudaSpace or Kokkos::HIPSpace).

I do not know if this breaks anything on AMD (please let me know Andreas). 
If it does, then I think we need to somehow add these macros to the unit tests instead.