### PR TITLE
Add arguments to tests in test/solver, and set some compile only

### DIFF
--- a/test/maxwell/CMakeLists.txt
+++ b/test/maxwell/CMakeLists.txt
@@ -57,22 +57,14 @@ if(NOT TARGET stb_image_write::impl)
             $<$<CXX_COMPILER_ID:MSVC>:/wd4351>)
 endif()
 
-if(IPPL_ENABLE_FFT)
-  # cmake-format: off
-  add_ippl_integration_test(TestStandardFDTDSolver LINK_LIBS stb_image_write::impl LABELS solver
-                            integration)
+# cmake-format: off
 
-  add_ippl_integration_test(TestNonStandardFDTDSolver LINK_LIBS stb_image_write::impl LABELS solver
-                            integration)
-
-  add_ippl_integration_test(TestStandardFDTDSolver_convergence 
-    COMPILE_ONLY
-    LINK_LIBS stb_image_write::impl
-    LABELS solver integration)
-
-  add_ippl_integration_test(TestNonStandardFDTDSolver_convergence LINK_LIBS stb_image_write::header
-                            LABELS solver integration)
-  # cmake-format: on
-else()
-  message(STATUS "⚠️ FFT disabled; skipping Maxwell FDTD integration tests.")
-endif()
+# compile only
+add_ippl_integration_test(TestStandardFDTDSolver COMPILE_ONLY LINK_LIBS stb_image_write::impl 
+                          LABELS solver integration)
+add_ippl_integration_test(TestNonStandardFDTDSolver COMPILE_ONLY LINK_LIBS stb_image_write::impl 
+                          LABELS solver integration)
+add_ippl_integration_test(TestStandardFDTDSolver_convergence COMPILE_ONLY 
+                          LINK_LIBS stb_image_write::impl LABELS solver integration)
+add_ippl_integration_test(TestNonStandardFDTDSolver_convergence COMPILE_ONLY
+                          LINK_LIBS stb_image_write::header LABELS solver integration)

