### PR TITLE
Propagate (default) `Kokkos_VERSION` to `Kokkos_VERSION_GIT`

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -180,6 +180,8 @@ extract_git_label(Kokkos_VERSION KOKKOS_VERSION_GIT)
 set(Kokkos_REPOSITORY "https://github.com/kokkos/kokkos.git")
 if(NOT KOKKOS_VERSION_GIT)
   find_package(Kokkos ${Kokkos_VERSION} QUIET COMPONENTS ${IPPL_PLATFORMS})
+  # Plain Kokkos versions are also release tags; use them for the source fallback.
+  set(KOKKOS_VERSION_GIT "${Kokkos_VERSION}")
 endif()
 
 # If Kokkos found on system, Check that it has the platform backends that we need

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -168,7 +168,7 @@ endfunction()
 # ------------------------------------------------------------------------------
 # set the default version of kokkos we will ask for if not already set
 if(NOT Kokkos_VERSION_DEFAULT)
-  set(Kokkos_VERSION_DEFAULT 5.1.1)
+  set(Kokkos_VERSION_DEFAULT 5.0.0)
 endif()
 # if the user has not asked for a specific version, we will use a default
 if(NOT Kokkos_VERSION)


### PR DESCRIPTION
closes #524 

The fix is simple: if no version is provided (default behaviour) and no compatible local source is found, build it from source with the default version instead of an empty git tag defaulting to "master". Now, e.g. the OPALX cmake shows:
```
-- Fetching IPPL ref: 524-default-kokkos-511-is-not-fetched
-- IPPL shallow fetch: TRUE
-- Build type is: Release
Cloning into 'ippl-src'...
Switched to a new branch '524-default-kokkos-511-is-not-fetched'
branch '524-default-kokkos-511-is-not-fetched' set up to track 'origin/524-default-kokkos-511-is-not-fetched'.
-- 📦 Configuring IPPL Version: 3.2 : "IPPL v3.2"
-- 🔧IPPL will be built as a STATIC library
-- Build type is: Release
-- ✅ Project setup complete
-- ✅ Compiler options configured
-- ✅ MPI found 3.1
-- ✅ Kokkos 5.1.1 building from source
-- IPPL_PLATFORM set: Kokkos_ENABLE_SERIAL 'ON'
-- IPPL_PLATFORM set: Kokkos_ENABLE_OPENMP 'OFF'
-- IPPL_PLATFORM set: Kokkos_ENABLE_CUDA 'OFF'
-- IPPL_PLATFORM set: Kokkos_ENABLE_HIP 'OFF'
-- IPPL_PLATFORM set: Kokkos_ENABLE_SYCL 'OFF'
Cloning into 'kokkos-src'...
HEAD is now at 267ebc25f Reference to SLSA GitHub Generator by tag instead of digest
-- Setting default Kokkos CXX standard to 20
-- Kokkos version: 5.1.1
-- The project name is: Kokkos
-- Configured git information in /Users/aliemen/Desktop/opalx/buildtest/_deps/ippl-build/_deps/kokkos-build/generated/Kokkos_Version_Info.cpp
-- Kokkos is configured for CMake languages CXX compilation (using Clang version 21.1.8)
-- Using -std=c++20 for C++20 standard as feature
-- Built-in Execution Spaces:
--     Device Parallel: NoTypeDefined
--     Host Parallel: NoTypeDefined
--       Host Serial: SERIAL
```
Before it would always say "`Kokkos version: 4.7.01`".