### PR TITLE
Add `SYCL` platform to IPPL (for OPALX compilation)

### DIFF
--- a/cmake/Platforms.cmake
+++ b/cmake/Platforms.cmake
@@ -18,7 +18,7 @@
 # -----------------------------------------------------------------------------
 # platforms we do support
 # -----------------------------------------------------------------------------
-set(IPPL_SUPPORTED_PLATFORMS "SERIAL;OPENMP;CUDA;HIP")
+set(IPPL_SUPPORTED_PLATFORMS "SERIAL;OPENMP;CUDA;HIP;SYCL")
 
 # === Default to SERIAL if IPPL_PLATFORMS not set ===
 if(NOT IPPL_PLATFORMS)

--- a/src/FFT/FFT.h
+++ b/src/FFT/FFT.h
@@ -123,6 +123,20 @@ namespace ippl {
 #endif
 #endif
 
+#ifdef KOKKOS_ENABLE_SYCL
+        // No SYCL-specific Heffte backend wired up yet. Heffte's oneMKL backend
+        // would go here when Heffte_ENABLE_ONEAPI plumbing is added in IPPL's
+        // Dependencies.cmake. For now, fall back to the stock CPU backend so
+        // SYCL builds at least compile (FFTs will run on the host).
+        template <>
+        struct HeffteBackendType<Kokkos::SYCLDeviceUSMSpace> {
+            using backend     = heffte::backend::stock;
+            using backendSine = heffte::backend::stock_sin;
+            using backendCos  = heffte::backend::stock_cos;
+            using backendCos1 = heffte::backend::stock_cos1;
+        };
+#endif
+
 #if !defined(Heffte_ENABLE_MKL) && !defined(Heffte_ENABLE_FFTW)
         /**
          * Use heFFTe's inbuilt 1D fft computation on CPUs if no


### PR DESCRIPTION
This PR adds `FFT` backend "support" for `SYCL`. Currently, the compiler explicitly forbids compiling for `SYCL`, however it should work out of the box. 

All I do here is fall back to the host FFT implementation if the `SYCL` backend is selected. This means that it probably doesn't make sense to run it with SYCL, but it should at least work. The idea is to test OPALX compilation as a status check, see for example [here](https://github.com/OPALX-project/OPALX/actions/runs/25213659236/job/73929260041?pr=401). 

I know that we have no way of testing it on an Intel GPU, so I am not able to verify that this actually works. However, the only code added (the `#ifdef KOKKOS_ENABLE_SYCL`) is never compiled for other backends, so previous behaviour should not be changed by this PR.  