### PR TITLE
Fix override warning and replace all deprecated `atomic_increment` with `atomic_inc`

### DIFF
--- a/examples/collisions/P3MHeating.hpp
+++ b/examples/collisions/P3MHeating.hpp
@@ -282,7 +282,7 @@ public:
         m << "L2-Norm of Temperature: " << temperature << endl;
     }
 
-    void dump() {
+    void dump() override {
         computeBeamStatistics();
         computeTemperature();
     }

--- a/src/Particle/ParticleSpatialOverlapLayout.hpp
+++ b/src/Particle/ParticleSpatialOverlapLayout.hpp
@@ -652,7 +652,7 @@ namespace ippl {
 
                     /// inRegion: Checks whether particle pID is inside region j.
                     if (positionInRegion(is, positions(pId), regions(rank), overlap)) {
-                        Kokkos::atomic_increment(&outsideCounts(i));
+                        Kokkos::atomic_inc(&outsideCounts(i));
                     }
                 });
             Kokkos::fence();
@@ -732,7 +732,7 @@ namespace ippl {
             "Calculate nSends", policy_type(0, ranks.extent(0)),
             KOKKOS_LAMBDA(const size_t i) {
                 size_type rank = ranks(i);
-                Kokkos::atomic_increment(&nSends_dview(rank));
+                Kokkos::atomic_inc(&nSends_dview(rank));
             });
         Kokkos::fence();
 
@@ -868,7 +868,7 @@ namespace ippl {
                 const auto locCellIndex = getCellIndex(positions(i), localRegion, cellWidth);
                 const auto locCellIndexFlat =
                     toFlatCellIndex(locCellIndex, cellStrides, cellPermutationForward);
-                Kokkos::atomic_increment(&cellParticleCount(locCellIndexFlat));
+                Kokkos::atomic_inc(&cellParticleCount(locCellIndexFlat));
                 cellIndex(i) = locCellIndexFlat;
             });
         Kokkos::fence();


### PR DESCRIPTION
closes #527 

See attached issue for explanation. This PR makes some fixes for Kokkos 5 in the `P3MHeating` test.