### PR TITLE
Fix particle archive memory spaces (fix all known failing tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+ippl-IPPL-1.0.0
 build/
 doc/html
 doc/latex

--- a/cmake/FailingTests.cmake
+++ b/cmake/FailingTests.cmake
@@ -11,9 +11,6 @@
 if(BUILD_TESTING AND IPPL_MARK_FAILING_TESTS)
   set(IPPL_DISABLED_TEST_LIST
       AssembleRHS
-      ParticleSendRecv
-      ORB
-      PIC
       TestSolverDesign
       TestGaussian_convergence
       TestSphere

--- a/src/Communicate/Archive.hpp
+++ b/src/Communicate/Archive.hpp
@@ -26,8 +26,14 @@ namespace ippl {
             char* src_ptr         = (char*)(view.data());
             assert(writepos_m + (nsends * size) <= buffer_m.size());
             // construct temp views of the src/dst buffers of the correct size (bytes)
-            Kokkos::View<char*, Kokkos::MemoryUnmanaged> src_view(src_ptr, size * nsends);
-            Kokkos::View<char*, Kokkos::MemoryUnmanaged> dst_view(dst_ptr, size * nsends);
+            using src_view_type =
+                Kokkos::View<char*, typename Kokkos::View<T*, ViewArgs...>::memory_space,
+                             Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+            using dst_view_type =
+                Kokkos::View<char*, typename buffer_type::memory_space,
+                             Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+            src_view_type src_view(src_ptr, size * nsends);
+            dst_view_type dst_view(dst_ptr, size * nsends);
             Kokkos::deep_copy(dst_view, src_view);
             Kokkos::fence();
             writepos_m += (nsends * size);
@@ -74,8 +80,14 @@ namespace ippl {
             char* dst_ptr         = (char*)(view.data());
             assert(readpos_m + (nrecvs * size) <= buffer_m.size());
             // construct temp views of the src/dst buffers of the correct size (bytes)
-            Kokkos::View<char*, Kokkos::MemoryUnmanaged> src_view(src_ptr, size * nrecvs);
-            Kokkos::View<char*, Kokkos::MemoryUnmanaged> dst_view(dst_ptr, size * nrecvs);
+            using src_view_type =
+                Kokkos::View<char*, typename buffer_type::memory_space,
+                             Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+            using dst_view_type =
+                Kokkos::View<char*, typename Kokkos::View<T*, ViewArgs...>::memory_space,
+                             Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+            src_view_type src_view(src_ptr, size * nrecvs);
+            dst_view_type dst_view(dst_ptr, size * nrecvs);
             Kokkos::deep_copy(dst_view, src_view);
             Kokkos::fence();
             readpos_m += (nrecvs * size);

--- a/src/Particle/ParticleSpatialLayout.hpp
+++ b/src/Particle/ParticleSpatialLayout.hpp
@@ -274,6 +274,7 @@ namespace ippl {
         auto positions           = pc.R.getView();
         region_view_type Regions = rlayout_m.getdLocalRegions();
 
+        using policy_type  = Kokkos::RangePolicy<position_execution_space>;
         using mdrange_type = Kokkos::MDRangePolicy<Kokkos::Rank<2>, position_execution_space>;
 
         size_type myRank = Comm->rank();
@@ -330,7 +331,7 @@ namespace ippl {
 
         Kokkos::parallel_scan(
             "ParticleSpatialLayout::locateParticles()",
-            Kokkos::RangePolicy<size_t>(0, ranks.extent(0)),
+            policy_type(0, ranks.extent(0)),
             KOKKOS_LAMBDA(const size_type i, increment_type& val, const bool final) {
                 /* Step 1
                  * inCurr: True if the particle hasn't left the current MPI rank.
@@ -403,17 +404,18 @@ namespace ippl {
         IpplTimings::stopTimer(nonNeighboringParticles);
 
         Kokkos::parallel_for(
-            "Calculate nSends", Kokkos::RangePolicy<size_t>(0, ranks.extent(0)),
+            "Calculate nSends", policy_type(0, ranks.extent(0)),
             KOKKOS_LAMBDA(const size_t i) {
                 size_type rank = ranks(i);
                 Kokkos::atomic_fetch_add(&nSends_dview(rank), 1);
             });
 
         // Number of Ranks we need to send to
-        Kokkos::View<size_type> rankSends("Number of Ranks we need to send to");
+        Kokkos::View<size_type, position_memory_space> rankSends(
+            "Number of Ranks we need to send to");
 
         Kokkos::parallel_for(
-            "Calculate sends", Kokkos::RangePolicy<size_t>(0, nSends_dview.extent(0)),
+            "Calculate sends", policy_type(0, nSends_dview.extent(0)),
             KOKKOS_LAMBDA(const size_t rank) {
                 if (nSends_dview(rank) != 0) {
                     size_type index    = Kokkos::atomic_fetch_add(&rankSends(), 1);

--- a/src/Particle/ParticleSpatialOverlapLayout.hpp
+++ b/src/Particle/ParticleSpatialOverlapLayout.hpp
@@ -85,9 +85,10 @@ namespace ippl {
         hash_type ghostPrefixSum("ghost prefix sum", totalCells_m);
         const auto& numCells = numCells_m;
         constexpr auto is    = std::make_index_sequence<Dim>();
+        using policy_type    = Kokkos::RangePolicy<position_execution_space>;
 
         Kokkos::parallel_scan(
-            "scan_local", Kokkos::RangePolicy(0, totalCells_m),
+            "scan_local", policy_type(0, totalCells_m),
             KOKKOS_LAMBDA(const size_type i, size_type& update, const bool final) {
                 const size_type val = isLocalCellIndex(is, toCellIndex(i, numCells), numCells);
                 if (final) {
@@ -96,7 +97,7 @@ namespace ippl {
                 update += val;
             });
         Kokkos::parallel_scan(
-            "scan_ghost", Kokkos::RangePolicy(0, totalCells_m),
+            "scan_ghost", policy_type(0, totalCells_m),
             KOKKOS_LAMBDA(const size_type i, size_type& update, const bool final) {
                 const size_type val = !isLocalCellIndex(is, toCellIndex(i, numCells), numCells);
                 if (final) {
@@ -108,7 +109,7 @@ namespace ippl {
         /* Step 2. assign the cells at the correct locations of the permutations */
         const auto numLocalCells = numLocalCells_m;
         Kokkos::parallel_for(
-            "assign_permutations", Kokkos::RangePolicy(0, totalCells_m),
+            "assign_permutations", policy_type(0, totalCells_m),
             KOKKOS_LAMBDA(const size_type i) {
                 if (const auto cellIdx = toCellIndex(i, numCells);
                     isLocalCellIndex(is, cellIdx, numCells)) {
@@ -512,24 +513,25 @@ namespace ippl {
         // Step 1. Mark all non-neighbor ranks, by removing all neighbors and self
         const auto total_ranks = Comm->size();
         bool_type is_remaining("is_remaining", total_ranks);
+        using policy_type = Kokkos::RangePolicy<position_execution_space>;
         Kokkos::deep_copy(is_remaining, true);
         Kokkos::fence();
 
         const auto myRank = Comm->rank();
         Kokkos::parallel_for(
-            "mark_comm_ranks", Kokkos::RangePolicy(myRank, myRank + 1),
+            "mark_comm_ranks", policy_type(myRank, myRank + 1),
             KOKKOS_LAMBDA(const size_t& i) { is_remaining(i) = false; });
         Kokkos::parallel_for(
-            "mark_comm_ranks", neighbors_view.extent(0),
+            "mark_comm_ranks", policy_type(0, neighbors_view.extent(0)),
             KOKKOS_LAMBDA(const size_t& i) { is_remaining(neighbors_view(i)) = false; });
         Kokkos::fence();
 
         // Step 2. Fill remaining ranks
-        Kokkos::View<size_type> counter("counter");
+        Kokkos::View<size_type, position_memory_space> counter("counter");
         Kokkos::deep_copy(counter, 0);
         Kokkos::fence();
         Kokkos::parallel_for(
-            "fill_remaining", total_ranks, KOKKOS_LAMBDA(const size_t& i) {
+            "fill_remaining", policy_type(0, total_ranks), KOKKOS_LAMBDA(const size_t& i) {
                 if (is_remaining(i)) {
                     const size_type idx   = Kokkos::atomic_fetch_inc(&counter());
                     nonNeighborRanks(idx) = i;
@@ -550,6 +552,7 @@ namespace ippl {
         const auto localNum  = pc.getLocalNum();
         const T overlap      = rcutoff_m;
         constexpr auto is    = std::make_index_sequence<Dim>();
+        using policy_type    = Kokkos::RangePolicy<position_execution_space>;
 
         /// outsideIds: Container of particle IDs that travelled outside of the neighborhood.
         /// counts: count assignments per particle
@@ -583,7 +586,8 @@ namespace ippl {
 
         /* First Pass: count the numbers of neighbor ranks (including self) a particle belongs to */
         Kokkos::parallel_for(
-            "ParticleSpatialLayout::locateParticles()", localNum, KOKKOS_LAMBDA(const size_t& i) {
+            "ParticleSpatialLayout::locateParticles()", policy_type(0, localNum),
+            KOKKOS_LAMBDA(const size_t& i) {
                 const bool inCurr = positionInRegion(is, positions(i), regions(myRank), overlap);
 
                 size_type count = inCurr;
@@ -607,7 +611,7 @@ namespace ippl {
          * neighbors.
          */
         Kokkos::parallel_scan(
-            "count_outside", localNum,
+            "count_outside", policy_type(0, localNum),
             KOKKOS_LAMBDA(const size_type i, increment_type& val, const bool final) {
                 const bool inCurr = !invalid(i);
                 if (final && !inCurr) {
@@ -651,7 +655,7 @@ namespace ippl {
                 });
             Kokkos::fence();
             Kokkos::parallel_for(
-                "ParticleSpatialLayout::leftParticles()", outsideCount,
+                "ParticleSpatialLayout::leftParticles()", policy_type(0, outsideCount),
                 KOKKOS_LAMBDA(const size_t& i) { counts(outsideIds(i)) += outsideCounts(i); });
             Kokkos::fence();
         }
@@ -661,7 +665,7 @@ namespace ippl {
         /* prefix sum for particle rank offsets */
         Kokkos::deep_copy(Kokkos::subview(rankOffsets, 0), 0);
         Kokkos::parallel_scan(
-            "ParticleSpatialLayout::locateParticles()", localNum,
+            "ParticleSpatialLayout::locateParticles()", policy_type(0, localNum),
             KOKKOS_LAMBDA(const size_t i, size_type& localSum, const bool final) {
                 const auto count_i = counts(i);
                 if (final) {
@@ -679,7 +683,8 @@ namespace ippl {
 
         /* Last Pass: fill the rank data */
         Kokkos::parallel_for(
-            "ParticleSpatialLayout::locateParticles()", localNum, KOKKOS_LAMBDA(const size_t& i) {
+            "ParticleSpatialLayout::locateParticles()", policy_type(0, localNum),
+            KOKKOS_LAMBDA(const size_t& i) {
                 const size_t offset   = rankOffsets(i);
                 size_type local_count = 0;
                 if (positionInRegion(is, positions(i), regions(myRank), overlap)) {
@@ -702,7 +707,7 @@ namespace ippl {
         IpplTimings::startTimer(nonNeighboringParticles);
         if (outsideCount > 0) {
             Kokkos::parallel_for(
-                "ParticleSpatialLayout::leftParticles()", outsideCount,
+                "ParticleSpatialLayout::leftParticles()", policy_type(0, outsideCount),
                 KOKKOS_LAMBDA(const size_t& i) {
                     /// pID: (local) ID of the particle that is currently being searched.
                     const size_type pId    = outsideIds(i);
@@ -722,7 +727,7 @@ namespace ippl {
         /* compute the number of sends to all ranks */
         Kokkos::deep_copy(nSends_dview, 0);
         Kokkos::parallel_for(
-            "Calculate nSends", Kokkos::RangePolicy<size_t>(0, ranks.extent(0)),
+            "Calculate nSends", policy_type(0, ranks.extent(0)),
             KOKKOS_LAMBDA(const size_t i) {
                 size_type rank = ranks(i);
                 Kokkos::atomic_increment(&nSends_dview(rank));
@@ -730,9 +735,10 @@ namespace ippl {
         Kokkos::fence();
 
         /* compute the ranks to send to and the number of ranks to send to*/
-        Kokkos::View<size_type> rankSends("Number of Ranks we need to send to");
+        Kokkos::View<size_type, position_memory_space> rankSends(
+            "Number of Ranks we need to send to");
         Kokkos::parallel_for(
-            "Calculate sends", Kokkos::RangePolicy<size_t>(0, nSends_dview.extent(0)),
+            "Calculate sends", policy_type(0, nSends_dview.extent(0)),
             KOKKOS_LAMBDA(const size_t rank) {
                 if (nSends_dview(rank) != 0) {
                     size_type index    = Kokkos::atomic_fetch_inc(&rankSends());

--- a/unit_tests/Particle/ParticleSendRecv.cpp
+++ b/unit_tests/Particle/ParticleSendRecv.cpp
@@ -33,7 +33,7 @@ public:
 
         ~Bunch() = default;
 
-        using charge_container_type = ippl::ParticleAttrib<T>;
+        using charge_container_type = ippl::ParticleAttrib<T, ExecSpace>;
 
         rank_type expectedRank;
         charge_container_type Q;


### PR DESCRIPTION
# Summary
This PR addresses a device failure observed in ParticleSendRecv.SendAndRecieve, where particle exchange can trigger a Kokkos inaccessible-memory-space assertion and is closing #508. 

In addition all known-failng test are now #453 running again! 

# Changes

This PR changes 

1. Q to:
```
using charge_container_type = ippl::ParticleAttrib<T, ExecSpace>;
```
2. Archive scalar byte views
```
Archive::serialize() and Archive::deserialize() 
```
wrapped raw byte pointers using:
```
Kokkos::View<char*, Kokkos::MemoryUnmanaged>
```
Those unmanaged byte views did not explicitly preserve the memory space of either the source attribute view or the archive buffer. On device builds this can wrap a CUDA/HIP pointer as a view in the wrong/default space and then fail during ``` Kokkos::deep_copy ```.

This PR changes the scalar archive byte views to use explicit memory spaces:

- source attribute view memory space for serialized source bytes
- archive buffer memory space for archive bytes
- reversed source/destination memory spaces for deserialization

# Changes
Make ParticleSendRecv::Bunch::Q use ParticleAttrib<T, ExecSpace>.
Preserve source and destination memory spaces in scalar Archive byte-copy paths.
Keep the vector archive path unchanged.

# Notes
The vector archive path still uses std::memcpy inside a Kokkos device lambda for Vector<T, Dim> serialization/deserialization. That path was not changed here because the reported failure stack points at the scalar archive/deep-copy path, and this PR keeps the fix narrowly scoped.