### PR TITLE
Non-destructive `create` addition, new `alloc` and ID assignment on subsequent `create` calls fix

### DIFF
--- a/src/Particle/ParticleAttrib.h
+++ b/src/Particle/ParticleAttrib.h
@@ -48,9 +48,15 @@ namespace ippl {
 
         using size_type = detail::size_type;
 
-        // Create storage for M particle attributes.  The storage is uninitialized.
-        // New items are appended to the end of the array.
-        void create(size_type) override;
+        // Create storage for M particle attributes. The storage is uninitialized.
+        // New items are appended to the end of the array. When non_destructive is
+        // true, existing entries are preserved across a capacity grow.
+        void create(size_type, bool non_destructive = false) override;
+
+        // Allocate capacity for n particles (multiplied by the default overallocation
+        // factor) without touching the logical particle count. Existing data is
+        // discarded.
+        void alloc(size_type) override;
 
         /*!
          * Particle deletion function. Partition the particles into a valid region

--- a/src/Particle/ParticleAttrib.h
+++ b/src/Particle/ParticleAttrib.h
@@ -89,7 +89,17 @@ namespace ippl {
         }
         
         void resize(size_type n) { Kokkos::resize(dview_m, n); }
-        
+
+        /*!
+         * @brief Reallocate the underlying view with a new size.
+         *
+         * This function reallocates the device view to a new size. Existing data is
+         * discarded and should not be relied upon after this call. Note that this function does not
+         * apply overallocation. For use from outside, call `ParticleAttrib::alloc(size_type)`
+         * instead.
+         *
+         * @param n The new size to allocate in the internal view.
+         */
         void realloc(size_type n) { Kokkos::realloc(dview_m, n); }
 
         void print() {

--- a/src/Particle/ParticleAttrib.hpp
+++ b/src/Particle/ParticleAttrib.hpp
@@ -22,12 +22,24 @@
 namespace ippl {
 
     template <typename T, class... Properties>
-    void ParticleAttrib<T, Properties...>::create(size_type n) {
+    void ParticleAttrib<T, Properties...>::create(size_type n, bool non_destructive) {
         size_type required = *(this->localNum_mp) + n;
         if (this->size() < required) {
             int overalloc = Comm->getDefaultOverallocation();
-            this->realloc(required * overalloc);
+            if (non_destructive) {
+                // Kokkos::resize preserves existing entries when growing.
+                this->resize(required * overalloc);
+            } else {
+                // Kokkos::realloc is destructive (free + alloc, no copy).
+                this->realloc(required * overalloc);
+            }
         }
+    }
+
+    template <typename T, class... Properties>
+    void ParticleAttrib<T, Properties...>::alloc(size_type n) {
+        int overalloc = Comm->getDefaultOverallocation();
+        this->realloc(n * overalloc);
     }
 
     template <typename T, class... Properties>

--- a/src/Particle/ParticleAttribBase.h
+++ b/src/Particle/ParticleAttribBase.h
@@ -57,7 +57,7 @@ namespace ippl {
 
             virtual std::string get_name() const = 0;
 
-            // Allocate raw capacity for N particles. Does NOT touch the logical
+            // Allocate internal capacity for N particles. Does NOT touch the logical
             // particle count (localNum_m on ParticleBase). Existing data is not preserved.
             virtual void alloc(size_type) = 0;
 

--- a/src/Particle/ParticleAttribBase.h
+++ b/src/Particle/ParticleAttribBase.h
@@ -57,7 +57,14 @@ namespace ippl {
 
             virtual std::string get_name() const = 0;
 
-            virtual void create(size_type) = 0;
+            // Allocate raw capacity for N particles. Does NOT touch the logical
+            // particle count (localNum_m on ParticleBase). Existing data is not preserved.
+            virtual void alloc(size_type) = 0;
+
+            // non_destructive=false (default) keeps the historical destructive-on-grow
+            // behavior (Kokkos::realloc). non_destructive=true uses Kokkos::resize so
+            // prior entries survive a capacity grow.
+            virtual void create(size_type, bool non_destructive = false) = 0;
 
             virtual void destroy(const hash_type&, const hash_type&, size_type) = 0;
             virtual size_type packedSize(const size_type) const                 = 0;

--- a/src/Particle/ParticleBase.h
+++ b/src/Particle/ParticleBase.h
@@ -246,7 +246,8 @@ namespace ippl {
         }
 
         /*!
-         * Create nLocal rank local particles.
+         * Create nLocal rank local particles. This is a collective call,
+         * i.e. all MPI ranks must call this.
          *
          * @param nLocal number of local particles to be created (delta, not total).
          * @param non_destructive if true, preserve existing particle data when the

--- a/src/Particle/ParticleBase.h
+++ b/src/Particle/ParticleBase.h
@@ -246,11 +246,23 @@ namespace ippl {
         }
 
         /*!
-         * Create nLocal processor local particles. This is a collective call,
-         * i.e. all MPI ranks must call this.
-         * @param nLocal number of local particles to be created
+         * Create nLocal rank local particles.
+         *
+         * @param nLocal number of local particles to be created (delta, not total).
+         * @param non_destructive if true, preserve existing particle data when the
+         *        underlying views must grow (uses Kokkos::resize). Default false
+         *        keeps the destructive-on-grow behavior.
          */
-        void create(size_type nLocal);
+        void create(size_type nLocal, bool non_destructive = false);
+
+        /*!
+         * Pre-allocate capacity for nLocal particles on every attribute, without
+         * touching the logical particle count or assigning IDs. Caller is
+         * responsible for filling the entries.
+         * 
+         * @param nLocal capacity (in particles) to allocate per attribute.
+         */
+        void alloc(size_type nLocal);
 
         /*!
          * Create a new particle with a given ID. This is a collective call. If a process

--- a/src/Particle/ParticleBase.h
+++ b/src/Particle/ParticleBase.h
@@ -259,8 +259,8 @@ namespace ippl {
         /*!
          * Pre-allocate capacity for nLocal particles on every attribute, without
          * touching the logical particle count or assigning IDs. Caller is
-         * responsible for filling the entries.
-         * 
+         * responsible for filling the entries. Overallocation is additionally applied.
+         *
          * @param nLocal capacity (in particles) to allocate per attribute.
          */
         void alloc(size_type nLocal);

--- a/src/Particle/ParticleBase.hpp
+++ b/src/Particle/ParticleBase.hpp
@@ -88,25 +88,30 @@ namespace ippl {
     }
 
     template <class PLayout, typename... IP>
-    void ParticleBase<PLayout, IP...>::create(size_type nLocal) {
+    void ParticleBase<PLayout, IP...>::create(size_type nLocal, bool non_destructive) {
         PAssert(layout_m != nullptr);
 
         if (nLocal > 0) {
             forAllAttributes([&]<typename Attribute>(Attribute& attribute) {
-                attribute->create(nLocal);
+                attribute->create(nLocal, non_destructive);
             });
 
             if constexpr (EnableIDs) {
-                // set the unique ID value for these new particles
+                // Set the unique ID value for these new particles. The new entries
+                // live at indices [localNum_m, localNum_m + nLocal); the k-th new
+                // particle on this rank gets ID nextID + numNodes * k.
                 using policy_type =
                     Kokkos::RangePolicy<size_type, typename particle_index_type::execution_space>;
                 auto pIDs     = ID.getView();
                 auto nextID   = this->nextID_m;
                 auto numNodes = this->numNodes_m;
+                auto offset   = localNum_m;
                 Kokkos::parallel_for(
-                    "ParticleBase<...>::create(size_t)", policy_type(localNum_m, nLocal),
-                    KOKKOS_LAMBDA(const std::int64_t i) { pIDs(i) = nextID + numNodes * i; });
-                // nextID_m += numNodes_m * (nLocal - localNum_m);
+                    "ParticleBase<...>::create(size_t,bool)",
+                    policy_type(localNum_m, localNum_m + nLocal),
+                    KOKKOS_LAMBDA(const std::int64_t i) {
+                        pIDs(i) = nextID + numNodes * (i - offset);
+                    });
                 nextID_m += numNodes_m * nLocal;
             }
 
@@ -115,6 +120,15 @@ namespace ippl {
         }
 
         Comm->allreduce(localNum_m, totalNum_m, 1, std::plus<size_type>());
+    }
+
+    template <class PLayout, typename... IP>
+    void ParticleBase<PLayout, IP...>::alloc(size_type nLocal) {
+        PAssert(layout_m != nullptr);
+        forAllAttributes([&]<typename Attribute>(Attribute& attribute) {
+            attribute->alloc(nLocal);
+        });
+        // Intentionally does NOT touch localNum_m, totalNum_m, nextID_m.
     }
 
     template <class PLayout, typename... IP>

--- a/unit_tests/Particle/ParticleBase.cpp
+++ b/unit_tests/Particle/ParticleBase.cpp
@@ -90,7 +90,7 @@ TYPED_TEST(ParticleBaseTest, CreateAndDestroy) {
 
 TYPED_TEST(ParticleBaseTest, Alloc) {
     if (ippl::Comm->size() > 1) {
-        std::cerr << "ParticleBaseTest::Alloc test only works for one MPI rank!" << std::endl;
+        std::cerr << "ParticleBaseTest::Alloc test only works on one MPI rank!" << std::endl;
         return;
     }
     constexpr size_t nReserved = 1024;

--- a/unit_tests/Particle/ParticleBase.cpp
+++ b/unit_tests/Particle/ParticleBase.cpp
@@ -88,6 +88,85 @@ TYPED_TEST(ParticleBaseTest, CreateAndDestroy) {
     }
 }
 
+TYPED_TEST(ParticleBaseTest, Alloc) {
+    if (ippl::Comm->size() > 1) {
+        std::cerr << "ParticleBaseTest::Alloc test only works for one MPI rank!" << std::endl;
+        return;
+    }
+    constexpr size_t nReserved = 1024;
+
+    auto& pbase = this->pbase;
+    pbase->alloc(nReserved);
+
+    EXPECT_EQ(size_t(0), pbase->getLocalNum());
+    EXPECT_GE(pbase->R.size(), nReserved);
+    EXPECT_GE(pbase->ID.size(), nReserved);
+}
+
+TYPED_TEST(ParticleBaseTest, CreatePreservesExistingData) {
+    if (ippl::Comm->size() > 1) {
+        std::cerr << "ParticleBaseTest::CreatePreservesExistingData test only works for one "
+                     "MPI rank!"
+                  << std::endl;
+        return;
+    }
+    constexpr size_t nFirst = 100;
+
+    auto& pbase = this->pbase;
+    pbase->create(nFirst);
+
+    // After the first create the capacity is nFirst * overalloc. Add enough particles
+    // in the second call to force a capacity grow regardless of overalloc factor.
+    const size_t capAfterFirst = pbase->ID.size();
+    const size_t nSecond       = capAfterFirst + 50;
+
+    pbase->create(nSecond, /*non_destructive=*/true);
+
+    EXPECT_EQ(nFirst + nSecond, pbase->getLocalNum());
+    EXPECT_GE(pbase->ID.size(), nFirst + nSecond);
+
+    // The first nFirst IDs should still be [0, nFirst). With nextID=0 and numNodes=1
+    // (single rank) that is what ParticleBase::create assigned in the first call.
+    auto mirror = pbase->ID.getHostMirror();
+    Kokkos::deep_copy(mirror, pbase->ID.getView());
+    for (size_t i = 0; i < nFirst; ++i) {
+        EXPECT_EQ(mirror[i], (int)i);
+    }
+}
+
+TYPED_TEST(ParticleBaseTest, AllocThenCreatePreserves) {
+    if (ippl::Comm->size() > 1) {
+        std::cerr << "ParticleBaseTest::AllocThenCreatePreserves test only works for one MPI "
+                     "rank!"
+                  << std::endl;
+        return;
+    }
+    constexpr size_t nFinal = 4096;
+    constexpr size_t nStep  = 256;
+
+    auto& pbase = this->pbase;
+    pbase->alloc(nFinal);
+
+    // Capture device pointers; they must stay stable while cumulative size <= nFinal.
+    const auto idDataBefore = pbase->ID.getView().data();
+    const auto rDataBefore  = pbase->R.getView().data();
+
+    for (size_t i = 0; i < nFinal / nStep; ++i) {
+        pbase->create(nStep, /*non_destructive=*/true);
+        EXPECT_EQ(pbase->ID.getView().data(), idDataBefore);
+        EXPECT_EQ(pbase->R.getView().data(), rDataBefore);
+    }
+
+    EXPECT_EQ(nFinal, pbase->getLocalNum());
+
+    // IDs in [0, nFinal) should be [0, nFinal) since nextID=0 and numNodes=1.
+    auto mirror = pbase->ID.getHostMirror();
+    Kokkos::deep_copy(mirror, pbase->ID.getView());
+    for (size_t i = 0; i < nFinal; ++i) {
+        EXPECT_EQ(mirror[i], (int)i);
+    }
+}
+
 TYPED_TEST(ParticleBaseTest, AddAttribute) {
     using attrib_type = typename TestFixture::attribute_type;
 


### PR DESCRIPTION
closes #496 

This PR implements a few helpers in the particle attribute logic that will help us to get rid of workarounds like [this](https://github.com/OPALX-project/OPALX/blob/5d38107b739806a36ac84d3784bb8a6f5c7584f6/src/PartBunch/PartBunch.cpp#L137). I used an optional flag in the `create` function such that legacy behaviour is preserved. 

## Changelog 

Extend `ParticleBase` / `ParticleAttribBase` with a non-destructive growth API:
- New pure virtual `ParticleAttribBase::alloc(size_type)` and concrete `ParticleAttrib::alloc(n)` doing `Kokkos::realloc(dview_m, n * Comm->getDefaultOverallocation())`. Reserves capacity only.
- `create(size_type)` becomes `create(size_type, bool non_destructive = false)`. `non_destructive=true` uses `Kokkos::resize` (preserves data); the default keeps the existing `Kokkos::realloc` semantics, so same behaviour for e.g. alpine.
- `ParticleBase` does the same. `alloc()` is non-collective and does not touch `localNum_m` / `totalNum_m` / `nextID_m`.
- Bugfix: `ParticleBase::create` ID-assignment kernel used `policy_type(localNum_m, nLocal)` which is an iteration interval, not start+delta. On repeated `create(N)` calls the range was empty and new IDs silently stayed 0. Replaced with `policy_type(localNum_m, localNum_m + nLocal)` and a lambda using `nextID + numNodes * (i - offset)`.
- New unit tests: `Alloc`, `CreatePreservesExistingData`, `AllocThenCreatePreserves`.