### PR TITLE
Changed P3M solver name after it was renamed in the latest P3M merge

### DIFF
--- a/cosmology/GravityLoadBalancer.hpp
+++ b/cosmology/GravityLoadBalancer.hpp
@@ -127,8 +127,8 @@ public:
                 std::get<FFTSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
             }
             if constexpr (Dim == 3) {
-                if (fs_m->getStype() == "P3M") {
-                    std::get<P3MSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
+                if (fs_m->getStype() == "TG") {
+                    std::get<FFTTruncatedGreenSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
                 } else if (fs_m->getStype() == "OPEN") {
                     std::get<OpenSolver_t<T, Dim>>(fs_m->getSolver()).setRhs(*rho_m);
                 }


### PR DESCRIPTION
Closes #372 

Simply change the P3M solver name to match what was used in [the P3M merge](https://github.com/IPPL-framework/ippl/pull/334). It is the same change that was made in [alpine](https://github.com/IPPL-framework/ippl/blob/e8c6d93811dac85febcde7b33ced2f22d7f83ca8/alpine/LoadBalancer.hpp#L102) - it was just forgotten in the cosmology example.