### PR TITLE
Avoid numeric_limits in vector reduction identities

### DIFF
--- a/src/Field/BareField.hpp
+++ b/src/Field/BareField.hpp
@@ -6,7 +6,6 @@
 
 #include <Kokkos_ReductionIdentity.hpp>
 #include <cstdlib>
-#include <limits>
 #include <map>
 #include <utility>
 
@@ -24,10 +23,10 @@ namespace Kokkos {
             return ippl::Vector<T, Dim>(1);
         }
         KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> min() {
-            return ippl::Vector<T, Dim>(std::numeric_limits<T>::infinity());
+            return ippl::Vector<T, Dim>(Kokkos::reduction_identity<T>::min());
         }
         KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> max() {
-            return ippl::Vector<T, Dim>(-std::numeric_limits<T>::infinity());
+            return ippl::Vector<T, Dim>(Kokkos::reduction_identity<T>::max());
         }
     };
 }  // namespace Kokkos


### PR DESCRIPTION
## Summary

This PR updates the `Kokkos::reduction_identity<ippl::Vector<T, Dim>>` specialization to use Kokkos' scalar reduction identities instead of `std::numeric_limits<T>::infinity()`.

The previous implementation called `std::numeric_limits<T>::infinity()` from `KOKKOS_FORCEINLINE_FUNCTION` methods:

The remaining warnings are not IPPL related, they come from 
            /user-environment/env/default/include/experimental/__p0009_bits/utility.hpp


```cpp
KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> min() {
    return ippl::Vector<T, Dim>(std::numeric_limits<T>::infinity());
}

KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> max() {
    return ippl::Vector<T, Dim>(-std::numeric_limits<T>::infinity());
}
```

NVCC diagnoses this on GH200 as warning `#20013-D`, because the `std::numeric_limits<T>::infinity()` call is treated as a constexpr host function called from a host-device function.

The new implementation delegates to Kokkos:

```cpp
KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> min() {
    return ippl::Vector<T, Dim>(Kokkos::reduction_identity<T>::min());
}

KOKKOS_FORCEINLINE_FUNCTION static ippl::Vector<T, Dim> max() {
    return ippl::Vector<T, Dim>(Kokkos::reduction_identity<T>::max());
}
```

## Changes

- Replace `std::numeric_limits<T>::infinity()` in vector min/max reduction identities with `Kokkos::reduction_identity<T>::min()` and `max()`.
- Remove the now-unused `<limits>` include from `src/Field/BareField.hpp`.
- closing #513

