### PR TITLE
531 more std cleanup in kokkos functions and kernels

### DIFF
--- a/src/Communicate/Archive.hpp
+++ b/src/Communicate/Archive.hpp
@@ -2,12 +2,15 @@
 // Class Archive
 //   Class to (de-)serialize in MPI communication.
 //
-#include <cstring>
-
 #include "Archive.h"
 
 namespace ippl {
     namespace detail {
+        KOKKOS_INLINE_FUNCTION void copyBytes(char* dst, const char* src, size_t size) {
+            for (size_t i = 0; i < size; ++i) {
+                dst[i] = src[i];
+            }
+        }
 
         template <class... Properties>
         Archive<Properties...>::Archive(size_type size)
@@ -57,7 +60,9 @@ namespace ippl {
             Kokkos::parallel_for(
                 "Archive::serialize()", mdrange_t({0, 0}, {(long int)nsends, Dim}),
                 KOKKOS_LAMBDA(const size_type i, const size_t d) {
-                    std::memcpy(dst_ptr + (Dim * i + d) * size + wp, &(*(src_ptr + i))[d], size);
+                    const char* src = reinterpret_cast<const char*>(&src_ptr[i][d]);
+                    char* dst       = dst_ptr + (Dim * i + d) * size + wp;
+                    copyBytes(dst, src, size);
                 });
 
             Kokkos::fence();
@@ -115,7 +120,9 @@ namespace ippl {
             Kokkos::parallel_for(
                 "Archive::deserialize()", mdrange_t({0, 0}, {(long int)nrecvs, Dim}),
                 KOKKOS_LAMBDA(const size_type i, const size_t d) {
-                    std::memcpy(&(*(dst_ptr + i))[d], src_ptr + (Dim * i + d) * size + rp, size);
+                    const char* src = src_ptr + (Dim * i + d) * size + rp;
+                    char* dst       = reinterpret_cast<char*>(&dst_ptr[i][d]);
+                    copyBytes(dst, src, size);
                 });
             Kokkos::fence();
             readpos_m += Dim * size * nrecvs;

--- a/src/Particle/ParticleSpatialOverlapLayout.hpp
+++ b/src/Particle/ParticleSpatialOverlapLayout.hpp
@@ -991,7 +991,7 @@ namespace ippl {
         for (size_type neighborIdx = 0; neighborIdx < numNeighbors; ++neighborIdx) {
             auto n = particleNeighborData.cellParticleCount(neighbors[neighborIdx]);
             neighborSizes[neighborIdx]   = n;
-            maxParticleInNeighbors       = std::max<size_type>(n, maxParticleInNeighbors);
+            maxParticleInNeighbors       = n > maxParticleInNeighbors ? n : maxParticleInNeighbors;
             neighborOffsets[neighborIdx] = totalParticleInNeighbors;
             totalParticleInNeighbors += n;
         }
@@ -1041,7 +1041,7 @@ namespace ippl {
         // #pragma unroll
         for (size_type neighborIdx = 0; neighborIdx < numNeighbors; ++neighborIdx) {
             auto n                 = particleNeighborData.cellParticleCount(neighbors[neighborIdx]);
-            maxParticleInNeighbors = std::max<size_type>(n, maxParticleInNeighbors);
+            maxParticleInNeighbors = n > maxParticleInNeighbors ? n : maxParticleInNeighbors;
             neighborOffsets[neighborIdx] = totalParticleInNeighbors;
             totalParticleInNeighbors += n;
         }

--- a/test/field/TestCurl.cpp
+++ b/test/field/TestCurl.cpp
@@ -14,17 +14,20 @@
 
 #include "Ippl.h"
 
+#include <Kokkos_MathematicalConstants.hpp>
+#include <Kokkos_MathematicalFunctions.hpp>
+
 #include <array>
 #include <iostream>
 #include <typeinfo>
 
 KOKKOS_INLINE_FUNCTION double gaussian(double x, double y, double z, double sigma = 1.0,
                                        double mu = 0.5) {
-    double pi        = std::acos(-1.0);
-    double prefactor = (1 / std::sqrt(2 * 2 * 2 * pi * pi * pi)) * (1 / (sigma * sigma * sigma));
+    double pi        = Kokkos::numbers::pi_v<double>;
+    double prefactor = (1 / Kokkos::sqrt(2 * 2 * 2 * pi * pi * pi)) * (1 / (sigma * sigma * sigma));
     double r2        = (x - mu) * (x - mu) + (y - mu) * (y - mu) + (z - mu) * (z - mu);
 
-    return -prefactor * std::exp(-r2 / (2 * sigma * sigma));
+    return -prefactor * Kokkos::exp(-r2 / (2 * sigma * sigma));
 }
 
 int main(int argc, char* argv[]) {

--- a/test/field/TestHessian.cpp
+++ b/test/field/TestHessian.cpp
@@ -13,17 +13,20 @@
 
 #include "Ippl.h"
 
+#include <Kokkos_MathematicalConstants.hpp>
+#include <Kokkos_MathematicalFunctions.hpp>
+
 #include <array>
 #include <iostream>
 #include <typeinfo>
 
 KOKKOS_INLINE_FUNCTION double gaussian(double x, double y, double z, double sigma = 1.0,
                                        double mu = 0.5) {
-    double pi        = std::acos(-1.0);
-    double prefactor = (1 / std::sqrt(2 * 2 * 2 * pi * pi * pi)) * (1 / (sigma * sigma * sigma));
+    double pi        = Kokkos::numbers::pi_v<double>;
+    double prefactor = (1 / Kokkos::sqrt(2 * 2 * 2 * pi * pi * pi)) * (1 / (sigma * sigma * sigma));
     double r2        = (x - mu) * (x - mu) + (y - mu) * (y - mu) + (z - mu) * (z - mu);
 
-    return -prefactor * std::exp(-r2 / (2 * sigma * sigma));
+    return -prefactor * Kokkos::exp(-r2 / (2 * sigma * sigma));
 }
 
 int main(int argc, char* argv[]) {

--- a/test/solver/TestGaussian.cpp
+++ b/test/solver/TestGaussian.cpp
@@ -38,7 +38,7 @@ KOKKOS_INLINE_FUNCTION double gaussian(double x, double y, double z, double sigm
     double prefactor = (1 / Kokkos::sqrt(2 * 2 * 2 * pi * pi * pi)) * (1 / (sigma * sigma * sigma));
     double r2        = (x - mu) * (x - mu) + (y - mu) * (y - mu) + (z - mu) * (z - mu);
 
-    return prefactor * exp(-r2 / (2 * sigma * sigma));
+    return prefactor * Kokkos::exp(-r2 / (2 * sigma * sigma));
 }
 
 KOKKOS_INLINE_FUNCTION double exact_fct(double x, double y, double z, double sigma = 0.05,
@@ -56,7 +56,7 @@ KOKKOS_INLINE_FUNCTION ippl::Vector<double, 3> exact_E(double x, double y, doubl
     double factor =
         (1.0 / (4.0 * pi * r * r))
         * ((1.0 / r) * Kokkos::erf(r / (Kokkos::sqrt(2.0) * sigma))
-           - Kokkos::sqrt(2.0 / pi) * (1.0 / sigma) * exp(-r * r / (2 * sigma * sigma)));
+           - Kokkos::sqrt(2.0 / pi) * (1.0 / sigma) * Kokkos::exp(-r * r / (2 * sigma * sigma)));
 
     ippl::Vector<double, 3> Efield = {(x - mu), (y - mu), (z - mu)};
     return factor * Efield;

--- a/test/solver/TestGaussian_biharmonic.cpp
+++ b/test/solver/TestGaussian_biharmonic.cpp
@@ -25,7 +25,7 @@ KOKKOS_INLINE_FUNCTION double gaussian(double x, double y, double z, double sigm
     double prefactor = (1 / Kokkos::sqrt(2 * 2 * 2 * pi * pi * pi)) * (1 / (sigma * sigma * sigma));
     double r2        = (x - mu) * (x - mu) + (y - mu) * (y - mu) + (z - mu) * (z - mu);
 
-    return prefactor * exp(-r2 / (2 * sigma * sigma));
+    return prefactor * Kokkos::exp(-r2 / (2 * sigma * sigma));
 }
 
 KOKKOS_INLINE_FUNCTION double exact_fct(double x, double y, double z, double sigma = 0.05,
@@ -35,7 +35,7 @@ KOKKOS_INLINE_FUNCTION double exact_fct(double x, double y, double z, double sig
     double r2 = (x - mu) * (x - mu) + (y - mu) * (y - mu) + (z - mu) * (z - mu);
 
     return (1 / (8.0 * pi))
-           * (sigma * Kokkos::sqrt(2.0 / pi) * exp(-r2 / (2 * sigma * sigma))
+           * (sigma * Kokkos::sqrt(2.0 / pi) * Kokkos::exp(-r2 / (2 * sigma * sigma))
               + Kokkos::erf(r / (Kokkos::sqrt(2.0) * sigma)) * (r + (sigma * sigma / r)));
 }
 
@@ -48,7 +48,7 @@ KOKKOS_INLINE_FUNCTION ippl::Vector<double, 3> exact_grad(double x, double y, do
     ippl::Vector<double, 3> Efield = {(x - mu), (y - mu), (z - mu)};
     double factor =
         -(1.0 / r) * (1 / (8.0 * pi))
-        * ((sigma / r) * Kokkos::sqrt(2.0 / pi) * exp(-r2 / (2 * sigma * sigma))
+        * ((sigma / r) * Kokkos::sqrt(2.0 / pi) * Kokkos::exp(-r2 / (2 * sigma * sigma))
            + Kokkos::erf(r / (Kokkos::sqrt(2.0) * sigma)) * (1.0 - (sigma * sigma / (r * r))));
     return factor * Efield;
 }

--- a/test/solver/TestGaussian_convergence.cpp
+++ b/test/solver/TestGaussian_convergence.cpp
@@ -43,7 +43,7 @@ KOKKOS_INLINE_FUNCTION T gaussian(T x, T y, T z, T sigma = 0.05, T mu = 0.5) {
     T prefactor = (1 / Kokkos::sqrt(2 * 2 * 2 * pi * pi * pi)) * (1 / (sigma * sigma * sigma));
     T r2        = (x - mu) * (x - mu) + (y - mu) * (y - mu) + (z - mu) * (z - mu);
 
-    return prefactor * exp(-r2 / (2 * sigma * sigma));
+    return prefactor * Kokkos::exp(-r2 / (2 * sigma * sigma));
 }
 
 template <typename T>
@@ -61,7 +61,8 @@ KOKKOS_INLINE_FUNCTION ippl::Vector<T, 3> exact_E(T x, T y, T z, T sigma = 0.05,
     T r      = Kokkos::sqrt((x - mu) * (x - mu) + (y - mu) * (y - mu) + (z - mu) * (z - mu));
     T factor = (1.0 / (4.0 * pi * r * r))
                * ((1.0 / r) * Kokkos::erf(r / (Kokkos::sqrt(2.0) * sigma))
-                  - Kokkos::sqrt(2.0 / pi) * (1.0 / sigma) * exp(-r * r / (2 * sigma * sigma)));
+                  - Kokkos::sqrt(2.0 / pi) * (1.0 / sigma)
+                        * Kokkos::exp(-r * r / (2 * sigma * sigma)));
 
     ippl::Vector<T, 3> Efield = {(x - mu), (y - mu), (z - mu)};
     return factor * Efield;

--- a/test/solver/TestGaussian_hessian.cpp
+++ b/test/solver/TestGaussian_hessian.cpp
@@ -50,7 +50,7 @@ KOKKOS_INLINE_FUNCTION T gaussian(T x, T y, T z, T sigma = 0.05, T mu = 0.5) {
     T prefactor = (1 / Kokkos::sqrt(2 * 2 * 2 * pi * pi * pi)) * (1 / (sigma * sigma * sigma));
     T r2        = (x - mu) * (x - mu) + (y - mu) * (y - mu) + (z - mu) * (z - mu);
 
-    return prefactor * exp(-r2 / (2 * sigma * sigma));
+    return prefactor * Kokkos::exp(-r2 / (2 * sigma * sigma));
 }
 
 template <typename T>
@@ -68,7 +68,8 @@ KOKKOS_INLINE_FUNCTION ippl::Vector<T, 3> exact_E(T x, T y, T z, T sigma = 0.05,
     T r      = Kokkos::sqrt((x - mu) * (x - mu) + (y - mu) * (y - mu) + (z - mu) * (z - mu));
     T factor = (1.0 / (4.0 * pi * r * r))
                * ((1.0 / r) * Kokkos::erf(r / (Kokkos::sqrt(2.0) * sigma))
-                  - Kokkos::sqrt(2.0 / pi) * (1.0 / sigma) * exp(-r * r / (2 * sigma * sigma)));
+                  - Kokkos::sqrt(2.0 / pi) * (1.0 / sigma)
+                        * Kokkos::exp(-r * r / (2 * sigma * sigma)));
 
     ippl::Vector<T, 3> Efield = {(x - mu), (y - mu), (z - mu)};
     return factor * Efield;
@@ -84,7 +85,7 @@ KOKKOS_INLINE_FUNCTION Matrix_t<T> exact_H(T x, T y, T z, T sigma = 0.05, T mu =
 
     T r        = Kokkos::sqrt(x * x + y * y + z * z);
     T errorfct = Kokkos::erf(r / (Kokkos::sqrt(2.0) * sigma));
-    T exponent = exp(-r * r / (2 * sigma * sigma));
+    T exponent = Kokkos::exp(-r * r / (2 * sigma * sigma));
 
     Matrix_t<T> exactH;
 


### PR DESCRIPTION
## Summary

This PR removes host-oriented standard-library calls from Kokkos-labeled code paths that may be compiled for CUDA/HIP backends.

It contains two focused cleanups:

1. `Archive.hpp`
   - Replaces `std::memcpy` inside Kokkos kernels with a small `KOKKOS_INLINE_FUNCTION` byte-copy helper.
   - Applies to Archive vector serialization/deserialization.
   - Avoids relying on host-library `memcpy` availability from device code.

2. Kokkos-labeled math/test helpers
   - Replaces `std::max` in `ParticleSpatialOverlapLayout` neighbor sizing with a direct comparison usable from Kokkos functions.
   - Replaces `std::acos`, `std::sqrt`, and `std::exp` in `TestCurl.cpp` and `TestHessian.cpp` Gaussian helpers with Kokkos constants/math functions.
   - Qualifies unqualified `exp(...)` calls in solver test helper functions as `Kokkos::exp(...)`.

## Deferred
`Vector(std::initializer_list)` and `Tuple.h` may still need follow-up if CUDA/HIP reports host-device STL warnings there. Those are intentionally deferred because they touch broader construction/copy semantics.

