### PR TITLE
Fix warnings fem

### DIFF
--- a/src/FEM/LagrangeSpace.hpp
+++ b/src/FEM/LagrangeSpace.hpp
@@ -137,11 +137,11 @@ namespace ippl {
                 return i;
             }
         }
-        return Kokkos::Experimental::quiet_NaN_v<size_t>;
         // commented this due to this being on device 
         // however, it would be good to throw an error in this case
         //throw IpplException("LagrangeSpace::getLocalDOFIndex()",
         //                    "FEM Lagrange Space: Global DOF not found in specified element");
+        return 0;
     }
 
     template <typename T, unsigned Dim, unsigned Order, typename ElementType,

--- a/src/FEM/NedelecSpace.hpp
+++ b/src/FEM/NedelecSpace.hpp
@@ -169,7 +169,9 @@ namespace ippl {
                 return dof_mapping[i];
             }
         }
-        return Kokkos::Experimental::quiet_NaN_v<size_t>;
+        // it would be good to throw an error in this case
+        // just like the comment in the LagrangeSpace::getLocalDOFIndex()
+        return 0;
     }
 
     template <typename T, unsigned Dim, unsigned Order, typename ElementType,


### PR DESCRIPTION
Two warnings fixed:
1. Pointless comparison of unsigned with 0 fixed by changing if to if constexpr.
2. std::numeric_limits<size_t>::quiet_NaN() --> did not know how to do this fix because the return type of the function is size_t but Kokkos::Experimental::quiet_NaN is not available for this case. For now, just replaced it by 0, but would be good to possibly throw an exception  (which tight now is commented out due to it being on device).