### PR TITLE
Fix warnings in Test2DPoisson_convergence.cpp

### DIFF
--- a/test/solver/Test2DPoisson_convergence.cpp
+++ b/test/solver/Test2DPoisson_convergence.cpp
@@ -80,8 +80,8 @@ KOKKOS_INLINE_FUNCTION T expint_Ei_asymp(T x) {
 
 template <typename T>
 KOKKOS_INLINE_FUNCTION T expint_E1_pos(T x) {
-    const T eps    = std::numeric_limits<T>::epsilon();
-    const T fp_min = std::numeric_limits<T>::min();
+    const T eps    = Kokkos::Experimental::epsilon_v<T>;
+    const T fp_min = Kokkos::Experimental::norm_min_v<T>;
 
     if (x < T(1)) {
         T term = T(1);


### PR DESCRIPTION
Remove std::min and std::epsilon functions which were in the expint() implementation in test/solver/Test2DPoisson_convergence.cpp. 