### PR TITLE
Remove default boundary condition to fix strange template default param error

### DIFF
--- a/src/MaxwellSolvers/FDTDSolverBase.h
+++ b/src/MaxwellSolvers/FDTDSolverBase.h
@@ -24,7 +24,7 @@ namespace ippl {
      * @tparam SourceField The type representing the source field.
      * @tparam boundary_conditions The boundary conditions to be applied (default is periodic).
      */
-    template <typename EMField, typename SourceField, fdtd_bc boundary_conditions = periodic>
+    template <typename EMField, typename SourceField, fdtd_bc boundary_conditions>
     class FDTDSolverBase : public Maxwell<EMField, SourceField> {
     public:
         constexpr static unsigned Dim = EMField::dim;


### PR DESCRIPTION
gcc 13 reports an error due to a missing or redeclared default template parameter, but it does not appear to be an error.
This patch removes the default - which can be reinstated if an alternative fix is found