### PR TITLE
Field layout equal operator

### DIFF
--- a/src/FieldLayout/FieldLayout.h
+++ b/src/FieldLayout/FieldLayout.h
@@ -227,6 +227,12 @@ namespace ippl {
         }
 
         bool operator==(const FieldLayout<Dim>& x) const {
+
+            // Throw exception if the domains are not the same
+            if (gDomain_m.size() != x.getDomain().size()) {
+                throw std::runtime_error("FieldLayout: only FieldLayouts with the same global domain should be compared");
+            }
+
             for (unsigned int i = 0; i < Dim; ++i) {
                 if (hLocalDomains_m(comm.rank())[i] != x.getLocalNDIndex()[i]) {
                     return false;

--- a/src/FieldLayout/FieldLayout.h
+++ b/src/FieldLayout/FieldLayout.h
@@ -223,13 +223,19 @@ namespace ippl {
         // false:
         template <unsigned Dim2>
         bool operator==(const FieldLayout<Dim2>& x) const {
+
+            // Throw exception if the domains are not the same
+            if (gDomain_m != x.getDomain()) {
+                throw std::runtime_error("FieldLayout: only FieldLayouts with the same global domain should be compared");
+            }
+
             return gDomain_m == x.getDomain();
         }
 
         bool operator==(const FieldLayout<Dim>& x) const {
 
             // Throw exception if the domains are not the same
-            if (gDomain_m.size() != x.getDomain().size()) {
+            if (gDomain_m != x.getDomain()) {
                 throw std::runtime_error("FieldLayout: only FieldLayouts with the same global domain should be compared");
             }
 


### PR DESCRIPTION
Fix Issue #394 

We only intend to use the == operator in FieldLayout for FieldLayouts with the same domain.
Add an error in cases where we compare FieldLayouts with different domains.