### PR TITLE
Fix a missing if in FFTOpenPoissonSolver

### DIFF
--- a/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
@@ -475,8 +475,12 @@ namespace ippl {
 
         rho2_mr  = 0.0;
         rho2tr_m = 0.0;
-        grnL_m   = 0.0;
-        grn2n1_m = 0.0;
+        if (alg == Algorithm::VICO || alg == Algorithm::BIHARMONIC) {
+            grnL_m   = 0.0;
+        }
+        if (alg == Algorithm::DCT_VICO) {
+            grn2n1_m = 0.0;
+        }
 
         // call greensFunction and we will get the transformed G in the class attribute
         // this is done in initialization so that we already have the precomputed fct


### PR DESCRIPTION
There is a setting to 0 of fields which are never initialized with a mesh and a field layout unless the VICO algorithm is set. This could be a potential source of errors. It is fixed by putting this setting to 0 inside an if (so it should only be executed if we are running the VICO algorithm). 