### PR TITLE
Fix warning of grid path segmenter

### DIFF
--- a/src/FEM/GridPathSegmenter.hpp
+++ b/src/FEM/GridPathSegmenter.hpp
@@ -52,7 +52,7 @@ CutTimes<Dim,T> compute_axis_cuts_default(
   const T eps1 = (T)1e-12, one = (T)1;
 
   auto axis_cut = [&](auto Ax) {
-    constexpr int a = Ax;
+    constexpr int a = decltype(Ax)::value;
     const T dist = B[a] - A[a];
     const T eps  = eps1 * h[a];
     if (Kokkos::fabs(dist) <= eps) return; // no motion → no crossing


### PR DESCRIPTION
The GridPathSegementer.hpp file was producing the following compilation warning:

```
/users/smayani/ippl/src/FEM/GridPathSegmenter.hpp(55): warning #20013-D: calling a constexpr __host__ function("operator int") from a __host__ __device__ function("operator()") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
      constexpr int a = Ax;
                        ^
```

This is inside a lambda called from device, and the issue is the conversion to int().
This is fixed by reading the compile-time value directly , replacing:
`constexpr int a = Ax;
`
by:
`constexpr int a = decltype(Ax)::value;
`
