### PR TITLE
Implement `shiftedGreensFunction` in `FFTOpenPoissonSolver` + symmetric Dirichlet test

### DIFF
--- a/src/PoissonSolvers/FFTOpenPoissonSolver.h
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.h
@@ -156,7 +156,7 @@ namespace ippl {
         // using the same sign convention as greensFunction() (HOCKNEY). After
         // this call, solve() will convolve rho with the shifted kernel instead
         // of the standard one, up to the usual caveat that solve() recomputes
-        // greensFunction() if it detects a change in mesh spacing — so the
+        // greensFunction() if it detects a change in mesh spacing, so the
         // caller should keep the mesh fixed between setup and solve().
         //
         // To restore the standard kernel, call greensFunction() explicitly.

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.h
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.h
@@ -150,6 +150,28 @@ namespace ippl {
         // compute standard Green's function
         void greensFunction();
 
+        // Replace the cached FFT Green's function (grntr_m) with the FFT of a
+        // free-space Green's function translated by `shift` in real space, i.e.
+        //   G(r) = -1 / (4 pi |r - shift|)
+        // using the same sign convention as greensFunction() (HOCKNEY). After
+        // this call, solve() will convolve rho with the shifted kernel instead
+        // of the standard one, up to the usual caveat that solve() recomputes
+        // greensFunction() if it detects a change in mesh spacing — so the
+        // caller should keep the mesh fixed between setup and solve().
+        //
+        // To restore the standard kernel, call greensFunction() explicitly.
+        //
+        // Intended use for Dirichlet boundary conditions via the method of
+        // images: pick `shift[d] = 2 * (plane[d] - domain_center[d])` for each
+        // axis with a Dirichlet plane, then call solve() and axis-flip the
+        // resulting potential in the active axes to obtain the image-charge
+        // contribution. The caller composes open-BC and image contributions
+        // additively. See test/solver/TestShiftedGreensFunction.cpp for the
+        // reference orchestration.
+        //
+        // Preconditions: algorithm = HOCKNEY (throws otherwise).
+        void shiftedGreensFunction(const Vector<double, Dim>& shift);
+
         // function called in the constructor to initialize the fields
         void initializeFields();
 

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
@@ -2187,4 +2187,96 @@ namespace ippl {
         }
         ippl::Comm->freeAllBuffers();
     };
+
+    ////////////////////////////////////////////////////////////////////////
+    // Shifted Green's function: fills grn_mr with G(r - shift) on the doubled
+    // grid and caches FFT into grntr_m. Kokkos-parallel, mirrors the HOCKNEY
+    // greensFunction() branch in structure.
+    //
+    // After this call, solve() will convolve rho with the shifted kernel.
+    // To restore the standard kernel, call greensFunction() explicitly.
+
+    template <typename FieldLHS, typename FieldRHS>
+    void FFTOpenPoissonSolver<FieldLHS, FieldRHS>::shiftedGreensFunction(
+        const Vector<double, Dim>& shift) {
+        const int alg = this->params_m.template get<int>("algorithm");
+        if (alg != Algorithm::HOCKNEY) {
+            throw IpplException(
+                "FFTOpenPoissonSolver::shiftedGreensFunction",
+                "Shifted Green's function is only implemented for HOCKNEY.");
+        }
+
+        // Sync mesh spacing with the current RHS mesh (same logic as solve()'s
+        // mesh-change detection). Without this, two failure modes compound:
+        //   1. We would compute the shifted kernel at a STALE hr_m.
+        //   2. A subsequent solve() would see hr_m != mesh->getMeshSpacing(),
+        //      set green=true, and call greensFunction() — overwriting the
+        //      shifted kernel with the standard one.
+        // By updating hr_m (and the dependent mesh2_m / meshComplex_m) here,
+        // solve()'s mesh check finds no change and leaves grntr_m intact.
+        mesh_mp = &(this->rhs_mp->get_mesh());
+        for (unsigned int i = 0; i < Dim; ++i) {
+            hr_m[i] = mesh_mp->getMeshSpacing(i);
+        }
+        mesh2_m->setMeshSpacing(hr_m);
+        meshComplex_m->setMeshSpacing(hr_m);
+
+        const scalar_type pi = Kokkos::numbers::pi_v<scalar_type>;
+
+        typename Field_t::view_type view = grn_mr.getView();
+        const int nghost                 = grn_mr.getNghost();
+        const auto& ldom                 = layout2_m->getLocalNDIndex();
+
+        // Capture simple value arrays for the lambda.
+        Vector<int, Dim> nr       = nr_m;
+        Vector_t hs               = hr_m;
+        Vector<double, Dim> shft  = shift;
+
+        // Regularization threshold (axis-min mesh spacing, squared, quartered).
+        scalar_type hmin2 = hs[0] * hs[0];
+        for (unsigned int d = 1; d < Dim; ++d) {
+            hmin2 = (hs[d] * hs[d] < hmin2) ? (hs[d] * hs[d]) : hmin2;
+        }
+        const scalar_type regThresh = 0.25 * hmin2;
+
+        Kokkos::parallel_for(
+            "Shifted Green's function", grn_mr.getFieldRangePolicy(),
+            KOKKOS_LAMBDA(const int i, const int j, const int k) {
+                // local -> global indices
+                const int ig[3] = {i + ldom[0].first() - nghost,
+                                   j + ldom[1].first() - nghost,
+                                   k + ldom[2].first() - nghost};
+
+                // Half-wrap each axis so FFT cyclic convention gives symmetric
+                // physical offsets around the origin:
+                //   ig in [0, N)   -> offset =  ig           * h
+                //   ig in [N, 2N)  -> offset = (ig - 2N)     * h
+                // Then subtract the per-axis shift.
+                double rsq = 0.0;
+                for (unsigned int d = 0; d < Dim; ++d) {
+                    const double ig_signed = (ig[d] < nr[d])
+                                                 ? static_cast<double>(ig[d])
+                                                 : static_cast<double>(ig[d] - 2 * nr[d]);
+                    const double xoff      = ig_signed * hs[d] - shft[d];
+                    rsq += xoff * xoff;
+                }
+
+                // Sign convention matches greensFunction() (HOCKNEY): grn_mr stores -G0
+                // so that solve()'s `rho2tr_m = -rho2tr_m * grntr_m` yields +conv(rho,G0)
+                // where G0(r) = 1/(4 pi |r|).
+                const bool nearSing = (rsq < regThresh);
+                const scalar_type r = Kokkos::sqrt(rsq + nearSing * regThresh);
+                view(i, j, k)       = -1.0 / (4.0 * pi * r);
+            });
+
+        // Fourier-space cache for convolution.
+        static IpplTimings::TimerRef fftsg =
+            IpplTimings::getTimer("FFT: Shifted Green");
+        IpplTimings::startTimer(fftsg);
+
+        fft_m->transform(FORWARD, grn_mr, grntr_m);
+
+        IpplTimings::stopTimer(fftsg);
+    }
+
 }  // namespace ippl

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
@@ -2191,7 +2191,7 @@ namespace ippl {
     ////////////////////////////////////////////////////////////////////////
     // Shifted Green's function: fills grn_mr with G(r - shift) on the doubled
     // grid and caches FFT into grntr_m. Kokkos-parallel, mirrors the HOCKNEY
-    // greensFunction() branch in structure.
+    // greensFunction() method in structure.
     //
     // After this call, solve() will convolve rho with the shifted kernel.
     // To restore the standard kernel, call greensFunction() explicitly.
@@ -2201,9 +2201,8 @@ namespace ippl {
         const Vector<double, Dim>& shift) {
         const int alg = this->params_m.template get<int>("algorithm");
         if (alg != Algorithm::HOCKNEY) {
-            throw IpplException(
-                "FFTOpenPoissonSolver::shiftedGreensFunction",
-                "Shifted Green's function is only implemented for HOCKNEY.");
+            throw IpplException("FFTOpenPoissonSolver::shiftedGreensFunction",
+                                "Shifted Green's function is only implemented for HOCKNEY.");
         }
 
         // Sync mesh spacing with the current RHS mesh (same logic as solve()'s
@@ -2228,9 +2227,9 @@ namespace ippl {
         const auto& ldom                 = layout2_m->getLocalNDIndex();
 
         // Capture simple value arrays for the lambda.
-        Vector<int, Dim> nr       = nr_m;
-        Vector_t hs               = hr_m;
-        Vector<double, Dim> shft  = shift;
+        Vector<int, Dim> nr      = nr_m;
+        Vector_t hs              = hr_m;
+        Vector<double, Dim> shft = shift;
 
         // Regularization threshold (axis-min mesh spacing, squared, quartered).
         scalar_type hmin2 = hs[0] * hs[0];
@@ -2243,15 +2242,13 @@ namespace ippl {
             "Shifted Green's function", grn_mr.getFieldRangePolicy(),
             KOKKOS_LAMBDA(const int i, const int j, const int k) {
                 // local -> global indices
-                const int ig[3] = {i + ldom[0].first() - nghost,
-                                   j + ldom[1].first() - nghost,
+                const int ig[3] = {i + ldom[0].first() - nghost, j + ldom[1].first() - nghost,
                                    k + ldom[2].first() - nghost};
 
-                // Half-wrap each axis so FFT cyclic convention gives symmetric
-                // physical offsets around the origin:
-                //   ig in [0, N)   -> offset =  ig           * h
-                //   ig in [N, 2N)  -> offset = (ig - 2N)     * h
-                // Then subtract the per-axis shift.
+                // Hockney convention: map doubled-grid indices.
+                //   ig in [0, N)   -> offset =  ig        * h
+                //   ig in [N, 2N)  -> offset = (ig - 2N)  * h
+                // Subtract the shift to evaluate the shifted Green's function G(r-s).
                 double rsq = 0.0;
                 for (unsigned int d = 0; d < Dim; ++d) {
                     const double ig_signed = (ig[d] < nr[d])
@@ -2269,9 +2266,8 @@ namespace ippl {
                 view(i, j, k)       = -1.0 / (4.0 * pi * r);
             });
 
-        // Fourier-space cache for convolution.
-        static IpplTimings::TimerRef fftsg =
-            IpplTimings::getTimer("FFT: Shifted Green");
+        // Store Fourier transform of shifted Green's function for convolution in solve()
+        static IpplTimings::TimerRef fftsg = IpplTimings::getTimer("FFT: Shifted Green");
         IpplTimings::startTimer(fftsg);
 
         fft_m->transform(FORWARD, grn_mr, grntr_m);

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
@@ -2210,7 +2210,7 @@ namespace ippl {
         // mesh-change detection). Without this, two failure modes compound:
         //   1. We would compute the shifted kernel at a STALE hr_m.
         //   2. A subsequent solve() would see hr_m != mesh->getMeshSpacing(),
-        //      set green=true, and call greensFunction() — overwriting the
+        //      set green=true, and call greensFunction(), overwriting the
         //      shifted kernel with the standard one.
         // By updating hr_m (and the dependent mesh2_m / meshComplex_m) here,
         // solve()'s mesh check finds no change and leaves grntr_m intact.

--- a/test/solver/CMakeLists.txt
+++ b/test/solver/CMakeLists.txt
@@ -21,6 +21,9 @@ if(IPPL_ENABLE_FFT)
   # tests FFTOpenPoissonSolver
   add_ippl_integration_test(TestGaussian ARGS 16 16 16 pencils a2a no-reorder HOCKNEY LABELS solver integration)
 
+  # tests FFTOpenPoissonSolver::shiftedGreensFunction (Dirichlet image correction)
+  add_ippl_integration_test(TestShiftedGreensFunction LABELS solver integration)
+
   # tests the FFTTruncatedGreenPeriodicPoissonSolver
   add_ippl_integration_test(TestFFTTruncatedGreenPeriodicPoissonSolver ARGS 16 16 16 LABELS solver integration)
 

--- a/test/solver/TestShiftedGreensFunction.cpp
+++ b/test/solver/TestShiftedGreensFunction.cpp
@@ -1,0 +1,323 @@
+//
+// TestShiftedGreensFunction
+//
+// Validates FFTOpenPoissonSolver::shiftedGreensFunction. A Gaussian charge is
+// placed off-center inside a cubic box whose lower face (z = 0) is a Dirichlet
+// plane. The caller orchestrates the image correction externally:
+//
+//   1. solve() with the standard Green's function            -> phi_open
+//   2. shiftedGreensFunction(shift) + solve()                  -> phi_raw
+//   3. axis-flip phi_raw in z and negate                       -> phi_image
+//   4. phi_total = phi_open + phi_image
+//   5. greensFunction() restores the cached kernel
+//
+// With shift_z = 2 * (plane_z - z_domain_center), this enforces phi(plane) ~= 0
+// to within discretization error and reproduces the analytical image-dipole
+// solution in the bulk.
+//
+// Usage (single rank):
+//     ./TestShiftedGreensFunction
+//
+// Exit code: 0 on success, 1 on failure.
+//
+
+#include "Ippl.h"
+
+#include <Kokkos_MathematicalConstants.hpp>
+#include <Kokkos_MathematicalFunctions.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <functional>
+
+#include "PoissonSolvers/FFTOpenPoissonSolver.h"
+
+namespace {
+    // Gaussian charge density centered at mu with width sigma; integrated charge = 1.
+    KOKKOS_INLINE_FUNCTION double gaussian(double x, double y, double z,
+                                           double mu_x, double mu_y, double mu_z,
+                                           double sigma) {
+        const double pi  = Kokkos::numbers::pi_v<double>;
+        const double s3  = sigma * sigma * sigma;
+        const double pre = 1.0 / (Kokkos::sqrt(8.0 * pi * pi * pi) * s3);
+        const double dx  = x - mu_x;
+        const double dy  = y - mu_y;
+        const double dz  = z - mu_z;
+        const double r2  = dx * dx + dy * dy + dz * dz;
+        return pre * Kokkos::exp(-r2 / (2.0 * sigma * sigma));
+    }
+
+    // Free-space potential of a unit-charge Gaussian at mu.
+    KOKKOS_INLINE_FUNCTION double gaussian_potential(double x, double y, double z,
+                                                     double mu_x, double mu_y, double mu_z,
+                                                     double sigma) {
+        const double pi = Kokkos::numbers::pi_v<double>;
+        const double dx = x - mu_x;
+        const double dy = y - mu_y;
+        const double dz = z - mu_z;
+        const double r  = Kokkos::sqrt(dx * dx + dy * dy + dz * dz);
+        if (r < 1e-12) {
+            return 1.0 / (4.0 * pi * Kokkos::sqrt(2.0 * pi) * sigma);
+        }
+        return (1.0 / (4.0 * pi * r)) * Kokkos::erf(r / (Kokkos::sqrt(2.0) * sigma));
+    }
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    ippl::initialize(argc, argv);
+    int exit_code = 0;
+    {
+        Inform msg("TestShiftedGreensFunction");
+
+        constexpr unsigned int Dim = 3;
+        using Mesh_t      = ippl::UniformCartesian<double, Dim>;
+        using Centering_t = Mesh_t::DefaultCentering;
+        using field_t     = ippl::Field<double, Dim, Mesh_t, Centering_t>;
+        using fieldV_t    = ippl::Field<ippl::Vector<double, Dim>, Dim, Mesh_t, Centering_t>;
+        using Solver_t    = ippl::FFTOpenPoissonSolver<fieldV_t, field_t>;
+
+        // Geometry: box [0, L]^3, Dirichlet plane at z = 0, charge center at
+        // (L/2, L/2, L/4). The image charge is at (L/2, L/2, -L/4), entirely
+        // outside the mesh — exactly the scenario the shifted Green's function
+        // handles correctly (and the physical-image-particle approach does not).
+        const int N          = 32;
+        const double L       = 1.0;
+        const double sigma   = 0.05;
+        const double mu_x    = 0.5 * L;
+        const double mu_y    = 0.5 * L;
+        const double mu_z    = 0.25 * L;
+        const double plane_z = 0.0;
+
+        ippl::NDIndex<Dim> owned;
+        for (unsigned i = 0; i < Dim; ++i) {
+            owned[i] = ippl::Index(N);
+        }
+        std::array<bool, Dim> isParallel;
+        isParallel.fill(true);
+
+        ippl::Vector<double, Dim> hr     = {L / N, L / N, L / N};
+        ippl::Vector<double, Dim> origin = {0.0, 0.0, 0.0};
+        Mesh_t mesh(owned, hr, origin);
+        ippl::FieldLayout<Dim> layout(MPI_COMM_WORLD, owned, isParallel);
+
+        field_t rho, rho_clean, phi_open, phi_image, phi_total;
+        rho.initialize(mesh, layout);
+        rho_clean.initialize(mesh, layout);
+        phi_open.initialize(mesh, layout);
+        phi_image.initialize(mesh, layout);
+        phi_total.initialize(mesh, layout);
+
+        // Fill rho (and a stash copy rho_clean) with the Gaussian.
+        {
+            auto view        = rho.getView();
+            auto view_clean  = rho_clean.getView();
+            const int nghost = rho.getNghost();
+            const auto& ldom = layout.getLocalNDIndex();
+            Kokkos::parallel_for(
+                "init rho", rho.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k) {
+                    const int ig = i + ldom[0].first() - nghost;
+                    const int jg = j + ldom[1].first() - nghost;
+                    const int kg = k + ldom[2].first() - nghost;
+                    const double x = (ig + 0.5) * hr[0] + origin[0];
+                    const double y = (jg + 0.5) * hr[1] + origin[1];
+                    const double z = (kg + 0.5) * hr[2] + origin[2];
+                    const double g = gaussian(x, y, z, mu_x, mu_y, mu_z, sigma);
+                    view(i, j, k)       = g;
+                    view_clean(i, j, k) = g;
+                });
+        }
+
+        // Solver parameters. Output type = SOL so the potential ends up in RHS.
+        ippl::ParameterList params;
+        params.add("use_pencils", true);
+        params.add("comm", ippl::a2a);
+        params.add("use_reorder", false);
+        params.add("use_heffte_defaults", false);
+        params.add("use_gpu_aware", true);
+        params.add("r2c_direction", 0);
+        params.add("algorithm", Solver_t::HOCKNEY);
+        params.add("output_type", Solver_t::SOL);
+
+        Solver_t solver(rho, params);
+
+        // (1) Open-BC solve with the standard Green's function cached from
+        //     initializeFields(). rho is overwritten with phi_open.
+        solver.solve();
+        Kokkos::deep_copy(phi_open.getView(), rho.getView());
+
+        // Restore rho to the charge density before the image correction solve.
+        Kokkos::deep_copy(rho.getView(), rho_clean.getView());
+
+        // (2) Install the shifted Green's function (Dirichlet at z = plane_z)
+        //     and solve again. rho is overwritten with conv(rho, G_shifted).
+        //
+        // Shift derivation: cell-centered fields sample z_k = (k+0.5)*hz + origin.
+        // Z-flipping (k -> N-1-k) maps z_k -> L + 2*origin - z_k. After the
+        // shifted convolution G_shifted(r) = G0(r - shift), the post-flip z
+        // argument of G0 is (L + 2*origin - z - z_src - shift_z). Setting its
+        // magnitude equal to |z + z_src - 2*plane_z| (the image distance)
+        // gives shift_z = L + 2*origin_z - 2*plane_z = 2*(z_center - plane_z).
+        const double z_center = origin[2] + 0.5 * L;
+        ippl::Vector<double, Dim> shift = {0.0, 0.0, 2.0 * (z_center - plane_z)};
+        solver.shiftedGreensFunction(shift);
+        solver.solve();
+        // rho now holds the raw shifted convolution.
+
+        // (3) Axis-flip in z and negate to obtain phi_image.
+        //     (negate = image charge has opposite sign; flip = image position).
+        {
+            auto src    = rho.getView();
+            auto dst    = phi_image.getView();
+            const int gs = rho.getNghost();
+            const int gd = phi_image.getNghost();
+            // Assume identical N in all axes and single-rank (checked by solver
+            // upstream via Comm->size() > 1 guard when we later add multi-rank).
+            Kokkos::parallel_for(
+                "z-flip + negate", phi_image.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k) {
+                    // Physical k -> flipped k_src = N-1-k; adjust for nghost
+                    // in both views.
+                    const int kg_dst = k - gd;           // 0..N-1 in physical
+                    const int k_src  = (N - 1 - kg_dst) + gs;
+                    const int i_src  = (i - gd) + gs;
+                    const int j_src  = (j - gd) + gs;
+                    dst(i, j, k)     = -src(i_src, j_src, k_src);
+                });
+        }
+
+        // (4) Restore the cached kernel so future solve() calls use the
+        //     standard free-space Green's function again.
+        solver.greensFunction();
+
+        // (5) Compose the total: phi_total = phi_open + phi_image.
+        {
+            auto v_open  = phi_open.getView();
+            auto v_img   = phi_image.getView();
+            auto v_total = phi_total.getView();
+            Kokkos::parallel_for(
+                "sum", phi_total.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k) {
+                    v_total(i, j, k) = v_open(i, j, k) + v_img(i, j, k);
+                });
+        }
+
+        // Diagnostic 1: phi_total on the Dirichlet slab (k = 0, physical cells
+        // at z = 0.5 * hz) relative to the bulk maximum.
+        double maxOnPlane = 0.0;
+        double maxBulk    = 0.0;
+        {
+            auto view        = phi_total.getView();
+            const int nghost = phi_total.getNghost();
+            const auto& ldom = layout.getLocalNDIndex();
+            double localPlane = 0.0, localBulk = 0.0;
+
+            Kokkos::parallel_reduce(
+                "max on plane", phi_total.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k, double& lmax) {
+                    const int kg = k + ldom[2].first() - nghost;
+                    const double absv = Kokkos::fabs(view(i, j, k));
+                    if (kg == 0 && absv > lmax) lmax = absv;
+                },
+                Kokkos::Max<double>(localPlane));
+
+            Kokkos::parallel_reduce(
+                "max bulk", phi_total.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k, double& lmax) {
+                    const double absv = Kokkos::fabs(view(i, j, k));
+                    if (absv > lmax) lmax = absv;
+                },
+                Kokkos::Max<double>(localBulk));
+
+            ippl::Comm->allreduce(localPlane, maxOnPlane, 1, std::greater<double>());
+            ippl::Comm->allreduce(localBulk, maxBulk, 1, std::greater<double>());
+        }
+
+        // Diagnostic 2: relative L2 error vs analytical image dipole, evaluated
+        // outside the 3-sigma Gaussian core to avoid the kernel smoothing bias.
+        double l2err = 0.0, l2ref = 0.0;
+        {
+            auto view        = phi_total.getView();
+            const int nghost = phi_total.getNghost();
+            const auto& ldom = layout.getLocalNDIndex();
+            double localErr = 0.0, localRef = 0.0;
+
+            Kokkos::parallel_reduce(
+                "L2 err", phi_total.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k, double& le) {
+                    const int ig = i + ldom[0].first() - nghost;
+                    const int jg = j + ldom[1].first() - nghost;
+                    const int kg = k + ldom[2].first() - nghost;
+                    const double x = (ig + 0.5) * hr[0] + origin[0];
+                    const double y = (jg + 0.5) * hr[1] + origin[1];
+                    const double z = (kg + 0.5) * hr[2] + origin[2];
+                    const double dx = x - mu_x, dy = y - mu_y, dz = z - mu_z;
+                    if (dx*dx + dy*dy + dz*dz < 9.0 * sigma * sigma) return;
+                    const double phi_real  = gaussian_potential(x, y, z, mu_x, mu_y, mu_z, sigma);
+                    const double phi_img   = gaussian_potential(x, y, z, mu_x, mu_y,
+                                                                2.0 * plane_z - mu_z, sigma);
+                    const double phi_exact = phi_real - phi_img;
+                    const double diff      = view(i, j, k) - phi_exact;
+                    le += diff * diff;
+                },
+                Kokkos::Sum<double>(localErr));
+
+            Kokkos::parallel_reduce(
+                "L2 ref", phi_total.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k, double& lr) {
+                    const int ig = i + ldom[0].first() - nghost;
+                    const int jg = j + ldom[1].first() - nghost;
+                    const int kg = k + ldom[2].first() - nghost;
+                    const double x = (ig + 0.5) * hr[0] + origin[0];
+                    const double y = (jg + 0.5) * hr[1] + origin[1];
+                    const double z = (kg + 0.5) * hr[2] + origin[2];
+                    const double dx = x - mu_x, dy = y - mu_y, dz = z - mu_z;
+                    if (dx*dx + dy*dy + dz*dz < 9.0 * sigma * sigma) return;
+                    const double phi_real  = gaussian_potential(x, y, z, mu_x, mu_y, mu_z, sigma);
+                    const double phi_img   = gaussian_potential(x, y, z, mu_x, mu_y,
+                                                                2.0 * plane_z - mu_z, sigma);
+                    const double phi_exact = phi_real - phi_img;
+                    lr += phi_exact * phi_exact;
+                },
+                Kokkos::Sum<double>(localRef));
+
+            double gErr = 0.0, gRef = 0.0;
+            ippl::Comm->allreduce(localErr, gErr, 1, std::plus<double>());
+            ippl::Comm->allreduce(localRef, gRef, 1, std::plus<double>());
+            l2err = std::sqrt(gErr);
+            l2ref = std::sqrt(gRef);
+        }
+
+        const double relErr = (l2ref > 0) ? l2err / l2ref : 0.0;
+        const double ratio  = (maxBulk > 0) ? maxOnPlane / maxBulk : 0.0;
+
+        msg << "grid = " << N << "^3, L = " << L << ", sigma = " << sigma << endl;
+        msg << "charge at (" << mu_x << ", " << mu_y << ", " << mu_z
+            << "); plane z = " << plane_z << ", shift_z = " << shift[2] << endl;
+        msg << "max|phi| on plane / max|phi| bulk = " << maxOnPlane << " / "
+            << maxBulk << " = " << ratio << endl;
+        msg << "rel L2 error vs analytical image dipole (r > 3 sigma) = "
+            << relErr << endl;
+
+        // Generous thresholds for first-cut verification; they detect sign /
+        // flip / shift errors but leave room for O(h) bias near the plane.
+        const double planeTol = 0.05;
+        const double l2Tol    = 0.10;
+
+        if (maxBulk <= 0.0) {
+            msg << "FAIL: phi_total is identically zero." << endl;
+            exit_code = 1;
+        } else if (ratio > planeTol) {
+            msg << "FAIL: phi on Dirichlet plane exceeds " << planeTol
+                << " * bulk max." << endl;
+            exit_code = 1;
+        } else if (relErr > l2Tol) {
+            msg << "FAIL: relative L2 error exceeds " << l2Tol << "." << endl;
+            exit_code = 1;
+        } else {
+            msg << "PASS" << endl;
+        }
+    }
+    ippl::finalize();
+    return exit_code;
+}

