### PR TITLE
Empty domains in Field Layout not permitted

### DIFF
--- a/ci/tests.yml
+++ b/ci/tests.yml
@@ -27,14 +27,19 @@ variables:
     value: "false"
     options: ["true", "false"]
     description: "Run the compilation test for the Jureca supercomputer."
+  RUN_COMPILE_JURECA_AMPERE80:
+    value: "true"
+    options: ["true", "false"]
+    description: "Run the compilation test for the Jureca ampere80 architecture."
 
 include:
   - local: 'ci/tests/serial_unit.yml'
   - local: 'ci/generate/generate_report.yml'
-  - local: 'ci/tests/compile_gcc_debug.yml'
   - local: 'ci/tests/compile_gcc_release.yml'
   - local: 'ci/tests/compile_clang_debug.yml'
   - local: 'ci/tests/compile_jureca_release.yml'
+  - local: 'ci/tests/compile_jureca_ampere80.yml'
+  - local: 'ci/tests/compile_jureca_debug_gcc.yml'
 
 # Template for tests
 .test_template:

--- a/ci/tests/compile_jureca_ampere80.yml
+++ b/ci/tests/compile_jureca_ampere80.yml
@@ -1,43 +1,50 @@
 # This job tests the default GCC compilation.
 # It is designed to always pass from a CI perspective, reporting
 # success or failure in the Allure report instead.
-compile-gcc-debug:
+compile-jureca-ampere80:
   extends: .test_template 
   stage: test
   rules:
-    - if: '$RUN_COMPILE_GCC_DEBUG == "true" || $RUN_ALL_TESTS == "true"'
+    - if: '$RUN_COMPILE_JURECA_AMPERE80 == "true" || $RUN_ALL_TESTS == "true"'
   image: registry.jsc.fz-juelich.de/muralikrishnan1/ippl:latest
   tags:
-    - linux
-    - opensuse
+    - jureca
+    - jacamar
+    - login
+    - shell
   allow_failure: true 
   script: |
     set -e
-    echo "Starting default GCC compilation test..."
+    echo "Starting jureca GCC compilation test..."
     
-    TEST_NAME="Compile GCC - Serial Debug Mode"
+    TEST_NAME="Compile GCC - CUDA Release Mode Ampere80"
     RESULTS_SUBDIR="compile-test" 
     
     TEST_RESULTS_DIR="${RESULTS_DIR}/${RESULTS_SUBDIR}/"
     mkdir -p "${TEST_RESULTS_DIR}"
-
     
     # --- Compilation Step ---
     # The '|| true' ensures the CI script step doesn't fail if 'make' returns an error.
     # The exit code is captured to determine the test status.
     COMPILE_STATUS=0
     {
+      module load Stages/2025  GCC
+      module load CMake
+      module load NCCL
+      module load OpenMPI
+
       mkdir -p build && cd build &&
-    cmake .. \
-      -DCMAKE_BUILD_TYPE=Debug \
-      -DCMAKE_CXX_STANDARD=20 \
-      -DIPPL_ENABLE_TESTS=True \
-      -DIPPL_ENABLE_SOLVERS=ON \
-      -DIPPL_ENABLE_FFT=ON \
-      -DIPPL_ENABLE_UNIT_TESTS=True \
-      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-      -DKokkos_VERSION=4.5.00 &&
-      ASAN_OPTIONS="detect_leaks=0" make -j 2
+      cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKokkos_ARCH_AMPERE80=ON \
+        -DCMAKE_CXX_STANDARD=20 \
+        -DIPPL_ENABLE_FFT=ON \
+        -DIPPL_ENABLE_TESTS=ON \
+        -DUSE_ALTERNATIVE_VARIANT=ON \
+        -DIPPL_ENABLE_SOLVERS=ON \
+        -DIPPL_ENABLE_ALPINE=True \
+        -DIPPL_PLATFORMS=cuda &&
+      make -j 8
     } > "${TEST_RESULTS_DIR}/stdout.log" 2> "${TEST_RESULTS_DIR}/stderr.log" || COMPILE_STATUS=$?
 
     cd ..

--- a/ci/tests/compile_jureca_debug_gcc.yml
+++ b/ci/tests/compile_jureca_debug_gcc.yml
@@ -1,11 +1,11 @@
 # This job tests the default GCC compilation.
 # It is designed to always pass from a CI perspective, reporting
 # success or failure in the Allure report instead.
-compile-jureca-release:
+compile-jureca-debug-gcc:
   extends: .test_template 
   stage: test
   rules:
-    - if: '$RUN_COMPILE_JURECA == "true" || $RUN_ALL_TESTS == "true"'
+    - if: '$RUN_COMPILE_GCC_DEBUG == "true" || $RUN_ALL_TESTS == "true"'
   image: registry.jsc.fz-juelich.de/muralikrishnan1/ippl:latest
   tags:
     - jureca
@@ -17,7 +17,7 @@ compile-jureca-release:
     set -e
     echo "Starting jureca GCC compilation test..."
     
-    TEST_NAME="Compile GCC - CUDA Release Mode (JURECA)"
+    TEST_NAME="Compile GCC - CUDA Debug Mode Serial"
     RESULTS_SUBDIR="compile-test" 
     
     TEST_RESULTS_DIR="${RESULTS_DIR}/${RESULTS_SUBDIR}/"
@@ -35,16 +35,14 @@ compile-jureca-release:
 
       mkdir -p build && cd build &&
       cmake .. \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DKokkos_ARCH_AMPERE80=ON \
+        -DCMAKE_BUILD_TYPE=Debug \
         -DCMAKE_CXX_STANDARD=20 \
         -DIPPL_ENABLE_FFT=ON \
         -DIPPL_ENABLE_TESTS=ON \
         -DIPPL_ENABLE_UNIT_TESTS=True \
         -DUSE_ALTERNATIVE_VARIANT=ON \
         -DIPPL_ENABLE_SOLVERS=ON \
-        -DIPPL_ENABLE_ALPINE=True \
-        -DIPPL_PLATFORMS=cuda &&
+        -DIPPL_ENABLE_ALPINE=True &&
       make -j 8
     } > "${TEST_RESULTS_DIR}/stdout.log" 2> "${TEST_RESULTS_DIR}/stderr.log" || COMPILE_STATUS=$?
 
@@ -61,8 +59,6 @@ compile-jureca-release:
     else
       echo "Compilation successful."
     fi
-
-
 
     RESULT_FILE="${TEST_RESULTS_DIR}/result.json"
     echo "{" > "${RESULT_FILE}"


### PR DESCRIPTION
Do not allow the creation of fields, that have less possible local domains than ranks.

Split const NDIndex_t& getLocalNDIndex(int rank = -1) const; in to two functions, one without argument, that returns the domain of the current rank and one with a rank argument, that returns the domain of the rank that is asked for.
This solution prevents the case, where a random negative number is given for the rank. Now this prevented by an assert, before it just returned the domain of the current rank.

Closes #386 