### PR TITLE
Fix load balancing with FEM

### DIFF
--- a/alpine/LoadBalancer.hpp
+++ b/alpine/LoadBalancer.hpp
@@ -59,17 +59,22 @@ public:
         (*E_m).updateLayout(*fl);
         (*rho_m).updateLayout(*fl);
 
-        if (fs_m->getStype() == "CG" || fs_m->getStype() == "PCG") {
-            phi_m->updateLayout(*fl);
-            phi_m->setFieldBC(phi_m->getFieldBC());
-        } else if (fs_m->getStype() == "FEM" || fs_m->getStype() == "FEM_PRECON") {
+        if (fs_m->getStype() == "CG" || fs_m->getStype() == "PCG" || fs_m->getStype() == "FEM" ||
+            fs_m->getStype() == "FEM_PRECON") {
             phi_m->updateLayout(*fl);
             phi_m->setFieldBC(phi_m->getFieldBC());
 
-            // also update the layout in the FEM space
-            auto* solver = dynamic_cast<FieldSolver_t*>(this->fsolver_m.get());
-            auto& space = solver->getSpace();
-            space.updateLayout(*fl);
+            if (fs_m->getStype() == "FEM") {
+                // also update the layout in the FEM space
+                auto& space = std::get<FEMSolver_t<T, Dim>>(fs_m->getSolver()).getSpace();
+                space.updateLayout(*fl);
+            } 
+
+            if (fs_m->getStype() == "FEM_PRECON") {
+                // also update the layout in the FEM space
+                auto& space = std::get<FEMPreconSolver_t<T, Dim>>(fs_m->getSolver()).getSpace();
+                space.updateLayout(*fl);
+            } 
         }
 
         // Update layout with new FieldLayout

--- a/alpine/LoadBalancer.hpp
+++ b/alpine/LoadBalancer.hpp
@@ -59,10 +59,17 @@ public:
         (*E_m).updateLayout(*fl);
         (*rho_m).updateLayout(*fl);
 
-        if (fs_m->getStype() == "CG" || fs_m->getStype() == "PCG" || fs_m->getStype() == "FEM" ||
-            fs_m->getStype() == "FEM_PRECON") {
+        if (fs_m->getStype() == "CG" || fs_m->getStype() == "PCG") {
             phi_m->updateLayout(*fl);
             phi_m->setFieldBC(phi_m->getFieldBC());
+        } else if (fs_m->getStype() == "FEM" || fs_m->getStype() == "FEM_PRECON") {
+            phi_m->updateLayout(*fl);
+            phi_m->setFieldBC(phi_m->getFieldBC());
+
+            // also update the layout in the FEM space
+            auto* solver = dynamic_cast<FieldSolver_t*>(this->fsolver_m.get());
+            auto& space = solver->getSpace();
+            space.updateLayout(*fl);
         }
 
         // Update layout with new FieldLayout

--- a/src/FEM/LagrangeSpace.h
+++ b/src/FEM/LagrangeSpace.h
@@ -110,6 +110,14 @@ namespace ippl {
          */
         void initializeElementIndices(Layout_t& layout);
 
+        ///////////////////////////////////////////////////////////////////////
+        /**
+         * @brief Function to update the element partition and the layout of 
+         * fields in the LagrangeSpace if the layout has been changed during
+         * the simulation (for example by the load balancer).
+         */
+        void updateLayout(Layout_t& layout);
+
         /// Degree of Freedom operations //////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////
 

--- a/src/FEM/LagrangeSpace.hpp
+++ b/src/FEM/LagrangeSpace.hpp
@@ -106,6 +106,17 @@ namespace ippl {
             });
     }
 
+    // Update resultField and elementIndices according to changed domain decomposition.
+    template <typename T, unsigned Dim, unsigned Order, typename ElementType,
+              typename QuadratureType, typename FieldLHS, typename FieldRHS>
+    void LagrangeSpace<T, Dim, Order, ElementType, QuadratureType, FieldLHS,
+                       FieldRHS>::updateLayout(Layout_t& layout) {
+        // repartition elements
+        initializeElementIndices(layout);
+        // update layout of resultField member variable
+        resultField.updateLayout(layout);
+    }
+
     ///////////////////////////////////////////////////////////////////////
     /// Degree of Freedom operations //////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This closes #485

The issue is that after load balancing, the FEM space used by the solver does not update its partitioning of the element indices among ranks according to the new domain decomposition, and the member variable resultField_m also needs to update its layout. 

This issue was correctly identified by the AI tool Hugo in #487, but not properly fixed (fixed the symptom instead of the cause). 

To fix this properly, a new `updateLayout` member function is introduced in the LagrangeSpace, which is called by the LoadBalancer in alpine if using the FEM solver, in the same way that the `updateLayout` of the fields works in the LoadBalancer. This means that every time load balancing is done and the domain decomposition changes, the LagrangeSpace takes the new domain decomposition into account and repartitions the elements too. 