### PR TITLE
Make `FieldSolverBase::getStype()` const-correct (for OPALX)

### DIFF
--- a/src/Manager/FieldSolverBase.h
+++ b/src/Manager/FieldSolverBase.h
@@ -24,9 +24,9 @@ namespace ippl {
 
         virtual ~FieldSolverBase() = default;
 
-        const std::string& getStype() const { return stype_m; }
+        std::string getStype() const { return stype_m; }
 
-        void setStype(const std::string& solver) { stype_m = solver; }
+        void setStype(const std::string solver) { stype_m = solver; }
 
         Solver_t<T, Dim>& getSolver() { return solver_m; }
 


### PR DESCRIPTION
closes #460 

A simple addition that makes the getter/setter of `FieldSolverBase::stype_m` "more" `const` correct. See issue #460 for more information. 

I want to use the currently non-`const` getter inside a `const` function that is implemented in a class that inherits from `FieldSolverBase`. This does not work if the getter is not `const`.

I selected @mohsensadr as a reviewer, since he is the one who wrote this class initially. 