--- a/test/solver/CMakeLists.txt
+++ b/test/solver/CMakeLists.txt
@@ -7,13 +7,11 @@
 file(RELATIVE_PATH _relPath "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "🔧 Adding solver integration tests from: ${_relPath}")
 
-# tests solver design
-add_ippl_integration_test(TestSolverDesign LABELS solver integration)
-
 # tests the CG solver
 add_ippl_integration_test(TestCGSolver ARGS 4 j LABELS solver integration)
 
 # compile only
+add_ippl_integration_test(TestSolverDesign COMPILE_ONLY LABELS solver integration)
 add_ippl_integration_test(TestCGSolver_convergence COMPILE_ONLY LABELS solver integration)
 
 if(IPPL_ENABLE_FFT)

--- a/test/solver/CMakeLists.txt
+++ b/test/solver/CMakeLists.txt
@@ -7,16 +7,29 @@
 file(RELATIVE_PATH _relPath "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "🔧 Adding solver integration tests from: ${_relPath}")
 
+# tests solver design
 add_ippl_integration_test(TestSolverDesign LABELS solver integration)
-add_ippl_integration_test(TestCGSolver LABELS solver integration)
+
+# tests the CG solver
+add_ippl_integration_test(TestCGSolver ARGS 4 j LABELS solver integration)
+
+# compile only
+add_ippl_integration_test(TestCGSolver_convergence COMPILE_ONLY LABELS solver integration)
 
 if(IPPL_ENABLE_FFT)
-  add_ippl_integration_test(TestGaussian_convergence LABELS solver integration)
-  add_ippl_integration_test(TestSphere LABELS solver integration)
-  add_ippl_integration_test(Budiardja_plot LABELS solver integration)
-  add_ippl_integration_test(TestGaussian LABELS solver integration)
+  # tests FFTPeriodicPoissonSolver
   add_ippl_integration_test(TestFFTPeriodicPoissonSolver LABELS solver integration)
-  add_ippl_integration_test(TestGaussian_biharmonic LABELS solver integration TIMEOUT 120)
-  add_ippl_integration_test(TestGaussian_hessian LABELS solver integration)
-  add_ippl_integration_test(TestFFTTruncatedGreenPeriodicPoissonSolver LABELS solver integration)
+
+  # tests FFTOpenPoissonSolver
+  add_ippl_integration_test(TestGaussian ARGS 16 16 16 pencils a2a no-reorder HOCKNEY LABELS solver integration)
+
+  # tests the FFTTruncatedGreenPeriodicPoissonSolver
+  add_ippl_integration_test(TestFFTTruncatedGreenPeriodicPoissonSolver ARGS 16 16 16 LABELS solver integration)
+
+  # compile only
+  add_ippl_integration_test(TestGaussian_convergence COMPILE_ONLY LABELS solver integration)
+  add_ippl_integration_test(TestSphere COMPILE_ONLY LABELS solver integration)
+  add_ippl_integration_test(Budiardja_plot COMPILE_ONLY LABELS solver integration)
+  add_ippl_integration_test(TestGaussian_biharmonic COMPILE_ONLY LABELS solver integration TIMEOUT 120)
+  add_ippl_integration_test(TestGaussian_hessian COMPILE_ONLY LABELS solver integration)
 endif()

--- a/test/solver/fem/CMakeLists.txt
+++ b/test/solver/fem/CMakeLists.txt
@@ -10,24 +10,29 @@ message(STATUS "🔧 Adding FEM solver integration tests from: ${_relPath}")
 # cmake-format: off
 
 # ----------------------------------------------------------------------------
-# one dimensional periodic BC tests
+# one dimensional Zero BC tests
 add_ippl_integration_test(TestZeroBC_sin 
     ARGS 1 LABELS solver fem integration)
 add_ippl_integration_test(TestZeroBC_sin_preconditioned 
     ARGS 1 LABELS solver fem integration)
 
-# two dimensional BC tests
-add_ippl_integration_test(TestMaxwellDiffusionPolyZeroBC 
-    ARGS 2 COMPILE_ONLY LABELS solver fem integration)
-
-# ----------------------------------------------------------------------------
-# tests we won't run, but compile only
+# one dimensional Periodic BC tests
 add_ippl_integration_test(TestPeriodicBC_sin 
     ARGS 1 LABELS solver fem integration TIMEOUT 60)
 add_ippl_integration_test(TestPeriodicBC_sin_preconditioned 
     ARGS 1 LABELS solver fem integration TIMEOUT 60)
+
+# one dimensional Non-homogeneous Dirichlet BC tests
+add_ippl_integration_test(TestNonhomDirichlet_1d 
+    LABELS solver fem integration)
+add_ippl_integration_test(TestNonhomDirichlet_1d_preconditioned 
+    LABELS solver fem integration)
+
+# ----------------------------------------------------------------------------
+# Compile only (no testing)
+
 add_ippl_integration_test(TestPeriodicBC_sinsin 
-    ARGS 1 LABELS solver fem integration TIMEOUT 60)
+    COMPILE_ONLY LABELS solver fem integration)
 
 add_ippl_integration_test(TestZeroBC_constant1d 
     COMPILE_ONLY LABELS solver fem integration)
@@ -38,13 +43,9 @@ add_ippl_integration_test(TestZeroBC_polynomial2d
 add_ippl_integration_test(TestZeroBC_polynomial2d_preconditioned 
     COMPILE_ONLY LABELS solver fem integration)
 
-add_ippl_integration_test(TestNonhomDirichlet_1d 
-    COMPILE_ONLY LABELS solver fem integration)
 add_ippl_integration_test(TestNonhomDirichlet_2d 
     COMPILE_ONLY LABELS solver fem integration)
 add_ippl_integration_test(TestNonhomDirichlet_3d 
-    COMPILE_ONLY LABELS solver fem integration)
-add_ippl_integration_test(TestNonhomDirichlet_1d_preconditioned 
     COMPILE_ONLY LABELS solver fem integration)
 add_ippl_integration_test(TestNonhomDirichlet_2d_preconditioned 
     COMPILE_ONLY LABELS solver fem integration)
@@ -58,6 +59,8 @@ add_ippl_integration_test(TestScaling_ZeroBC_sin
 add_ippl_integration_test(TestScaling_PeriodicBC_sinsin 
     COMPILE_ONLY LABELS solver fem integration)
 
+add_ippl_integration_test(TestMaxwellDiffusionPolyZeroBC 
+    COMPILE_ONLY LABELS solver fem integration)
 add_ippl_integration_test(TestMaxwellDiffusionZeroBC 
     COMPILE_ONLY LABELS solver fem integration)
 add_ippl_integration_test(TestMaxwellDiffusionPolyZeroBCTimed 


### PR DESCRIPTION
There are some tests which are being run in the CI from test/solver, which are failing because they are run without arguments. While initially these tests were not meant to be tested in CI, as they are not unit tests, I have now added a few to be run in the CI (small tests e.g. 1D only), with arguments, and marked all others as compile only. Hopefully this removes them from the failing tests in the CI. 