### PR TITLE
Fix Kokkos host/device mismatch in FEMVector operator[]

### DIFF
--- a/src/FEM/FEMVector.hpp
+++ b/src/FEM/FEMVector.hpp
@@ -207,13 +207,13 @@ namespace ippl{
 
 
     template <typename T>
-    T FEMVector<T>::operator[] (size_t i) const {
+    KOKKOS_INLINE_FUNCTION T FEMVector<T>::operator[] (size_t i) const {
         return data_m(i);
     }
 
 
     template <typename T>
-    T FEMVector<T>::operator() (size_t i) const {
+    KOKKOS_INLINE_FUNCTION T FEMVector<T>::operator() (size_t i) const {
         return this->operator[](i);
     }
 

--- a/src/FEM/NedelecSpace.hpp
+++ b/src/FEM/NedelecSpace.hpp
@@ -989,7 +989,7 @@ namespace ippl {
 
     template <typename T, unsigned Dim, unsigned Order, typename ElementType,
               typename QuadratureType, typename FieldType>
-    bool NedelecSpace<T, Dim, Order, ElementType, QuadratureType, FieldType>
+    KOKKOS_FUNCTION bool NedelecSpace<T, Dim, Order, ElementType, QuadratureType, FieldType>
                                 ::isDOFOnBoundary(const size_t& dofIdx) const {
         
         bool onBoundary = false;
@@ -1077,7 +1077,7 @@ namespace ippl {
 
     template <typename T, unsigned Dim, unsigned Order, typename ElementType,
               typename QuadratureType, typename FieldType>
-    int NedelecSpace<T, Dim, Order, ElementType, QuadratureType, FieldType>
+    KOKKOS_FUNCTION int NedelecSpace<T, Dim, Order, ElementType, QuadratureType, FieldType>
                                 ::getBoundarySide(const size_t& dofIdx) const {
 
         if constexpr (Dim == 2) {


### PR DESCRIPTION
Add missing KOKKOS_FUNCTION to make clang happy