### PR TITLE
Fix preconditioner parameter checks in Alpine and PCG solver

### DIFF
--- a/alpine/FieldSolver.hpp
+++ b/alpine/FieldSolver.hpp
@@ -3,18 +3,113 @@
 
 #include <memory>
 #include <filesystem>
+#include <array>
+#include <algorithm>
 
 #include "Manager/BaseManager.h"
 #include "Manager/FieldSolverBase.h"
+#include "LinearSolvers/PreconditionerValidation.h"
 
 // Define the FieldSolver class
 template <typename T, unsigned Dim>
 class FieldSolver : public ippl::FieldSolverBase<T, Dim> {
 private:
+    struct ParsedPreconditionerParams {
+        std::string type = "";
+        bool use_defaults = true;
+        int newton_level = ippl::pcg_preconditioner_defaults::newton_level;
+        int chebyshev_degree = ippl::pcg_preconditioner_defaults::chebyshev_degree;
+        int richardson_iterations = ippl::pcg_preconditioner_defaults::richardson_iterations;
+        int gauss_seidel_inner_iterations = ippl::pcg_preconditioner_defaults::gauss_seidel_inner;
+        int gauss_seidel_outer_iterations = ippl::pcg_preconditioner_defaults::gauss_seidel_outer;
+        int communication = ippl::pcg_preconditioner_defaults::communication;
+        double ssor_omega = ippl::pcg_preconditioner_defaults::ssor_omega;
+    };
+
     Field_t<Dim>* rho_m;
     VField_t<T, Dim>* E_m;
     Field<T, Dim>* phi_m;
     std::vector<std::string> preconditioner_params_m;
+
+    // Parse the preconditioner params (PCG and FEMPrecon solvers);
+    //   [type, optional numeric args...]
+    // Type validation and numeric sanitization are delegated to the shared
+    // preconditioner validation helper to avoid duplication with Poisson solvers.
+    // If the type is known but the numeric args are invalid or the number
+    // of arguments is wrong, a warning is printed and default parameters
+    // are used.
+    ParsedPreconditionerParams parsePreconditionerParams(const std::string& solver_name) const {
+        Inform warn("FieldSolver");
+        ParsedPreconditionerParams parsed;
+        if (preconditioner_params_m.empty()) {
+            warn << "No preconditioner type provided for solver " << solver_name
+                 << "; using default identity preconditioner." << endl;
+            return parsed;
+        }
+
+        parsed.type = preconditioner_params_m[0];
+        ippl::preconditioner_validation::throwIfUnknownType(
+            parsed.type, "FieldSolver::parsePreconditionerParams");
+
+        size_t expected_arg_count = 0;
+        if (parsed.type == "newton" || parsed.type == "chebyshev" || parsed.type == "richardson_alt") {
+            expected_arg_count = 1;
+        } else if (parsed.type == "richardson") {
+            expected_arg_count = 2;
+        } else if (parsed.type == "gauss-seidel" || parsed.type == "ssor") {
+            expected_arg_count = 3;
+        }
+
+        const size_t provided_arg_count = preconditioner_params_m.size() - 1;
+        if (provided_arg_count == 0) {
+            return parsed;
+        }
+
+        auto warnAndUseDefaults = [&](const std::string& detail) {
+            warn << "Invalid parameters for preconditioner '" << parsed.type << "' in solver "
+                 << solver_name << " (" << detail << "). Using default preconditioner parameters."
+                 << endl;
+            parsed.use_defaults = true;
+        };
+
+        if (provided_arg_count != expected_arg_count) {
+            warnAndUseDefaults("expected " + std::to_string(expected_arg_count) + " argument(s), got "
+                               + std::to_string(provided_arg_count));
+            return parsed;
+        }
+
+        try {
+            int arg = 1;
+            if (parsed.type == "newton") {
+                parsed.newton_level = std::stoi(preconditioner_params_m[arg++]);
+            } else if (parsed.type == "chebyshev") {
+                parsed.chebyshev_degree = std::stoi(preconditioner_params_m[arg++]);
+            } else if (parsed.type == "richardson" || parsed.type == "richardson_alt") {
+                parsed.richardson_iterations = std::stoi(preconditioner_params_m[arg++]);
+                if (parsed.type == "richardson") {
+                    parsed.communication = std::stoi(preconditioner_params_m[arg++]);
+                }
+            } else if (parsed.type == "gauss-seidel") {
+                parsed.gauss_seidel_inner_iterations = std::stoi(preconditioner_params_m[arg++]);
+                parsed.gauss_seidel_outer_iterations = std::stoi(preconditioner_params_m[arg++]);
+                parsed.communication                 = std::stoi(preconditioner_params_m[arg++]);
+            } else if (parsed.type == "ssor") {
+                parsed.gauss_seidel_inner_iterations = std::stoi(preconditioner_params_m[arg++]);
+                parsed.gauss_seidel_outer_iterations = std::stoi(preconditioner_params_m[arg++]);
+                parsed.ssor_omega                    = std::stod(preconditioner_params_m[arg++]);
+            }
+            parsed.use_defaults = false;
+        } catch (const std::exception& ex) {
+            warnAndUseDefaults(std::string("failed to parse numeric values: ") + ex.what());
+        }
+
+        ippl::preconditioner_validation::sanitizeParams(
+            parsed.type, warn, parsed.newton_level, parsed.chebyshev_degree,
+            parsed.richardson_iterations, parsed.gauss_seidel_inner_iterations,
+            parsed.gauss_seidel_outer_iterations, parsed.ssor_omega, &parsed.communication);
+
+        return parsed;
+    }
 
 public:
     FieldSolver(std::string solver, Field_t<Dim>* rho, VField_t<T, Dim>* E, Field<T, Dim>* phi,
@@ -199,44 +294,16 @@ public:
         sp.add("output_type", CGSolver_t<T, Dim>::GRAD);
         // Increase tolerance in the 1D case
         sp.add("tolerance", 1e-4);
+        const auto parsed = parsePreconditionerParams("PCG");
 
-        int arg = 0;
-
-        int gauss_seidel_inner_iterations;
-        int gauss_seidel_outer_iterations;
-        int newton_level;
-        int chebyshev_degree;
-        int richardson_iterations;
-        int communication = 0;
-        double ssor_omega;
-        std::string preconditioner_type = "";
-
-        preconditioner_type = preconditioner_params_m[arg++];
-        if (preconditioner_type == "newton") {
-            newton_level = std::stoi(preconditioner_params_m[arg++]);
-        } else if (preconditioner_type == "chebyshev") {
-            chebyshev_degree = std::stoi(preconditioner_params_m[arg++]);
-        } else if (preconditioner_type == "richardson") {
-            richardson_iterations = std::stoi(preconditioner_params_m[arg++]);
-            communication         = std::stoi(preconditioner_params_m[arg++]);
-        } else if (preconditioner_type == "gauss-seidel") {
-            gauss_seidel_inner_iterations = std::stoi(preconditioner_params_m[arg++]);
-            gauss_seidel_outer_iterations = std::stoi(preconditioner_params_m[arg++]);
-            communication                 = std::stoi(preconditioner_params_m[arg++]);
-        } else if (preconditioner_type == "ssor") {
-            gauss_seidel_inner_iterations = std::stoi(preconditioner_params_m[arg++]);
-            gauss_seidel_outer_iterations = std::stoi(preconditioner_params_m[arg++]);
-            ssor_omega                    = std::stod(preconditioner_params_m[arg++]);
-        }
-
-        sp.add("preconditioner_type", preconditioner_type);
-        sp.add("gauss_seidel_inner_iterations", gauss_seidel_inner_iterations);
-        sp.add("gauss_seidel_outer_iterations", gauss_seidel_outer_iterations);
-        sp.add("newton_level", newton_level);
-        sp.add("chebyshev_degree", chebyshev_degree);
-        sp.add("richardson_iterations", richardson_iterations);
-        sp.add("communication", communication);
-        sp.add("ssor_omega", ssor_omega);
+        sp.add("preconditioner_type", parsed.type);
+        sp.add("gauss_seidel_inner_iterations", parsed.gauss_seidel_inner_iterations);
+        sp.add("gauss_seidel_outer_iterations", parsed.gauss_seidel_outer_iterations);
+        sp.add("newton_level", parsed.newton_level);
+        sp.add("chebyshev_degree", parsed.chebyshev_degree);
+        sp.add("richardson_iterations", parsed.richardson_iterations);
+        sp.add("communication", parsed.communication);
+        sp.add("ssor_omega", parsed.ssor_omega);
 
         initSolverWithParams<CGSolver_t<T, Dim>>(sp);
     }
@@ -254,44 +321,16 @@ public:
         sp.add("solver", "preconditioned");
         sp.add("output_type", FEMPreconSolver_t<T, Dim>::SOL);
         sp.add("tolerance", 1e-4);
+        const auto parsed = parsePreconditionerParams("FEM_PRECON");
 
-        int arg = 0;
-
-        int gauss_seidel_inner_iterations;
-        int gauss_seidel_outer_iterations;
-        int newton_level;
-        int chebyshev_degree;
-        int richardson_iterations;
-        int communication = 0;
-        double ssor_omega;
-        std::string preconditioner_type = "";
-
-        preconditioner_type = preconditioner_params_m[arg++];
-        if (preconditioner_type == "newton") {
-            newton_level = std::stoi(preconditioner_params_m[arg++]);
-        } else if (preconditioner_type == "chebyshev") {
-            chebyshev_degree = std::stoi(preconditioner_params_m[arg++]);
-        } else if (preconditioner_type == "richardson") {
-            richardson_iterations = std::stoi(preconditioner_params_m[arg++]);
-            communication         = std::stoi(preconditioner_params_m[arg++]);
-        } else if (preconditioner_type == "gauss-seidel") {
-            gauss_seidel_inner_iterations = std::stoi(preconditioner_params_m[arg++]);
-            gauss_seidel_outer_iterations = std::stoi(preconditioner_params_m[arg++]);
-            communication                 = std::stoi(preconditioner_params_m[arg++]);
-        } else if (preconditioner_type == "ssor") {
-            gauss_seidel_inner_iterations = std::stoi(preconditioner_params_m[arg++]);
-            gauss_seidel_outer_iterations = std::stoi(preconditioner_params_m[arg++]);
-            ssor_omega                    = std::stod(preconditioner_params_m[arg++]);
-        }
-
-        sp.add("preconditioner_type", preconditioner_type);
-        sp.add("gauss_seidel_inner_iterations", gauss_seidel_inner_iterations);
-        sp.add("gauss_seidel_outer_iterations", gauss_seidel_outer_iterations);
-        sp.add("newton_level", newton_level);
-        sp.add("chebyshev_degree", chebyshev_degree);
-        sp.add("richardson_iterations", richardson_iterations);
-        sp.add("communication", communication);
-        sp.add("ssor_omega", ssor_omega);
+        sp.add("preconditioner_type", parsed.type);
+        sp.add("gauss_seidel_inner_iterations", parsed.gauss_seidel_inner_iterations);
+        sp.add("gauss_seidel_outer_iterations", parsed.gauss_seidel_outer_iterations);
+        sp.add("newton_level", parsed.newton_level);
+        sp.add("chebyshev_degree", parsed.chebyshev_degree);
+        sp.add("richardson_iterations", parsed.richardson_iterations);
+        sp.add("communication", parsed.communication);
+        sp.add("ssor_omega", parsed.ssor_omega);
         
         initSolverWithParams<FEMPreconSolver_t<T, Dim>>(sp);
     }

