### PR TITLE
Fix FEM quadrature lifetime in assembled RHS

### DIFF
--- a/src/FEM/FiniteElementSpace.h
+++ b/src/FEM/FiniteElementSpace.h
@@ -226,7 +226,7 @@ namespace ippl {
 
         UniformCartesian<T, Dim>& mesh_m;
         ElementType ref_element_m;
-        const QuadratureType& quadrature_m;
+        QuadratureType quadrature_m;
         Vector<size_t, Dim> nr_m;
         Vector<double, Dim> hr_m;
         Vector<double, Dim> origin_m;

--- a/src/FEM/Quadrature/Quadrature.h
+++ b/src/FEM/Quadrature/Quadrature.h
@@ -109,7 +109,7 @@ namespace ippl {
 
     protected:
         unsigned degree_m;
-        const ElementType& ref_element_m;
+        ElementType ref_element_m;
         Vector<T, NumNodes1D> integration_nodes_m;
         Vector<T, NumNodes1D> weights_m;
 


### PR DESCRIPTION
## Problem 
c.f. #517 
## Solution 
Store FEM quadrature and reference element objects by value instead of retaining references to caller-owned objects. AssembleRHS can construct a space from local element/quadrature temporaries, and the previous reference members left the returned space with dangling state. Debug builds exposed this as a reference-element assertion during lumped-mass assembly, while Release builds happened to run past the invalid lifetime.

## Note
If the solution causes problems, I can adapt the unit test.

## Closes #517 