### PR TITLE
Change --prefix to --preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cd build
 #### CMakeUserPresets
 In the root IPPL source folder, there is a cmake user presets file which can be used to set some default cmake settings, they may be used in the following way
 ```
-cmake --prefix=release-testing ...
+cmake --preset=release-testing ...
 ```
 This will set the following variables automatically (exact values may change over time)
 ```


### PR DESCRIPTION
Cmake preset and prefix are not the same. To load a preset, one has to use e.g. `--preset=default`, not `--prefix=detault`. Prefix is used in the `cmake --install` process to change where the files are copied during installation (not needed here), while Presets are what we want to use here.