### PR TITLE
Add ParticleBaseBase class

### DIFF
--- a/src/Particle/ParticleBase.h
+++ b/src/Particle/ParticleBase.h
@@ -64,6 +64,18 @@
 namespace ippl {
 
     /*!
+     * @class ParticleBaseBase
+     *
+     *  Minimal empty base class for all ParticleBase specializations.
+     *  Needed for e.g: c++20 constraints and concepts using std::derived_from
+     * 
+     */
+    class ParticleBaseBase {
+    public:
+        virtual ~ParticleBaseBase() = default;
+    };
+
+    /*!
      * @class ParticleBase
      * @tparam PLayout the particle layout implementing an algorithm to
      * distribute the particles among MPI ranks
@@ -72,7 +84,7 @@ namespace ippl {
      * IDs will be disabled for the bunch)
      */
     template <class PLayout, typename... IDProperties>
-    class ParticleBase {
+    class ParticleBase: public ParticleBaseBase {
         constexpr static bool EnableIDs = sizeof...(IDProperties) > 0;
 
     public:


### PR DESCRIPTION
Add ParticleBaseBase class, make each specialisation of ParticleBase inherit from ParticleBaseBase.
Enables c++20  constraints or concepts to be used with: std::derived_from
Needed for upcoming Catalyst Vis implementation.