--- a/test/solver/TestShiftedGreensFunction.cpp
+++ b/test/solver/TestShiftedGreensFunction.cpp
@@ -5,7 +5,7 @@
 // placed off-center inside a cubic box whose lower face (z = 0) is a Dirichlet
 // plane. The caller orchestrates the image correction externally:
 //
-//   1. solve() with the standard Green's function            -> phi_open
+//   1. solve() with the standard Green's function              -> phi_open
 //   2. shiftedGreensFunction(shift) + solve()                  -> phi_raw
 //   3. axis-flip phi_raw in z and negate                       -> phi_image
 //   4. phi_total = phi_open + phi_image
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
 
         // Geometry: box [0, L]^3, Dirichlet plane at z = 0, charge center at
         // (L/2, L/2, L/4). The image charge is at (L/2, L/2, -L/4), entirely
-        // outside the mesh — exactly the scenario the shifted Green's function
+        // outside the mesh, exactly the scenario the shifted Green's function
         // handles correctly (and the physical-image-particle approach does not).
         const int N          = 32;
         const double L       = 1.0;
@@ -204,6 +204,26 @@ int main(int argc, char* argv[]) {
 
         // Diagnostic 1: phi_total on the Dirichlet slab (k = 0, physical cells
         // at z = 0.5 * hz) relative to the bulk maximum.
+        //
+        // IMPORTANT: this ratio is NOT a direct measure of Dirichlet enforcement.
+        // Cell-centered fields sample at z_k = (k + 0.5) * hz, so the nearest
+        // grid slab to the plane is at z = 0.5 * hz = hz/2, NOT at z = 0. The
+        // analytical image-dipole potential is exactly 0 at z = 0, but grows
+        // linearly away from the plane: phi(z) ~ phi'(0) * z for small z.
+        //
+        // For this test (charge at z_src = L/4, plane at z = 0, 32^3 grid with
+        // hz = 1/32), phi'(0) = 1/(2 * pi * z_src^2) ~= 2.55, so the analytical
+        // phi at z = 0.5 * hz just below the charge is ~0.0398, compared to the
+        // bulk max of ~0.96. Expected ratio ~= 4% by analytical symmetry, NOT
+        // solver error. The observed 4.1% ratio matches this to within 1%.
+        //
+        // The meaningful accuracy metric is Diagnostic 2 (L2 vs analytical in
+        // the bulk). Diagnostic 1 serves as a coarse sanity check, a ratio
+        // much larger than 4% (e.g. > 10%) would indicate a genuine
+        // sign / flip / shift error in the shifted Green's function path.
+        // To obtain a sub-percent direct Dirichlet residual, linearly
+        // extrapolate phi to z = 0 via phi_extrap = 1.5*phi[k=0] - 0.5*phi[k=1];
+        // this is O(h^2) and matches the L2 error magnitude.
         double maxOnPlane = 0.0;
         double maxBulk    = 0.0;
         {
@@ -299,8 +319,11 @@ int main(int argc, char* argv[]) {
         msg << "rel L2 error vs analytical image dipole (r > 3 sigma) = "
             << relErr << endl;
 
-        // Generous thresholds for first-cut verification; they detect sign /
-        // flip / shift errors but leave room for O(h) bias near the plane.
+        // Thresholds. planeTol = 5% is just slightly above the expected ~4%
+        // analytical value at z = 0.5 * hz (see Diagnostic 1 comment above);
+        // a larger ratio would indicate a genuine sign/flip/shift error, not
+        // a Dirichlet violation. l2Tol = 10% is very loose for the real
+        // accuracy check. In practice we observe ~0.07% on a 32^3 grid.
         const double planeTol = 0.05;
         const double l2Tol    = 0.10;
 


### PR DESCRIPTION
This pull request adds support for convolving with a shifted Green's function in the FFT open boundary Poisson solver, enabling the method of images for Dirichlet boundary conditions needed in OPALX. It introduces both the implementation and a test for this feature.

## New shifted Green's function support

- Added the `shiftedGreensFunction(const Vector<double, Dim>& shift)` method to `FFTOpenPoissonSolver`, which fills the cached FFT Green's function with one shifted in real space by a user-specified vector. 
- Implemented the `shiftedGreensFunction` method in `FFTOpenPoissonSolver.hpp`, more or less copies/extents `greensFunction` already present in the class. The method is restricted to the HOCKNEY algorithm (and throws an exception if the wrong algorithm is chosen).

## Testing and validation

### Image charges/Dirichlet example

Added a new integration test, `TestShiftedGreensFunction`, to the CMake test suite, which validates the shifted Green's function implementation by comparing the numerical result (including image correction) against the analytical image-dipole solution for a Gaussian charge near a Dirichlet plane. The test includes detailed diagnostics and passes if both the Dirichlet condition and L2 error are within expected tolerances. 

Note that the "zero plane" is evaluated at the grid point nearest to "0", so the "error" being 4% is exactly as expected. This test only works single rank for now, since flipping a multi-rank field would require a lot more code. 

### Shifted evaluation

An easier test is simply calculating the potential of a bunch located at the origin at a different position. I made such a test (not commited here, since it's just for visualization), where I create a uniform sphere with radius `1e-3` at the origin `(0,0,0)` with `12pC` and calculate the its field with a `1.5e-3` shift in `z` direction. With 64 grid points, the result looks like this:

<img width="1500" height="900" alt="N64_shifted_greens_z_profile" src="https://github.com/user-attachments/assets/fccaf824-9991-47d9-9c29-fc09bf7bfd45" />
<img width="1500" height="1050" alt="N64_shifted_greens_yz_sum_overlay" src="https://github.com/user-attachments/assets/3bc3ce5c-8030-4cb0-b564-316a79a1226a" />

The complete potential is the analytical solution while e.g. the orange line in the 2D plot is the shifted solution of the solver. As one can see, it matches as expected. This should show that at least the shifted Green's function implementation works as expected. The rest of the necessary implementation will either be part of OPALX. Or there will be another PR with a "field flip" helper. 

I will talk about it in detail in today's IPPL meeting.