--- a/alpine/LandauDamping.cpp
+++ b/alpine/LandauDamping.cpp
@@ -43,59 +43,79 @@ const char* TestName   = "LandauDamping";
 
 int main(int argc, char* argv[]) {
     ippl::initialize(argc, argv);
+    int exit_code = 0;
     {
-        Inform msg(TestName);
-        Inform msg2all(TestName, INFORM_ALL_NODES);
+        try {
+            Inform msg(TestName);
+            Inform msg2all(TestName, INFORM_ALL_NODES);
 
-        static IpplTimings::TimerRef mainTimer = IpplTimings::getTimer("total");
-        static IpplTimings::TimerRef initializeTimer = IpplTimings::getTimer("initialize");
-        IpplTimings::startTimer(mainTimer);
-        IpplTimings::startTimer(initializeTimer);
+            static IpplTimings::TimerRef mainTimer = IpplTimings::getTimer("total");
+            static IpplTimings::TimerRef initializeTimer = IpplTimings::getTimer("initialize");
+            IpplTimings::startTimer(mainTimer);
+            IpplTimings::startTimer(initializeTimer);
 
-        // Read input parameters, assign them to the corresponding memebers of manager
-        int arg = 1;
-        Vector_t<int, Dim> nr;
-        for (unsigned d = 0; d < Dim; d++) {
-            nr[d] = std::atoi(argv[arg++]);
-        }
-
-        size_type totalP   = std::atoll(argv[arg++]);
-        int nt             = std::atoi(argv[arg++]);
-        std::string solver = argv[arg++];
-
-        double lbt              = std::atof(argv[arg++]);
-        std::string step_method = argv[arg++];
-
-        std::vector<std::string> preconditioner_params;
-
-        if (solver == "PCG" || solver == "FEM_PRECON") {
-            for (int i = 0; i < 5; i++) {
-                preconditioner_params.push_back(argv[arg++]);
+            // Read input parameters, assign them to the corresponding memebers of manager
+            int arg = 1;
+            Vector_t<int, Dim> nr;
+            for (unsigned d = 0; d < Dim; d++) {
+                nr[d] = std::atoi(argv[arg++]);
             }
+
+            size_type totalP   = std::atoll(argv[arg++]);
+            int nt             = std::atoi(argv[arg++]);
+            std::string solver = argv[arg++];
+
+            double lbt              = std::atof(argv[arg++]);
+            std::string step_method = argv[arg++];
+
+            std::vector<std::string> preconditioner_params;
+
+            if (solver == "PCG" || solver == "FEM_PRECON") {
+                while (arg < argc) {
+                    const std::string token = argv[arg];
+                    if (token.rfind("--", 0) == 0) {
+                        break;
+                    }
+                    preconditioner_params.push_back(token);
+                    ++arg;
+                }
+            }
+
+            // Create an instance of a manager for the considered application
+            LandauDampingManager<T, Dim> manager(totalP, nt, nr, lbt, solver, step_method,
+                                                 preconditioner_params);
+
+            // Perform pre-run operations, including creating mesh, particles,...
+            manager.pre_run();
+
+            IpplTimings::stopTimer(initializeTimer);
+
+            manager.setTime(0.0);
+
+            msg << "Starting iterations ..." << endl;
+
+            manager.run(manager.getNt());
+
+            msg << "End." << endl;
+
+            IpplTimings::stopTimer(mainTimer);
+            IpplTimings::print();
+            IpplTimings::print(std::string("timing.dat"));
+        } catch (const IpplException& ex) {
+            Inform err(TestName);
+            err << "IPPL exception: " << ex.what() << endl;
+            exit_code = 1;
+        } catch (const std::exception& ex) {
+            Inform err(TestName);
+            err << "Unhandled std::exception: " << ex.what() << endl;
+            exit_code = 1;
+        } catch (...) {
+            Inform err(TestName);
+            err << "Unhandled unknown exception" << endl;
+            exit_code = 1;
         }
-
-        // Create an instance of a manager for the considered application
-        LandauDampingManager<T, Dim> manager(totalP, nt, nr, lbt, solver, step_method,
-                                             preconditioner_params);
-
-        // Perform pre-run operations, including creating mesh, particles,...
-        manager.pre_run();
-
-        IpplTimings::stopTimer(initializeTimer);
-        
-        manager.setTime(0.0);
-
-        msg << "Starting iterations ..." << endl;
-
-        manager.run(manager.getNt());
-
-        msg << "End." << endl;
-
-        IpplTimings::stopTimer(mainTimer);
-        IpplTimings::print();
-        IpplTimings::print(std::string("timing.dat"));
     }
     ippl::finalize();
 
-    return 0;
+    return exit_code;
 }

--- a/alpine/PenningTrap.cpp
+++ b/alpine/PenningTrap.cpp
@@ -44,55 +44,74 @@ const char* TestName   = "PenningTrap";
 
 int main(int argc, char* argv[]) {
     ippl::initialize(argc, argv);
+    int exit_code = 0;
     {
-        Inform msg(TestName);
-        Inform msg2all(TestName, INFORM_ALL_NODES);
+        try {
+            Inform msg(TestName);
+            Inform msg2all(TestName, INFORM_ALL_NODES);
 
-        static IpplTimings::TimerRef mainTimer = IpplTimings::getTimer("total");
-        IpplTimings::startTimer(mainTimer);
+            static IpplTimings::TimerRef mainTimer = IpplTimings::getTimer("total");
+            IpplTimings::startTimer(mainTimer);
 
-        // Read input parameters, assign them to the corresponding memebers of manager
-        int arg = 1;
-        Vector_t<int, Dim> nr;
+            // Read input parameters, assign them to the corresponding memebers of manager
+            int arg = 1;
+            Vector_t<int, Dim> nr;
 
-        for (unsigned d = 0; d < Dim; d++) {
-            nr[d] = std::atoi(argv[arg++]);
-        }
-        size_type totalP        = std::atoll(argv[arg++]);
-        int nt                  = std::atoi(argv[arg++]);
-        std::string solver      = argv[arg++];
-        double lbt              = std::atof(argv[arg++]);
-        std::string step_method = argv[arg++];
-
-        std::vector<std::string> preconditioner_params;
-
-        // Create an instance of a manger for the considered application
-        if (solver == "PCG") {
-            for (int i = 0; i < 5; i++) {
-                preconditioner_params.push_back(argv[arg++]);
+            for (unsigned d = 0; d < Dim; d++) {
+                nr[d] = std::atoi(argv[arg++]);
             }
+            size_type totalP        = std::atoll(argv[arg++]);
+            int nt                  = std::atoi(argv[arg++]);
+            std::string solver      = argv[arg++];
+            double lbt              = std::atof(argv[arg++]);
+            std::string step_method = argv[arg++];
+
+            std::vector<std::string> preconditioner_params;
+
+            if (solver == "PCG" || solver == "FEM_PRECON") {
+                while (arg < argc) {
+                    const std::string token = argv[arg];
+                    if (token.rfind("--", 0) == 0) {
+                        break;
+                    }
+                    preconditioner_params.push_back(token);
+                    ++arg;
+                }
+            }
+
+            // Create an instance of a manger for the considered application
+            PenningTrapManager<T, Dim> manager(totalP, nt, nr, lbt, solver, step_method,
+                                               preconditioner_params);
+
+            // Perform pre-run operations, including creating mesh, particles,...
+            manager.pre_run();
+
+            manager.setTime(0.0);
+
+            msg << "Starting iterations ..." << endl;
+
+            manager.run(manager.getNt());
+
+            msg << "End." << endl;
+
+            IpplTimings::stopTimer(mainTimer);
+            IpplTimings::print();
+            IpplTimings::print(std::string("timing.dat"));
+        } catch (const IpplException& ex) {
+            Inform err(TestName);
+            err << "IPPL exception: " << ex.what() << endl;
+            exit_code = 1;
+        } catch (const std::exception& ex) {
+            Inform err(TestName);
+            err << "Unhandled std::exception: " << ex.what() << endl;
+            exit_code = 1;
+        } catch (...) {
+            Inform err(TestName);
+            err << "Unhandled unknown exception" << endl;
+            exit_code = 1;
         }
-
-        // Create an instance of a manger for the considered application
-        PenningTrapManager<T, Dim> manager(totalP, nt, nr, lbt, solver, step_method,
-                                           preconditioner_params);
-
-        // Perform pre-run operations, including creating mesh, particles,...
-        manager.pre_run();
-
-        manager.setTime(0.0);
-
-        msg << "Starting iterations ..." << endl;
-
-        manager.run(manager.getNt());
-
-        msg << "End." << endl;
-
-        IpplTimings::stopTimer(mainTimer);
-        IpplTimings::print();
-        IpplTimings::print(std::string("timing.dat"));
     }
     ippl::finalize();
 
-    return 0;
+    return exit_code;
 }

--- a/src/LinearSolvers/PCG.h
+++ b/src/LinearSolvers/PCG.h
@@ -9,8 +9,28 @@
 #include "FEM/FEMVector.h"
 #include "Preconditioner.h"
 #include "SolverAlgorithm.h"
+#include <array>
+#include <algorithm>
 
 namespace ippl {
+    namespace pcg_preconditioner_defaults {
+        inline constexpr int newton_level = 5;
+        inline constexpr int chebyshev_degree = 31;
+        inline constexpr int richardson_iterations = 4;
+        inline constexpr int gauss_seidel_inner = 2;
+        inline constexpr int gauss_seidel_outer = 2;
+        inline constexpr int communication = 0;
+        inline constexpr double ssor_omega = 1.57079632679;
+
+        inline constexpr std::array<const char*, 7> valid_types = {
+            "jacobi", "newton", "chebyshev", "richardson", "richardson_alt", "gauss-seidel", "ssor"
+        };
+
+        inline bool is_valid_type(const std::string& type) {
+            return std::find(valid_types.begin(), valid_types.end(), type) != valid_types.end();
+        }
+    }  // namespace pcg_preconditioner_defaults
+
     template <typename OperatorRet, typename LowerRet, typename UpperRet, typename UpperLowerRet,
               typename InverseDiagRet, typename DiagRet, typename FieldLHS,
               typename FieldRHS = FieldLHS>
@@ -62,20 +82,20 @@ namespace ippl {
             [[maybe_unused]] std::string preconditioner_type =
                 "",  // Name of the preconditioner that should be used
             [[maybe_unused]] int level =
-                5,  // This is a dummy default parameter, actual default parameter should be
+                pcg_preconditioner_defaults::newton_level,  // This is a dummy default parameter, actual default parameter should be
             // set in main
             [[maybe_unused]] int degree =
-                31,  // This is a dummy default parameter, actual default parameter should
+                pcg_preconditioner_defaults::chebyshev_degree,  // This is a dummy default parameter, actual default parameter should
             // be set in main
             [[maybe_unused]] int richardson_iterations =
-                1,  // This is a dummy default parameter, actual default
+                pcg_preconditioner_defaults::richardson_iterations,  // This is a dummy default parameter, actual default
             // parameter should be set in main
             [[maybe_unused]] int inner =
-                5,  // This is a dummy default parameter, actual default parameter should be
+                pcg_preconditioner_defaults::gauss_seidel_inner,  // This is a dummy default parameter, actual default parameter should be
             // set in main
             [[maybe_unused]] int outer =
-                1,  // This is a dummy default parameter, actual default parameter should be
-            [[maybe_unused]] double omega = 1  // This is a dummy default parameter, actual default
+                pcg_preconditioner_defaults::gauss_seidel_outer,  // This is a dummy default parameter, actual default parameter should be
+            [[maybe_unused]] double omega = pcg_preconditioner_defaults::ssor_omega  // This is a dummy default parameter, actual default
                                                // parameter should be set in main
         ) {}
         /*!
@@ -229,18 +249,18 @@ namespace ippl {
             [[maybe_unused]] std::string preconditioner_type =
                 "",  // Name of the preconditioner that should be used
             [[maybe_unused]] int level =
-                5,  // This is a dummy default parameter, actual default parameter should be
+                pcg_preconditioner_defaults::newton_level,  // This is a dummy default parameter, actual default parameter should be
             // set in main
             [[maybe_unused]] int degree =
-                31,  // This is a dummy default parameter, actual default parameter should
+                pcg_preconditioner_defaults::chebyshev_degree,  // This is a dummy default parameter, actual default parameter should
             // be set in main
             [[maybe_unused]] int richardson_iterations =
-                1,  // This is a dummy default parameter, actual default
+                pcg_preconditioner_defaults::richardson_iterations,  // This is a dummy default parameter, actual default
             // parameter should be set in main
             [[maybe_unused]] int inner =
-                5,  // This is a dummy default parameter, actual default parameter should be
+                pcg_preconditioner_defaults::gauss_seidel_inner,  // This is a dummy default parameter, actual default parameter should be
             // set in main
-            [[maybe_unused]] int outer = 1  // This is a dummy default parameter, actual default
+            [[maybe_unused]] int outer = pcg_preconditioner_defaults::gauss_seidel_outer  // This is a dummy default parameter, actual default
                                             // parameter should be set in main
         ) {}
         /*!
@@ -357,17 +377,17 @@ namespace ippl {
             double alpha,                     // smallest eigenvalue of the operator
             double beta,                      // largest eigenvalue of the operator
             std::string preconditioner_type = "",  // Name of the preconditioner that should be used
-            int level = 5,  // This is a dummy default parameter, actual default parameter should be
+            int level = pcg_preconditioner_defaults::newton_level,  // This is a dummy default parameter, actual default parameter should be
             // set in main
-            int degree = 31,  // This is a dummy default parameter, actual default parameter should
+            int degree = pcg_preconditioner_defaults::chebyshev_degree,  // This is a dummy default parameter, actual default parameter should
             // be set in main
-            int richardson_iterations = 4,  // This is a dummy default parameter, actual default
+            int richardson_iterations = pcg_preconditioner_defaults::richardson_iterations,  // This is a dummy default parameter, actual default
             // parameter should be set in main
-            int inner = 2,  // This is a dummy default parameter, actual default parameter should be
+            int inner = pcg_preconditioner_defaults::gauss_seidel_inner,  // This is a dummy default parameter, actual default parameter should be
             // set in main
-            int outer = 2,  // This is a dummy default parameter, actual default parameter should be
+            int outer = pcg_preconditioner_defaults::gauss_seidel_outer,  // This is a dummy default parameter, actual default parameter should be
             // set in main
-            double omega = 1.57079632679  // This is a dummy default parameter, actual default
+            double omega = pcg_preconditioner_defaults::ssor_omega  // This is a dummy default parameter, actual default
             // parameter should be set in main
             // default = pi/2 as this was found optimal during hyperparameter scan for test case
             // (see

--- a/src/LinearSolvers/PreconditionerValidation.h
+++ b/src/LinearSolvers/PreconditionerValidation.h
@@ -1,0 +1,72 @@
+#ifndef IPPL_PRECONDITIONER_VALIDATION_H
+#define IPPL_PRECONDITIONER_VALIDATION_H
+
+#include <cmath>
+#include <string>
+
+#include "LinearSolvers/PCG.h"
+#include "Utility/Inform.h"
+#include "Utility/IpplException.h"
+
+namespace ippl::preconditioner_validation {
+    inline void throwIfUnknownType(const std::string& preconditioner_type,
+                                   const std::string& caller_name) {
+        if (!pcg_preconditioner_defaults::is_valid_type(preconditioner_type)) {
+            throw IpplException(
+                caller_name.c_str(),
+                ("Unknown preconditioner_type '" + preconditioner_type
+                 + "'. Supported types: jacobi, newton, chebyshev, richardson, "
+                   "richardson_alt, gauss-seidel, ssor")
+                    .c_str());
+        }
+    }
+
+    inline void sanitizeParams(const std::string& preconditioner_type, Inform& warn, int& level,
+                               int& degree, int& richardson_iterations, int& inner, int& outer,
+                               double& omega, int* communication = nullptr) {
+        auto warnAndDefault = [&](const std::string& what, const std::string& value,
+                                  const std::string& default_value) {
+            warn << "Invalid " << what << "='" << value << "' for preconditioner '"
+                 << preconditioner_type << "'. Using default " << what << "=" << default_value << "."
+                 << endl;
+        };
+
+        if (level <= 0) {
+            warnAndDefault("newton_level", std::to_string(level),
+                           std::to_string(pcg_preconditioner_defaults::newton_level));
+            level = pcg_preconditioner_defaults::newton_level;
+        }
+        if (degree <= 0) {
+            warnAndDefault("chebyshev_degree", std::to_string(degree),
+                           std::to_string(pcg_preconditioner_defaults::chebyshev_degree));
+            degree = pcg_preconditioner_defaults::chebyshev_degree;
+        }
+        if (richardson_iterations <= 0) {
+            warnAndDefault("richardson_iterations", std::to_string(richardson_iterations),
+                           std::to_string(pcg_preconditioner_defaults::richardson_iterations));
+            richardson_iterations = pcg_preconditioner_defaults::richardson_iterations;
+        }
+        if (inner <= 0) {
+            warnAndDefault("gauss_seidel_inner_iterations", std::to_string(inner),
+                           std::to_string(pcg_preconditioner_defaults::gauss_seidel_inner));
+            inner = pcg_preconditioner_defaults::gauss_seidel_inner;
+        }
+        if (outer <= 0) {
+            warnAndDefault("gauss_seidel_outer_iterations", std::to_string(outer),
+                           std::to_string(pcg_preconditioner_defaults::gauss_seidel_outer));
+            outer = pcg_preconditioner_defaults::gauss_seidel_outer;
+        }
+        if (!std::isfinite(omega)) {
+            warnAndDefault("ssor_omega", std::to_string(omega),
+                           std::to_string(pcg_preconditioner_defaults::ssor_omega));
+            omega = pcg_preconditioner_defaults::ssor_omega;
+        }
+        if (communication != nullptr && !(*communication == 0 || *communication == 1)) {
+            warnAndDefault("communication", std::to_string(*communication),
+                           std::to_string(pcg_preconditioner_defaults::communication));
+            *communication = pcg_preconditioner_defaults::communication;
+        }
+    }
+}  // namespace ippl::preconditioner_validation
+
+#endif

--- a/src/PoissonSolvers/PoissonCG.h
+++ b/src/PoissonSolvers/PoissonCG.h
@@ -8,15 +8,16 @@
 
 #include "LaplaceHelpers.h"
 #include "LinearSolvers/PCG.h"
+#include "LinearSolvers/PreconditionerValidation.h"
 #include "Poisson.h"
 namespace ippl {
 
-// IPPL_SOLVER_OPERATOR_WRAPPER is defined once in LinearSolvers/Preconditioner.h
-// (re-exported through this header via PCG.h). Defining it again here used to
-// silently shadow that definition with a by-value lambda, which copies the
-// Field on every op_m() call and reintroduces the per-iteration cudaMalloc
-// in the halo exchange (the realloc never propagates back to the original
-// Field). Keep a single by-reference definition.
+    // IPPL_SOLVER_OPERATOR_WRAPPER is defined once in LinearSolvers/Preconditioner.h
+    // (re-exported through this header via PCG.h). Defining it again here used to
+    // silently shadow that definition with a by-value lambda, which copies the
+    // Field on every op_m() call and reintroduces the per-iteration cudaMalloc
+    // in the halo exchange (the realloc never propagates back to the original
+    // Field). Keep a single by-reference definition.
 
     template <typename FieldLHS, typename FieldRHS = FieldLHS>
     class PoissonCG : public Poisson<FieldLHS, FieldRHS> {
@@ -63,8 +64,13 @@ namespace ippl {
                 algo_m = std::move(
                     std::make_unique<PCG<OperatorRet, LowerRet, UpperRet, UpperAndLowerRet,
                                          InverseDiagonalRet, DiagRet, FieldLHS, FieldRHS>>());
+                // Get the preconditioner type,
+                // if it is not part of the valid list of preconditioners, throw an error.
                 std::string preconditioner_type =
                     this->params_m.template get<std::string>("preconditioner_type");
+                preconditioner_validation::throwIfUnknownType(preconditioner_type, "PoissonCG::setSolver");
+
+                // Read in the preconditioner parameters
                 int level    = this->params_m.template get<int>("newton_level");
                 int degree   = this->params_m.template get<int>("chebyshev_degree");
                 int inner    = this->params_m.template get<int>("gauss_seidel_inner_iterations");
@@ -73,6 +79,14 @@ namespace ippl {
                 int richardson_iterations =
                     this->params_m.template get<int>("richardson_iterations");
                 int communication = this->params_m.template get<int>("communication");
+
+                Inform warn("PoissonCG");
+                // After reading in preconditioner parameters, if they are invalid, 
+                // the user is warned that the parameter is invalid, and a default
+                // parameter is used.
+                preconditioner_validation::sanitizeParams(preconditioner_type, warn, level, degree,
+                                                         richardson_iterations, inner, outer, omega,
+                                                         &communication);
                 // Analytical eigenvalues for the d dimensional laplace operator
                 // Going brute force through all possible eigenvalues seems to be the only way to
                 // find max and min

--- a/src/PoissonSolvers/PreconditionedFEMPoissonSolver.h
+++ b/src/PoissonSolvers/PreconditionedFEMPoissonSolver.h
@@ -9,6 +9,7 @@
 #include "EvalFunctor.h"
 #include "LaplaceHelpers.h"
 #include "LinearSolvers/PCG.h"
+#include "LinearSolvers/PreconditionerValidation.h"
 #include "Poisson.h"
 
 namespace ippl {
@@ -184,12 +185,18 @@ namespace ippl {
             // set preconditioner for PCG
             std::string preconditioner_type =
                 this->params_m.template get<std::string>("preconditioner_type");
+            preconditioner_validation::throwIfUnknownType(preconditioner_type,
+                                                          "PreconditionedFEMPoissonSolver::solve");
+
+            Inform warn("PreconditionedFEMPoissonSolver");
             int level    = this->params_m.template get<int>("newton_level");
             int degree   = this->params_m.template get<int>("chebyshev_degree");
             int inner    = this->params_m.template get<int>("gauss_seidel_inner_iterations");
             int outer    = this->params_m.template get<int>("gauss_seidel_outer_iterations");
             double omega = this->params_m.template get<double>("ssor_omega");
             int richardson_iterations = this->params_m.template get<int>("richardson_iterations");
+            preconditioner_validation::sanitizeParams(preconditioner_type, warn, level, degree,
+                                                     richardson_iterations, inner, outer, omega);
 
             pcg_algo_m.setPreconditioner(algoOperator, algoOperatorL, algoOperatorU, algoOperatorUL,
                                          algoOperatorInvD, algoOperatorD, 0, 0, preconditioner_type,

--- a/test/solver/CMakeLists.txt
+++ b/test/solver/CMakeLists.txt
@@ -14,6 +14,7 @@ add_ippl_integration_test(TestCGSolver ARGS 4 j LABELS solver integration)
 add_ippl_integration_test(TestSolverDesign COMPILE_ONLY LABELS solver integration)
 add_ippl_integration_test(TestCGSolver_convergence_constant COMPILE_ONLY LABELS solver integration)
 add_ippl_integration_test(TestCGSolver_convergence_periodic COMPILE_ONLY LABELS solver integration)
+add_ippl_integration_test(TestPreconditionerValidation LABELS solver integration)
 
 if(IPPL_ENABLE_FFT)
   # tests FFTPeriodicPoissonSolver

--- a/test/solver/TestPreconditionerValidation.cpp
+++ b/test/solver/TestPreconditionerValidation.cpp
@@ -1,0 +1,94 @@
+// Integration test for preconditioner input validation behavior.
+//
+// Verifies two policies:
+// 1) Unknown preconditioner types are rejected with an exception.
+// 2) Known preconditioners with invalid tuning values are accepted by
+//    falling back to default parameters (with warnings).
+#include "Ippl.h"
+
+#include <array>
+#include <exception>
+#include <limits>
+#include <memory>
+
+#include "PoissonSolvers/PoissonCG.h"
+
+int main(int argc, char* argv[]) {
+    ippl::initialize(argc, argv);
+    {
+        constexpr unsigned int dim = 3;
+        using Mesh_t                = ippl::UniformCartesian<double, dim>;
+        using Centering_t           = Mesh_t::DefaultCentering;
+        using Field_t               = ippl::Field<double, dim, Mesh_t, Centering_t>;
+        using BConds_t              = ippl::BConds<Field_t, dim>;
+
+        ippl::Vector<unsigned, dim> I(4);
+        ippl::NDIndex<dim> domain(I);
+        std::array<bool, dim> isParallel;
+        isParallel.fill(true);
+
+        ippl::FieldLayout<dim> layout(MPI_COMM_WORLD, domain, isParallel);
+        ippl::Vector<double, dim> hx     = 1.0 / 4.0;
+        ippl::Vector<double, dim> origin = 0.0;
+        Mesh_t mesh(domain, hx, origin);
+
+        Field_t rhs(mesh, layout);
+        Field_t lhs(mesh, layout);
+        rhs = 0.0;
+        lhs = 0.0;
+
+        BConds_t bcField;
+        for (unsigned int i = 0; i < 2 * dim; ++i) {
+            bcField[i] = std::make_shared<ippl::PeriodicFace<Field_t>>(i);
+        }
+        rhs.setFieldBC(bcField);
+        lhs.setFieldBC(bcField);
+
+        bool unknownTypeThrows = false;
+        try {
+            ippl::PoissonCG<Field_t> solver;
+            ippl::ParameterList params;
+            params.add("solver", "preconditioned");
+            params.add("preconditioner_type", "my_preconditioner");
+            solver.mergeParameters(params);
+            solver.setRhs(rhs);
+            solver.setLhs(lhs);
+        } catch (const IpplException&) {
+            unknownTypeThrows = true;
+        } catch (...) {
+            unknownTypeThrows = true;
+        }
+
+        if (!unknownTypeThrows) {
+            ippl::finalize();
+            return 1;
+        }
+
+        bool invalidKnownTypeAccepted = true;
+        try {
+            ippl::PoissonCG<Field_t> solver;
+            ippl::ParameterList params;
+            params.add("solver", "preconditioned");
+            params.add("preconditioner_type", "ssor");
+            params.add("newton_level", -1);
+            params.add("chebyshev_degree", -1);
+            params.add("gauss_seidel_inner_iterations", -2);
+            params.add("gauss_seidel_outer_iterations", -3);
+            params.add("richardson_iterations", -4);
+            params.add("communication", 5);
+            params.add("ssor_omega", std::numeric_limits<double>::quiet_NaN());
+            solver.mergeParameters(params);
+            solver.setRhs(rhs);
+            solver.setLhs(lhs);
+        } catch (...) {
+            invalidKnownTypeAccepted = false;
+        }
+
+        if (!invalidKnownTypeAccepted) {
+            ippl::finalize();
+            return 2;
+        }
+    }
+    ippl::finalize();
+    return 0;
+}


### PR DESCRIPTION
The preconditioner parameters are not thoroughly checked in IPPL when using the PoissonCG solver. This causes undefined behaviour in the alpine mini-apps when an unknown preconditioner type is passed, see issue #546.

This PR adds preconditioner input validation across alpine mini-apps and library solvers, with consistent error/warning behavior and centralized default values.

Problem
- Unknown preconditioner types (e.g. multigrid) were not rejected.
- Known preconditioners could be given the wrong number of parameters with no clear feedback.
- Default preconditioner values were duplicated in several places.
- Alpine examples always read exactly five preconditioner parameters, even when fewer were needed.

Solution:
- Added a validation file: src/LinearSolvers/PreconditionerValidation.h which provides functions for checking preconditioner parameters. 
- If unknown preconditioner type, throw an error and abort.
- If the number of parameters given are wrong or they are invalid (e.g. negative number of iterations), then a warning is printed, and default parameters are used.

Test:
- A test is added, test/solver/TestPreconditionerValidation.cpp.

This closes issue #546.

This PR was made in collaboration with Cursor.