### PR TITLE
Add --diff-filter ACMR to exclude deleted files from the clang-format check

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           git fetch origin ${{ github.base_ref }}
 
-          FILES=$(git diff --name-only \
+          FILES=$(git diff --name-only --diff-filter=ACMR \
             origin/${{ github.base_ref }}...HEAD \
             | grep -E '\.(c|cc|cpp|cxx|h|hpp)$' || true)
 


### PR DESCRIPTION
See OPALX-project/OPALX#442 and OPALX-project/OPALX#443 for details. 