### PR TITLE
Re-implement field write api from #506, but template view directly (no `auto` in function parameter)

### DIFF
--- a/src/Field/BareField.h
+++ b/src/Field/BareField.h
@@ -199,6 +199,27 @@ namespace ippl {
          */
         void write(Inform& inf) const;
 
+        /*!
+         * Print the rank local BareField.
+         * @param out stream
+         */
+        void write_as_list(std::ostream& out = std::cout) const;
+
+        /*!
+         * Print the rank local BareField.
+         * @param inf Inform object
+         */
+        void write_as_list(Inform& inf) const;
+
+        /*!
+         * Stream opreator to print the rank local BareField.
+         */
+        friend std::ostream& operator<<(std::ostream& out,
+                                        const BareField<T, Dim, ViewArgs...>& field) {
+            field.write_as_list(out);
+            return out;
+        }
+
         T sum(int nghost = 0) const;
         T max(int nghost = 0) const;
         T min(int nghost = 0) const;

--- a/src/Field/BareField.hpp
+++ b/src/Field/BareField.hpp
@@ -2,6 +2,9 @@
 // Class BareField
 //   A BareField consists of multple LFields and represents a field.
 //
+#ifndef IPPL_BARE_FIELD_HPP
+#define IPPL_BARE_FIELD_HPP
+
 #include "Ippl.h"
 
 #include <Kokkos_ReductionIdentity.hpp>
@@ -13,6 +16,8 @@
 
 #include "Utility/Inform.h"
 #include "Utility/IpplInfo.h"
+
+#include "BareField.h"
 namespace Kokkos {
     template <typename T, unsigned Dim>
     struct reduction_identity<ippl::Vector<T, Dim>> {
@@ -191,12 +196,23 @@ namespace ippl {
     template <typename T, unsigned Dim, class... ViewArgs>
     void BareField<T, Dim, ViewArgs...>::write(std::ostream& out) const {
         Kokkos::fence();
-        detail::write<T, Dim>(dview_m, out);
+        detail::write<T, Dim, ViewArgs...>(dview_m, out);
     }
 
     template <typename T, unsigned Dim, class... ViewArgs>
     void BareField<T, Dim, ViewArgs...>::write(Inform& inf) const {
         write(inf.getDestination());
+    }
+
+    template <typename T, unsigned Dim, class... ViewArgs>
+    void BareField<T, Dim, ViewArgs...>::write_as_list(std::ostream& out) const {
+        Kokkos::fence();
+        detail::write_as_list<T, Dim, ViewArgs...>(dview_m, out);
+    }
+
+    template <typename T, unsigned Dim, class... ViewArgs>
+    void BareField<T, Dim, ViewArgs...>::write_as_list(Inform& inf) const {
+        write_as_list(inf.getDestination());
     }
 
 #define DefineReduction(fun, name, op, MPI_Op)                                                 \
@@ -223,3 +239,4 @@ namespace ippl {
     DefineReduction(Prod, prod, valL *= myVal, std::multiplies)
 
 }  // namespace ippl
+#endif  // IPPL_BARE_FIELD_HPP

--- a/src/Utility/ViewUtils.h
+++ b/src/Utility/ViewUtils.h
@@ -8,6 +8,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <iostream>
+
 #include "Types/ViewTypes.h"
 
 namespace ippl {
@@ -97,6 +99,52 @@ namespace ippl {
                         out << std::endl;
                     }
                 });
+        }
+
+        /*!
+         * Recursive implementation to write a view in list format to output stream
+         * @tparam Dim
+         *
+         * @param view
+         * @param out stream
+         */
+        template <unsigned Dim, typename View>
+        void write_as_list_impl(const View& view, std::ostream& out = std::cout) {
+            auto N = view.extent(0);
+            out << "[";
+            for (std::size_t i = 0; i < N; ++i) {
+                if constexpr (Dim == 1) {
+                    out << view(i);
+                } else {
+                    auto make_subview = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+                        return Kokkos::subview(view, i, (static_cast<void>(Is), Kokkos::ALL)...);
+                    };
+
+                    auto subview = make_subview(std::make_index_sequence<Dim - 1>());
+                    write_as_list_impl<Dim - 1>(subview, out);
+                }
+                if (i != N - 1)
+                    out << ", ";
+            }
+            out << "]";
+        };
+
+        /*!
+         * Writes a view to an output stream in folded list format
+         * @tparam T view data type
+         * @tparam Dim view dimension
+         * @tparam Properties further template parameters of Kokkos
+         *
+         * @param view to write
+         * @param out stream
+         */
+        template <typename T, unsigned Dim, class... Properties>
+        void write_as_list(const typename ViewType<T, Dim, Properties...>::view_type& view,
+                           std::ostream& out = std::cout) {
+            auto hview =
+                Kokkos::create_mirror_view_and_copy(Kokkos::DefaultHostExecutionSpace(), view);
+
+            write_as_list_impl<Dim>(hview, out);
         }
 
         /*!

--- a/unit_tests/BareField/BareField.cpp
+++ b/unit_tests/BareField/BareField.cpp
@@ -7,6 +7,7 @@
 #include <Kokkos_MathematicalConstants.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <cstring>
+#include <sstream>
 
 #include "Utility/TypeUtils.h"
 
@@ -257,6 +258,62 @@ TYPED_TEST(BareFieldTest, AllFuncs) {
     nestedViewLoop(mirror, shift, [&]<typename... Idx>(const Idx... args) {
         assertEqual<T>(mirror(args...), beta);
     });
+}
+
+TYPED_TEST(BareFieldTest, write_as_list) {
+    using T                       = typename TestFixture::value_type;
+    using ExecSpace               = typename TestFixture::exec_space;
+    constexpr static unsigned Dim = TestFixture::dim;
+
+    if constexpr (Dim == 2) {
+        // not implemented for MPI Communicators greater than two
+        if (ippl::Comm->size() <= 2) {
+            // 2D, 2x2 Field
+            ippl::FieldLayout<Dim> layout(ippl::Comm->getCommunicator(),
+                                          ippl::NDIndex<Dim>(ippl::Vector<unsigned, Dim>(2)),
+                                          std::array<bool, Dim>{true});
+            ippl::BareField<T, Dim, Kokkos::LayoutRight, ExecSpace> field(layout, 0);
+
+            auto view = field.getView();
+            auto hview =
+                Kokkos::create_mirror_view_and_copy(Kokkos::DefaultHostExecutionSpace(), view);
+
+            if (layout.comm.size() == 1) {
+                hview(0, 0) = 1;
+                hview(0, 1) = 2;
+                hview(1, 0) = 3;
+                hview(1, 1) = 4;
+            } else if (layout.comm.size() == 2) {
+                if (layout.comm.rank() == 0) {
+                    hview(0, 0) = 1;
+                    hview(0, 1) = 2;
+                }
+                if (layout.comm.rank() == 1) {
+                    hview(0, 0) = 3;
+                    hview(0, 1) = 4;
+                }
+            }
+
+            Kokkos::deep_copy(view, hview);
+
+            std::ostringstream ss;
+            field.write_as_list(ss);
+
+            if (layout.comm.size() == 1) {
+                ASSERT_STREQ(ss.str().c_str(), "[[1, 2], [3, 4]]");
+            } else if (layout.comm.size() == 2) {
+                if (layout.comm.rank() == 0) {
+                    ASSERT_STREQ(ss.str().c_str(), "[[1, 2]]");
+                }
+                if (layout.comm.rank() == 1) {
+                    ASSERT_STREQ(ss.str().c_str(), "[[3, 4]]");
+                }
+            } else
+                GTEST_SKIP();
+        } else
+            GTEST_SKIP();
+    } else
+        GTEST_SKIP();
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
See description of #506.

I want to re-run the jülrich ci and see if this was actually the problem. Here is what I changed. From this:
```cpp
template <unsigned Dim>
void write_as_list_impl(const auto view, std::ostream& out = std::cout) {
    auto N = view.extent(0);
    ...
```
to this:
```cpp
template <unsigned Dim, typename View>
void write_as_list_impl(const View& view, std::ostream& out = std::cout) {
    auto N = view.extent(0);
    ...
```
I think that the Jülich `cuda/12.6` + `gcc/13` combination didn't like this one. Newer `cuda` versions don't seem to have a problem with that (that's why the cscs ci passed).