### PR TITLE
Fixing the warnings on cuda

### DIFF
--- a/src/Decomposition/OrthogonalRecursiveBisection.hpp
+++ b/src/Decomposition/OrthogonalRecursiveBisection.hpp
@@ -278,11 +278,15 @@ namespace ippl {
 
         using policy_type = Kokkos::RangePolicy<size_t, typename Field::execution_space>;
 
+        // Extract the view to avoid capturing the entire ParticleAttrib in the lambda
+        // (ParticleAttrib's destructor is host-only)
+        auto rview = r.getView();
+
         Kokkos::parallel_for(
             "ParticleAttrib::scatterR", policy_type(0, r.getParticleCount()),
             KOKKOS_LAMBDA(const size_t idx) {
                 // Find nearest grid point
-                Vector<Tp, Dim> l      = (r(idx) - origin) * invdx + 0.5;
+                Vector<Tp, Dim> l      = (rview(idx) - origin) * invdx + 0.5;
                 Vector<int, Dim> index = l;
                 Vector<Tf, Dim> whi    = l - index;
                 Vector<Tf, Dim> wlo    = 1.0 - whi;

--- a/src/Field/BcTypes.h
+++ b/src/Field/BcTypes.h
@@ -52,7 +52,8 @@ namespace ippl {
             // The components default to setting all components.
             BCondBase(unsigned int face);
 
-            virtual ~BCondBase() = default;
+            KOKKOS_FUNCTION
+            virtual ~BCondBase() {}
 
             virtual FieldBC getBCType() const { return NO_FACE; }
 
@@ -98,7 +99,8 @@ namespace ippl {
             , offset_m(offset)
             , slope_m(slope) {}
 
-        virtual ~ExtrapolateFace() = default;
+        KOKKOS_FUNCTION
+        virtual ~ExtrapolateFace() {}
 
         virtual FieldBC getBCType() const { return EXTRAPOLATE_FACE; }
 

--- a/src/Particle/ParticleAttrib.h
+++ b/src/Particle/ParticleAttrib.h
@@ -16,6 +16,8 @@
 #ifndef IPPL_PARTICLE_ATTRIB_H
 #define IPPL_PARTICLE_ATTRIB_H
 
+#include <cstring>
+
 #include "Expression/IpplExpressions.h"
 
 #include "Interpolation/CIC.h"
@@ -100,9 +102,16 @@ namespace ippl {
 
         HostMirror getHostMirror() const { return Kokkos::create_mirror(dview_m); }
         
-        void  set_name(const std::string & name_) override { this->name_m = name_; }
+        void set_name(const std::string& name_) override {
+            size_t len = name_.size();
+            if (len >= detail::ATTRIB_NAME_MAX_LEN) {
+                len = detail::ATTRIB_NAME_MAX_LEN - 1;
+            }
+            std::memcpy(this->name_m, name_.c_str(), len);
+            this->name_m[len] = '\0';
+        }
 
-        std::string get_name() const override { return this->name_m; }
+        std::string get_name() const override { return std::string(this->name_m); }
 
         /*!
          * Assign the same value to the whole attribute.

--- a/src/Particle/ParticleAttribBase.h
+++ b/src/Particle/ParticleAttribBase.h
@@ -14,6 +14,8 @@
 #ifndef IPPL_PARTICLE_ATTRIB_BASE_H
 #define IPPL_PARTICLE_ATTRIB_BASE_H
 
+#include <cstring>
+
 #include "Types/IpplTypes.h"
 #include "Types/ViewTypes.h"
 
@@ -21,6 +23,9 @@
 
 namespace ippl {
     namespace detail {
+        // Maximum length for attribute names (including null terminator)
+        constexpr size_t ATTRIB_NAME_MAX_LEN = 64;
+
         template <typename MemorySpace = Kokkos::DefaultExecutionSpace::memory_space>
         class ParticleAttribBase {
             template <class... Properties>
@@ -37,10 +42,19 @@ namespace ippl {
             template <typename... Properties>
             using with_properties = typename WithMemSpace<Properties...>::type;
 
-            ParticleAttribBase(){this->name_m = "UNNAMED_attribute";}
+            KOKKOS_FUNCTION
+            ParticleAttribBase() {
+                const char* default_name = "UNNAMED_attribute";
+                for (size_t i = 0; i < ATTRIB_NAME_MAX_LEN && default_name[i] != '\0'; ++i) {
+                    name_m[i] = default_name[i];
+                    if (i + 1 < ATTRIB_NAME_MAX_LEN) {
+                        name_m[i + 1] = '\0';
+                    }
+                }
+            }
 
-            virtual void set_name(const std::string & name_) = 0;
-            
+            virtual void set_name(const std::string& name_) = 0;
+
             virtual std::string get_name() const = 0;
 
             virtual void create(size_type) = 0;
@@ -68,7 +82,7 @@ namespace ippl {
 
         protected:
             const size_type* localNum_mp;
-            std::string name_m;
+            char name_m[ATTRIB_NAME_MAX_LEN];
         };
     }  // namespace detail
 }  // namespace ippl


### PR DESCRIPTION
From opalx side, we see a lot of warnings coming from the internals of ippl that worries us. In order to eliminate possible causes of open solver crashing in opalx, I made this PR to fix these warnings

https://github.com/OPALX-project/OPALX/issues/166

Most fixes are proposed to get rid of "calling host function inside a host-device function". Also, "KOKKOS_CLASS_LAMBDA" seems to be somewhat broken. Reducing it to simple kokkos lambda fixes some of the warnings. Also, std:string is not allowed on device. 