### PR TITLE
Fix FEM load-balanced layout reinitialization

### DIFF
--- a/alpine/LoadBalancer.hpp
+++ b/alpine/LoadBalancer.hpp
@@ -58,6 +58,7 @@ public:
         IpplTimings::startTimer(tupdateLayout);
         (*E_m).updateLayout(*fl);
         (*rho_m).updateLayout(*fl);
+        rho_m->setFieldBC(rho_m->getFieldBC());
 
         if (fs_m->getStype() == "CG" || fs_m->getStype() == "PCG" || fs_m->getStype() == "FEM" ||
             fs_m->getStype() == "FEM_PRECON") {

--- a/alpine/LoadBalancer.hpp
+++ b/alpine/LoadBalancer.hpp
@@ -59,17 +59,22 @@ public:
         (*E_m).updateLayout(*fl);
         (*rho_m).updateLayout(*fl);
 
-        if (fs_m->getStype() == "CG" || fs_m->getStype() == "PCG") {
-            phi_m->updateLayout(*fl);
-            phi_m->setFieldBC(phi_m->getFieldBC());
-        } else if (fs_m->getStype() == "FEM" || fs_m->getStype() == "FEM_PRECON") {
+        if (fs_m->getStype() == "CG" || fs_m->getStype() == "PCG" || fs_m->getStype() == "FEM" ||
+            fs_m->getStype() == "FEM_PRECON") {
             phi_m->updateLayout(*fl);
             phi_m->setFieldBC(phi_m->getFieldBC());
 
-            // also update the layout in the FEM space
-            auto* solver = dynamic_cast<FieldSolver_t*>(this->fsolver_m.get());
-            auto& space = solver->getSpace();
-            space.updateLayout(*fl);
+            if (fs_m->getStype() == "FEM") {
+                // also update the layout in the FEM space
+                auto& space = std::get<FEMSolver_t<T, Dim>>(fs_m->getSolver()).getSpace();
+                space.updateLayout(*fl);
+            } 
+
+            if (fs_m->getStype() == "FEM_PRECON") {
+                // also update the layout in the FEM space
+                auto& space = std::get<FEMPreconSolver_t<T, Dim>>(fs_m->getSolver()).getSpace();
+                space.updateLayout(*fl);
+            } 
         }
 
         // Update layout with new FieldLayout

--- a/alpine/LoadBalancer.hpp
+++ b/alpine/LoadBalancer.hpp
@@ -59,10 +59,17 @@ public:
         (*E_m).updateLayout(*fl);
         (*rho_m).updateLayout(*fl);
 
-        if (fs_m->getStype() == "CG" || fs_m->getStype() == "PCG" || fs_m->getStype() == "FEM" ||
-            fs_m->getStype() == "FEM_PRECON") {
+        if (fs_m->getStype() == "CG" || fs_m->getStype() == "PCG") {
             phi_m->updateLayout(*fl);
             phi_m->setFieldBC(phi_m->getFieldBC());
+        } else if (fs_m->getStype() == "FEM" || fs_m->getStype() == "FEM_PRECON") {
+            phi_m->updateLayout(*fl);
+            phi_m->setFieldBC(phi_m->getFieldBC());
+
+            // also update the layout in the FEM space
+            auto* solver = dynamic_cast<FieldSolver_t*>(this->fsolver_m.get());
+            auto& space = solver->getSpace();
+            space.updateLayout(*fl);
         }
 
         // Update layout with new FieldLayout

--- a/src/FEM/LagrangeSpace.h
+++ b/src/FEM/LagrangeSpace.h
@@ -110,6 +110,14 @@ namespace ippl {
          */
         void initializeElementIndices(Layout_t& layout);
 
+        ///////////////////////////////////////////////////////////////////////
+        /**
+         * @brief Function to update the element partition and the layout of 
+         * fields in the LagrangeSpace if the layout has been changed during
+         * the simulation (for example by the load balancer).
+         */
+        void updateLayout(Layout_t& layout);
+
         /// Degree of Freedom operations //////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////
 

--- a/src/FEM/LagrangeSpace.hpp
+++ b/src/FEM/LagrangeSpace.hpp
@@ -17,8 +17,9 @@ namespace ippl {
         // Initialize the elementIndices view
         initializeElementIndices(layout);
 
-        // Initialize the resultField
+        // Initialize or resize the workspace field to the current layout.
         resultField.initialize(mesh, layout);
+        resultField.updateLayout(layout);
     }
 
     // LagrangeSpace constructor, which calls the FiniteElementSpace constructor.
@@ -47,8 +48,9 @@ namespace ippl {
         // Initialize the elementIndices view
         initializeElementIndices(layout);
 
-        // Initialize the resultField
+        // Initialize or resize the workspace field to the current layout.
         resultField.initialize(mesh, layout);
+        resultField.updateLayout(layout);
     }
 
     // Initialize element indices Kokkos View by distributing elements among MPI ranks.

--- a/src/FEM/LagrangeSpace.hpp
+++ b/src/FEM/LagrangeSpace.hpp
@@ -106,6 +106,17 @@ namespace ippl {
             });
     }
 
+    // Update resultField and elementIndices according to changed domain decomposition.
+    template <typename T, unsigned Dim, unsigned Order, typename ElementType,
+              typename QuadratureType, typename FieldLHS, typename FieldRHS>
+    void LagrangeSpace<T, Dim, Order, ElementType, QuadratureType, FieldLHS,
+                       FieldRHS>::updateLayout(Layout_t& layout) {
+        // repartition elements
+        initializeElementIndices(layout);
+        // update layout of resultField member variable
+        resultField.updateLayout(layout);
+    }
+
     ///////////////////////////////////////////////////////////////////////
     /// Degree of Freedom operations //////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////

--- a/unit_tests/PIC/CMakeLists.txt
+++ b/unit_tests/PIC/CMakeLists.txt
@@ -3,3 +3,4 @@ message(STATUS "Adding unit tests found in ${_relPath}")
 
 add_ippl_test(ORB)
 add_ippl_test(PIC)
+add_ippl_test(LoadBalancer INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/alpine TIMEOUT 300)

--- a/unit_tests/PIC/LoadBalancer.cpp
+++ b/unit_tests/PIC/LoadBalancer.cpp
@@ -1,0 +1,186 @@
+#include "Ippl.h"
+
+#include <cmath>
+#include <memory>
+#include <random>
+
+#include "Manager/datatypes.h"
+#include "PoissonSolvers/EvalFunctor.h"
+#include "FieldContainer.hpp"
+#include "FieldSolver.hpp"
+#include "LoadBalancer.hpp"
+#include "ParticleContainer.hpp"
+#include "TestUtils.h"
+#include "gtest/gtest.h"
+
+const char* TestName = "LoadBalancerRegression";
+
+namespace {
+    template <unsigned Dim>
+    ippl::NDIndex<Dim> makeDomain(const std::array<int, Dim>& nPoints) {
+        std::array<ippl::Index, Dim> args;
+        for (unsigned d = 0; d < Dim; ++d) {
+            args[d] = ippl::Index(nPoints[d]);
+        }
+        return std::make_from_tuple<ippl::NDIndex<Dim>>(args);
+    }
+
+    template <typename T, unsigned Dim>
+    T maxParticleDeviationFraction(const std::shared_ptr<ParticleContainer<T, Dim>>& particles) {
+        const size_type localParticles = particles->getLocalNum();
+        size_type globalParticles      = 0;
+        ippl::Comm->allreduce(localParticles, globalParticles, 1, std::plus<size_type>());
+
+        const T idealParticles = static_cast<T>(globalParticles) / ippl::Comm->size();
+        const T localDeviation =
+            std::abs(static_cast<T>(localParticles) - idealParticles) / globalParticles;
+
+        T globalDeviation = 0;
+        ippl::Comm->allreduce(localDeviation, globalDeviation, 1, std::greater<T>());
+        return globalDeviation;
+    }
+
+    template <typename T, unsigned Dim>
+    size_type globalParticleCount(const std::shared_ptr<ParticleContainer<T, Dim>>& particles) {
+        const size_type localParticles = particles->getLocalNum();
+        size_type globalParticles      = 0;
+        ippl::Comm->allreduce(localParticles, globalParticles, 1, std::plus<size_type>());
+        return globalParticles;
+    }
+
+    template <typename Field>
+    int maxExtentMismatch(Field& field) {
+        constexpr unsigned Dim = Field::dim;
+        const auto& localDomain = field.getLayout().getLocalNDIndex();
+        const auto view         = field.getView();
+        const int nghost        = field.getNghost();
+
+        int localMismatch = 0;
+        for (unsigned d = 0; d < Dim; ++d) {
+            const int expectedExtent = localDomain[d].length() + 2 * nghost;
+            const int actualExtent   = static_cast<int>(view.extent(d));
+            localMismatch            = std::max(localMismatch, std::abs(actualExtent - expectedExtent));
+        }
+
+        int globalMismatch = 0;
+        ippl::Comm->allreduce(localMismatch, globalMismatch, 1, std::greater<int>());
+        return globalMismatch;
+    }
+}  // namespace
+
+TEST(LoadBalancer, RebalancesArtificialPileUpAndReinitializesFEMOperator) {
+    constexpr unsigned Dim      = 3;
+    using value_type            = double;
+    constexpr size_type nGlobal = 1000000;
+
+    const std::array<int, Dim> nPoints = {17, 17, 17};
+    auto domain                         = makeDomain<Dim>(nPoints);
+
+    Vector_t<value_type, Dim> hr;
+    Vector_t<value_type, Dim> rmin(0.0);
+    Vector_t<value_type, Dim> rmax(1.0);
+    Vector_t<value_type, Dim> origin(0.0);
+    std::array<bool, Dim> isParallel;
+    isParallel.fill(true);
+
+    for (unsigned d = 0; d < Dim; ++d) {
+        hr[d] = (rmax[d] - rmin[d]) / nPoints[d];
+    }
+
+    auto fieldContainer =
+        std::make_shared<FieldContainer<value_type, Dim>>(hr, rmin, rmax, isParallel, domain,
+                                                          origin, true);
+    fieldContainer->initializeFields("FEM");
+
+    auto particleContainer =
+        std::make_shared<ParticleContainer<value_type, Dim>>(fieldContainer->getMesh(),
+                                                             fieldContainer->getFL(), true);
+    auto fieldSolver = std::make_shared<FieldSolver<value_type, Dim>>(
+        "FEM", &fieldContainer->getRho(), &fieldContainer->getE(), &fieldContainer->getPhi());
+    fieldSolver->initSolver();
+    std::shared_ptr<ippl::FieldSolverBase<value_type, Dim>> fieldSolverBase = fieldSolver;
+
+    auto loadBalancer = std::make_shared<LoadBalancer<value_type, Dim>>(
+        0.01, fieldContainer, particleContainer, fieldSolverBase);
+
+    const size_type baseLocal = nGlobal / ippl::Comm->size();
+    const size_type remainder = nGlobal % ippl::Comm->size();
+    const size_type localNum =
+        baseLocal + (static_cast<size_type>(ippl::Comm->rank()) < remainder ? 1 : 0);
+
+    particleContainer->create(localNum);
+    particleContainer->q = 1.0 / nGlobal;
+    particleContainer->P = Vector_t<value_type, Dim>(0.0);
+    particleContainer->E = Vector_t<value_type, Dim>(0.0);
+
+    std::mt19937_64 eng(42);
+    eng.discard(localNum * ippl::Comm->rank());
+    std::uniform_real_distribution<value_type> xUniform(0.0, 1.0);
+    std::uniform_real_distribution<value_type> yzUniform(0.0, 1.0);
+
+    auto positions = particleContainer->R.getHostMirror();
+    for (size_type i = 0; i < localNum; ++i) {
+        const value_type sample = xUniform(eng);
+        positions(i)[0]         = sample * sample;
+        positions(i)[1] = yzUniform(eng);
+        positions(i)[2] = yzUniform(eng);
+    }
+    Kokkos::deep_copy(particleContainer->R.getView(), positions);
+
+    particleContainer->update();
+
+    loadBalancer->initializeORB(&fieldContainer->getFL(), &fieldContainer->getMesh());
+
+    const value_type imbalanceBefore = maxParticleDeviationFraction(particleContainer);
+    EXPECT_GT(imbalanceBefore, 0.10);
+    EXPECT_EQ(globalParticleCount(particleContainer), nGlobal);
+    EXPECT_TRUE(loadBalancer->balance(nGlobal, 1));
+
+    bool isFirstRepartition = false;
+    loadBalancer->repartition(&fieldContainer->getFL(), &fieldContainer->getMesh(),
+                              isFirstRepartition);
+
+    const value_type imbalanceAfter = maxParticleDeviationFraction(particleContainer);
+    EXPECT_EQ(globalParticleCount(particleContainer), nGlobal);
+    EXPECT_LT(imbalanceAfter, imbalanceBefore);
+    EXPECT_LT(imbalanceAfter, 0.10);
+
+    auto& femSolver = std::get<FEMSolver_t<value_type, Dim>>(fieldSolver->getSolver());
+    auto& space     = femSolver.getSpace();
+    fieldContainer->getRho() = 0.0;
+    femSolver.setRhs(fieldContainer->getRho());
+
+    fieldContainer->getPhi() = 1.0;
+    fieldContainer->getPhi().fillHalo();
+
+    using fem_solver_type = FEMSolver_t<value_type, Dim>;
+    using lagrange_type   = typename fem_solver_type::LagrangeType;
+    using element_type    = typename fem_solver_type::ElementType;
+
+    element_type refElement;
+    const Vector_t<size_t, Dim> zeroNdIndex(0);
+    const auto firstElementVertexPoints = space.getElementMeshVertexPoints(zeroNdIndex);
+    const Vector_t<value_type, Dim> DPhiInvT =
+        refElement.getInverseTransposeTransformationJacobian(firstElementVertexPoints);
+    const value_type absDetDPhi = Kokkos::abs(
+        refElement.getDeterminantOfTransformationJacobian(firstElementVertexPoints));
+    ippl::EvalFunctor<value_type, Dim, lagrange_type::numElementDOFs> poissonEquationEval(
+        DPhiInvT, absDetDPhi);
+
+    auto ax = space.evaluateAx(fieldContainer->getPhi(), poissonEquationEval);
+    ax.fillHalo();
+
+    EXPECT_EQ(maxExtentMismatch(ax), 0);
+    EXPECT_TRUE(std::isfinite(ax.sum()));
+}
+
+int main(int argc, char* argv[]) {
+    int success = 1;
+    ippl::initialize(argc, argv);
+    {
+        ::testing::InitGoogleTest(&argc, argv);
+        success = RUN_ALL_TESTS();
+    }
+    ippl::finalize();
+    return success;
+}

--- a/unit_tests/PIC/LoadBalancer.cpp
+++ b/unit_tests/PIC/LoadBalancer.cpp
@@ -13,6 +13,18 @@
 #include "TestUtils.h"
 #include "gtest/gtest.h"
 
+/**
+ * @file LoadBalancer.cpp
+ * @brief Regression test for PIC load balancing with FEM field-operator reinitialization.
+ *
+ * This test creates a deliberately imbalanced particle distribution, triggers ORB-based
+ * repartitioning, and then verifies two invariants:
+ * - particle migration preserves the total particle count and reduces the imbalance
+ * - the FEM operator can be reinitialized on the new layout without stale field extents
+ *
+ * The second check targets the issue fixed in #485, where repartitioned FEM workspaces could
+ * retain the old layout and cause later operator application to use mismatched local extents.
+ */
 const char* TestName = "LoadBalancerRegression";
 
 namespace {
@@ -48,6 +60,13 @@ namespace {
         return globalParticles;
     }
 
+    /**
+     * @brief Return the maximum local-view extent mismatch after repartition.
+     *
+     * For each dimension this compares the actual Kokkos view extent against the extent implied
+     * by the current local domain and ghost width. A nonzero result indicates that a field view
+     * still reflects an old layout.
+     */
     template <typename Field>
     int maxExtentMismatch(Field& field) {
         constexpr unsigned Dim = Field::dim;
@@ -68,6 +87,18 @@ namespace {
     }
 }  // namespace
 
+/**
+ * @brief Rebalance an artificial particle pile-up and verify FEM operator reinitialization.
+ *
+ * The particle cloud is biased toward low x by sampling x = u^2 with u uniformly distributed
+ * on [0,1], while y and z remain uniform. This creates a reproducible but still smooth load
+ * imbalance that ORB can rebalance on the fixed 17^3 mesh.
+ *
+ * After repartition the test does not run a full physics solve. Instead, it forces the FEM
+ * solver to rebuild its state for the redistributed layout and directly applies evaluateAx()
+ * to a constant field. The returned field must have extents consistent with the new layout on
+ * every rank. That is the specific regression guard for the stale-workspace bug from #485.
+ */
 TEST(LoadBalancer, RebalancesArtificialPileUpAndReinitializesFEMOperator) {
     constexpr unsigned Dim      = 3;
     using value_type            = double;


### PR DESCRIPTION
This PR fixes the FEM load-balancing failure, in collaboration with Hugo

closing #485.

The real problem was stale FEM field state after repartition. When Alpine triggered load balancing, the
solver called LagrangeSpace::initialize(mesh, layout) again, but the internal FEM workspace field resultField in src/FEM/LagrangeSpace.hpp was only passed through initialize(...). Since Field::initialize() is one-shot, that call became a no-op after the first setup, so resultField kept the old layout and old extents after repartition. The next evaluateAx() then operated on a workspace that no longer matched the redistributed domain decomposition, which explains the failed warmup solve, the huge t=0 field energy, and the later halo/exchange crashes.

The fix is to explicitly resize that workspace on every FEM reinitialization:

  - in src/FEM/LagrangeSpace.hpp, resultField.updateLayout(layout) is now called in both layout-aware initialization paths, so the workspace is always rebuilt to the current repartitioned layout
  - in alpine/LoadBalancer.hpp, rho_m->setFieldBC(rho_m->getFieldBC()) is called after rho_m.updateLayout(*fl) so periodic BC neighbor metadata is refreshed for the redistributed density field

**Behavior After This Change**

  With this patch, the reduced FEM load-balanced runs no longer exhibit the old failure mode:

  - no operator extent mismatch
  - no 1000-iteration warmup stall
  - no t=0 energy blow-up by orders of magnitude
  - no follow-on halo corruption from stale FEM workspace state

This should not change the intended FEM discretization, conservation properties, or solver formulation. It is a state-management fix after repartition, not a numerical algorithm change. The floating-point path should follow the same correct code path as before load balancing; the difference is that the redistributed layout is now actually propagated into the FEM workspace and refreshed BC metadata.

**Validation**

  I validated the fix in two stages.

  Local reduced 2-rank CPU case:

  - control FEM 1.0: t=0 Ex = 9.9526424907379614
  - load-balanced FEM 0.01: t=0 Ex = 9.9532389888656407

  A100 2-GPU reduced case on Merlin:

  - control FEM 1.0: t=0 Ex = 9.3334714317865917, CG entries 0,23 then 0,12
  - load-balanced FEM 0.01: t=0 Ex = 9.3018131240904989, CG entries 0,23 then 0,19
