### PR TITLE
Add integrated Green function for FFT open solver

### DIFF
--- a/src/PoissonSolvers/FFTOpenPoissonSolver.h
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.h
@@ -53,7 +53,40 @@ namespace ippl {
             DCT_VICO   = 0b100
         };
 
-        // enum type for the real-space Green's function used by Hockney
+        /**
+         * @brief Real-space Green-function model used by the Hockney open-boundary solver.
+         *
+         * `STANDARD` samples the free-space Green function at doubled-grid points:
+         * @f[
+         *   G(\mathbf{r}) = -\frac{1}{4\pi |\mathbf{r}|}.
+         * @f]
+         *
+         * `INTEGRATED` uses the cell-averaged Green function of Qiang et al.
+         * for a uniform charge density in each source cell:
+         * @f[
+         *   \overline{G}(\mathbf{r}) =
+         *   -\frac{1}{4\pi h_x h_y h_z}
+         *   \int_{-h_x/2}^{h_x/2}
+         *   \int_{-h_y/2}^{h_y/2}
+         *   \int_{-h_z/2}^{h_z/2}
+         *   \frac{dx' dy' dz'}
+         *        {\sqrt{(x-x')^2 + (y-y')^2 + (z-z')^2}}.
+         * @f]
+         *
+         * The integrated kernel is currently supported for 3D Hockney open
+         * boundary conditions only. It is intended for high-aspect-ratio beams
+         * where point sampling of @f$1/r@f$ can be inefficient near narrow
+         * dimensions.
+         *
+         * References:
+         * - J. Qiang, S. M. Lidia, R. D. Ryne, and C. Limborg-Deprey,
+         *   "Three-Dimensional Quasi-Static Model for High Brightness Beam
+         *   Dynamics Simulation," Phys. Rev. ST Accel. Beams 9, 044204 (2006),
+         *   https://doi.org/10.1103/PhysRevSTAB.9.044204.
+         * - J. Qiang et al., LBNL-59098,
+         *   http://repositories.cdlib.org/lbnl/LBNL-59098.
+         * - See also IPPL issue #556.
+         */
         enum GreenFunction {
             STANDARD   = 0,
             INTEGRATED = 1
@@ -113,30 +146,48 @@ namespace ippl {
             return &hess_m;
         }
 
-        // compute Green's function
+        /**
+         * @brief Compute and cache the FFT of the selected Green function.
+         *
+         * The selected kernel is controlled by the integer parameter
+         * `greens_function`, with values from GreenFunction. For Hockney, the
+         * real-space kernel is filled on the doubled convolution grid and then
+         * transformed into `grntr_m`. The default is GreenFunction::STANDARD to
+         * preserve historical IPPL behavior.
+         */
         void greensFunction();
 
-        // Replace the cached FFT Green's function (grntr_m) with the FFT of a
-        // free-space Green's function translated by `shift` in real space. For
-        // `greens_function = STANDARD`, this is the point-sampled kernel
-        // G(r) = -1 / (4 pi |r - shift|). For `greens_function = INTEGRATED`,
-        // this is the cell-averaged kernel translated by `shift`. After this
-        // call, solve() will convolve rho with the shifted kernel instead of
-        // the standard one, up to the usual caveat that solve() recomputes
-        // greensFunction() if it detects a change in mesh spacing, so the caller
-        // should keep the mesh fixed between setup and solve().
-        //
-        // To restore the standard kernel, call greensFunction() explicitly.
-        //
-        // Intended use for Dirichlet boundary conditions via the method of
-        // images: pick `shift[d] = 2 * (plane[d] - domain_center[d])` for each
-        // axis with a Dirichlet plane, then call solve() and axis-flip the
-        // resulting potential in the active axes to obtain the image-charge
-        // contribution. The caller composes open-BC and image contributions
-        // additively. See test/solver/TestShiftedGreensFunction.cpp for the
-        // reference orchestration.
-        //
-        // Preconditions: algorithm = HOCKNEY (throws otherwise).
+        /**
+         * @brief Replace the cached kernel by a shifted Hockney Green function.
+         *
+         * For GreenFunction::STANDARD, the shifted kernel is
+         * @f[
+         *   G_s(\mathbf{r}) = -\frac{1}{4\pi |\mathbf{r}-\mathbf{s}|},
+         * @f]
+         * where @f$\mathbf{s}@f$ is `shift`.
+         *
+         * For GreenFunction::INTEGRATED, the same translation is applied before
+         * the cell average:
+         * @f[
+         *   \overline{G}_s(\mathbf{r}) =
+         *   -\frac{1}{4\pi h_x h_y h_z}
+         *   \int_{\mathrm{cell}}
+         *   \frac{d^3\mathbf{r}'}
+         *        {|\mathbf{r}-\mathbf{s}-\mathbf{r}'|}.
+         * @f]
+         *
+         * After this call, solve() convolves the RHS with the shifted kernel
+         * until greensFunction() is called again or the mesh spacing changes.
+         *
+         * Intended use for Dirichlet boundary conditions via the method of
+         * images: choose the shift from the plane location and domain center,
+         * solve with the shifted kernel, then let the caller flip/sign-compose
+         * the image contribution. See test/solver/TestShiftedGreensFunction.cpp
+         * for the reference orchestration.
+         *
+         * @pre `algorithm == HOCKNEY`.
+         * @pre GreenFunction::INTEGRATED additionally requires `Dim == 3`.
+         */
         void shiftedGreensFunction(const Vector<double, Dim>& shift);
 
         // function called in the constructor to initialize the fields
@@ -233,6 +284,20 @@ namespace ippl {
         // buffer for communication
         detail::FieldBufferData<Trhs> fd_m;
 
+        /**
+         * @brief Closed-form antiderivative for the integrated 3D Green kernel.
+         *
+         * Let @f$r=\sqrt{x^2+y^2+z^2}@f$. This evaluates
+         * @f[
+         * F(x,y,z) =
+         * -\frac{z^2}{2}\tan^{-1}\!\left(\frac{xy}{zr}\right)
+         * -\frac{y^2}{2}\tan^{-1}\!\left(\frac{xz}{yr}\right)
+         * -\frac{x^2}{2}\tan^{-1}\!\left(\frac{yz}{xr}\right)
+         * + yz\ln(x+r) + xz\ln(y+r) + xy\ln(z+r).
+         * @f]
+         * The integrated kernel is formed by the eight-corner difference of
+         * @f$F@f$ divided by the cell volume.
+         */
         KOKKOS_INLINE_FUNCTION static scalar_type integratedGreenAntiderivative(
             const scalar_type& x, const scalar_type& y, const scalar_type& z);
 
@@ -244,6 +309,13 @@ namespace ippl {
         KOKKOS_INLINE_FUNCTION static scalar_type integratedGreenAtanTerm(
             const scalar_type& numerator, const scalar_type& denominator);
 
+        /**
+         * @brief Cell average of @f$1/r@f$ over a cell centered at `(x,y,z)`.
+         *
+         * The returned value is the cell average without the Poisson prefactor;
+         * callers multiply by @f$-1/(4\pi)@f$ to match IPPL's Hockney sign
+         * convention.
+         */
         KOKKOS_INLINE_FUNCTION static scalar_type integratedGreenAverage(const scalar_type& x,
                                                                          const scalar_type& y,
                                                                          const scalar_type& z,

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.h
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.h
@@ -53,6 +53,12 @@ namespace ippl {
             DCT_VICO   = 0b100
         };
 
+        // enum type for the real-space Green's function used by Hockney
+        enum GreenFunction {
+            STANDARD   = 0,
+            INTEGRATED = 1
+        };
+
         // define a type for a 3 dimensional field (e.g. charge density field)
         // define a type of Field with integers to be used for the helper Green's function
         // also define a type for the Fourier transformed complex valued fields
@@ -107,17 +113,18 @@ namespace ippl {
             return &hess_m;
         }
 
-        // compute standard Green's function
+        // compute Green's function
         void greensFunction();
 
         // Replace the cached FFT Green's function (grntr_m) with the FFT of a
-        // free-space Green's function translated by `shift` in real space, i.e.
-        //   G(r) = -1 / (4 pi |r - shift|)
-        // using the same sign convention as greensFunction() (HOCKNEY). After
-        // this call, solve() will convolve rho with the shifted kernel instead
-        // of the standard one, up to the usual caveat that solve() recomputes
-        // greensFunction() if it detects a change in mesh spacing, so the
-        // caller should keep the mesh fixed between setup and solve().
+        // free-space Green's function translated by `shift` in real space. For
+        // `greens_function = STANDARD`, this is the point-sampled kernel
+        // G(r) = -1 / (4 pi |r - shift|). For `greens_function = INTEGRATED`,
+        // this is the cell-averaged kernel translated by `shift`. After this
+        // call, solve() will convolve rho with the shifted kernel instead of
+        // the standard one, up to the usual caveat that solve() recomputes
+        // greensFunction() if it detects a change in mesh spacing, so the caller
+        // should keep the mesh fixed between setup and solve().
         //
         // To restore the standard kernel, call greensFunction() explicitly.
         //
@@ -226,6 +233,22 @@ namespace ippl {
         // buffer for communication
         detail::FieldBufferData<Trhs> fd_m;
 
+        KOKKOS_INLINE_FUNCTION static scalar_type integratedGreenAntiderivative(
+            const scalar_type& x, const scalar_type& y, const scalar_type& z);
+
+        KOKKOS_INLINE_FUNCTION static scalar_type integratedGreenLogTerm(const scalar_type& a,
+                                                                         const scalar_type& b,
+                                                                         const scalar_type& c,
+                                                                         const scalar_type& r);
+
+        KOKKOS_INLINE_FUNCTION static scalar_type integratedGreenAtanTerm(
+            const scalar_type& numerator, const scalar_type& denominator);
+
+        KOKKOS_INLINE_FUNCTION static scalar_type integratedGreenAverage(const scalar_type& x,
+                                                                         const scalar_type& y,
+                                                                         const scalar_type& z,
+                                                                         const vector_type& h);
+
     protected:
         virtual void setDefaultParameters() override {
             using heffteBackend       = typename FFT_t::heffteBackend;
@@ -254,6 +277,7 @@ namespace ippl {
             }
 
             this->params_m.add("algorithm", HOCKNEY);
+            this->params_m.add("greens_function", STANDARD);
             this->params_m.add("hessian", false);
         }
     };

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
@@ -15,7 +15,6 @@ namespace ippl {
     using detail::solver_send;
     using detail::unpack;
 
-
     /////////////////////////////////////////////////////////////////////////
     // constructor and destructor
     template <typename FieldLHS, typename FieldRHS>
@@ -122,8 +121,9 @@ namespace ippl {
     template <typename FieldLHS, typename FieldRHS>
     void FFTOpenPoissonSolver<FieldLHS, FieldRHS>::initializeFields() {
         // get algorithm and hessian flag from parameter list
-        const int alg      = this->params_m.template get<int>("algorithm");
-        const bool hessian = this->params_m.template get<bool>("hessian");
+        const int alg                = this->params_m.template get<int>("algorithm");
+        const int greensFunctionType = this->params_m.template get<int>("greens_function");
+        const bool hessian           = this->params_m.template get<bool>("hessian");
 
         // first check if valid algorithm choice
         if ((alg != Algorithm::VICO) && (alg != Algorithm::HOCKNEY)
@@ -131,6 +131,20 @@ namespace ippl {
             throw IpplException("FFTOpenPoissonSolver::initializeFields()",
                                 "Currently only HOCKNEY, VICO, DCT_VICO, and BIHARMONIC are "
                                 "supported for open BCs");
+        }
+
+        if ((greensFunctionType != GreenFunction::STANDARD)
+            && (greensFunctionType != GreenFunction::INTEGRATED)) {
+            throw IpplException("FFTOpenPoissonSolver::initializeFields()",
+                                "Currently only STANDARD and INTEGRATED Green's functions are "
+                                "supported for open BCs");
+        }
+
+        if ((greensFunctionType == GreenFunction::INTEGRATED)
+            && ((alg != Algorithm::HOCKNEY) || (Dim != 3))) {
+            throw IpplException("FFTOpenPoissonSolver::initializeFields()",
+                                "The integrated Green's function is currently only implemented "
+                                "for 3D HOCKNEY open BCs");
         }
 
         // check dimension
@@ -285,7 +299,7 @@ namespace ippl {
                     grnIField_m[gd].getFieldRangePolicy(),
                     KOKKOS_LAMBDA(const index_array_type& args) {
                         scalar_type checkVal = 0.0;
-                                
+
                         // go from local indices to global
                         Vector<int, Dim> igVec = args - nghost;
                         for (unsigned d = 0; d < Dim; ++d) {
@@ -295,15 +309,13 @@ namespace ippl {
 
                         // assign (index)^2 if 0 <= index < N, and (2N-index)^2 elsewhere
                         const bool outsideN = (igVec[gd] >= size);
-                        apply(view, args) = (2 * size * outsideN - igVec[gd]) 
-                                          * (2 * size * outsideN - igVec[gd]);
+                        apply(view, args) =
+                            (2 * size * outsideN - igVec[gd]) * (2 * size * outsideN - igVec[gd]);
 
                         // add 1.0 if at (0,0,0) to avoid singularity
                         const bool isOrig = (checkVal == 0);
                         apply(view, args) += isOrig * 1.0;
                     });
-
-
             }
             IpplTimings::stopTimer(initialize_hockney);
         }
@@ -325,7 +337,7 @@ namespace ippl {
         rho2_mr  = 0.0;
         rho2tr_m = 0.0;
         if (alg == Algorithm::VICO || alg == Algorithm::BIHARMONIC) {
-            grnL_m   = 0.0;
+            grnL_m = 0.0;
         }
         if (alg == Algorithm::DCT_VICO) {
             grn2n1_m = 0.0;
@@ -587,7 +599,7 @@ namespace ippl {
                             checkVal += Kokkos::abs(igVec1[d] - igVec2[d]);
                         }
 
-                        // Take [0,N-1] quadrant as physical solution. 
+                        // Take [0,N-1] quadrant as physical solution.
                         // Check whether we are in the 1st quadrant by checking whether
                         // the global indices for view1 and view2 are equal.
                         // This is done using checkVal, which should be 0 if ig1 = ig2.
@@ -748,7 +760,7 @@ namespace ippl {
                                 checkVal += Kokkos::abs(igVec1[d] - igVec2[d]);
                             }
 
-                            // Take [0,N-1] quadrant as physical solution. 
+                            // Take [0,N-1] quadrant as physical solution.
                             // Check whether we are in the 1st quadrant by checking whether
                             // the global indices for view1 and view2 are equal.
                             // This is done using checkVal, which should be 0 if ig1 = ig2.
@@ -912,11 +924,11 @@ namespace ippl {
                                     checkVal += Kokkos::abs(igVec1[d] - igVec2[d]);
                                 }
 
-                                // Take [0,N-1] quadrant as physical solution. 
+                                // Take [0,N-1] quadrant as physical solution.
                                 // Check whether we are in the 1st quadrant by checking whether
                                 // the global indices for view1 and view2 are equal.
                                 // This is done using checkVal, which should be 0 if ig1 = ig2.
-                                const bool isQuadrant1 = (checkVal == 0);
+                                const bool isQuadrant1       = (checkVal == 0);
                                 apply(viewH, args)[row][col] = apply(view2, args) * isQuadrant1;
                             });
                     }
@@ -932,11 +944,86 @@ namespace ippl {
     // calculate FFT of the Green's function
 
     template <typename FieldLHS, typename FieldRHS>
+    KOKKOS_INLINE_FUNCTION typename FFTOpenPoissonSolver<FieldLHS, FieldRHS>::scalar_type
+    FFTOpenPoissonSolver<FieldLHS, FieldRHS>::integratedGreenAtanTerm(
+        const scalar_type& numerator, const scalar_type& denominator) {
+        const scalar_type pi = Kokkos::numbers::pi_v<scalar_type>;
+        if (denominator == scalar_type(0)) {
+            if (numerator > scalar_type(0)) {
+                return scalar_type(0.5) * pi;
+            }
+            if (numerator < scalar_type(0)) {
+                return -scalar_type(0.5) * pi;
+            }
+            return scalar_type(0);
+        }
+        return Kokkos::atan(numerator / denominator);
+    }
+
+    template <typename FieldLHS, typename FieldRHS>
+    KOKKOS_INLINE_FUNCTION typename FFTOpenPoissonSolver<FieldLHS, FieldRHS>::scalar_type
+    FFTOpenPoissonSolver<FieldLHS, FieldRHS>::integratedGreenLogTerm(const scalar_type& a,
+                                                                     const scalar_type& b,
+                                                                     const scalar_type& c,
+                                                                     const scalar_type& r) {
+        const scalar_type coeff = b * c;
+        return (coeff == scalar_type(0)) ? scalar_type(0) : coeff * Kokkos::log(a + r);
+    }
+
+    template <typename FieldLHS, typename FieldRHS>
+    KOKKOS_INLINE_FUNCTION typename FFTOpenPoissonSolver<FieldLHS, FieldRHS>::scalar_type
+    FFTOpenPoissonSolver<FieldLHS, FieldRHS>::integratedGreenAntiderivative(const scalar_type& x,
+                                                                            const scalar_type& y,
+                                                                            const scalar_type& z) {
+        const scalar_type r2 = x * x + y * y + z * z;
+        if (r2 == scalar_type(0)) {
+            return scalar_type(0);
+        }
+
+        const scalar_type r = Kokkos::sqrt(r2);
+        scalar_type value   = scalar_type(0);
+        value -= scalar_type(0.5) * z * z * integratedGreenAtanTerm(x * y, z * r);
+        value -= scalar_type(0.5) * y * y * integratedGreenAtanTerm(x * z, y * r);
+        value -= scalar_type(0.5) * x * x * integratedGreenAtanTerm(y * z, x * r);
+        value += integratedGreenLogTerm(x, y, z, r);
+        value += integratedGreenLogTerm(y, x, z, r);
+        value += integratedGreenLogTerm(z, x, y, r);
+        return value;
+    }
+
+    template <typename FieldLHS, typename FieldRHS>
+    KOKKOS_INLINE_FUNCTION typename FFTOpenPoissonSolver<FieldLHS, FieldRHS>::scalar_type
+    FFTOpenPoissonSolver<FieldLHS, FieldRHS>::integratedGreenAverage(const scalar_type& x,
+                                                                     const scalar_type& y,
+                                                                     const scalar_type& z,
+                                                                     const vector_type& h) {
+        const scalar_type half = scalar_type(0.5);
+        const scalar_type x0   = x - half * h[0];
+        const scalar_type x1   = x + half * h[0];
+        const scalar_type y0   = y - half * h[1];
+        const scalar_type y1   = y + half * h[1];
+        const scalar_type z0   = z - half * h[2];
+        const scalar_type z1   = z + half * h[2];
+
+        scalar_type integral = integratedGreenAntiderivative(x1, y1, z1);
+        integral -= integratedGreenAntiderivative(x0, y1, z1);
+        integral -= integratedGreenAntiderivative(x1, y0, z1);
+        integral += integratedGreenAntiderivative(x0, y0, z1);
+        integral -= integratedGreenAntiderivative(x1, y1, z0);
+        integral += integratedGreenAntiderivative(x0, y1, z0);
+        integral += integratedGreenAntiderivative(x1, y0, z0);
+        integral -= integratedGreenAntiderivative(x0, y0, z0);
+
+        return integral / (h[0] * h[1] * h[2]);
+    }
+
+    template <typename FieldLHS, typename FieldRHS>
     void FFTOpenPoissonSolver<FieldLHS, FieldRHS>::greensFunction() {
         const scalar_type pi = Kokkos::numbers::pi_v<scalar_type>;
         grn_mr               = 0.0;
 
-        const int alg = this->params_m.template get<int>("algorithm");
+        const int alg                = this->params_m.template get<int>("algorithm");
+        const int greensFunctionType = this->params_m.template get<int>("greens_function");
 
         using index_array_type = typename RangePolicy<Dim>::index_array_type;
 
@@ -993,8 +1080,8 @@ namespace ippl {
                             Tg s = 0;
                             for (unsigned d = 0; d < Dim; ++d) {
                                 bool isOutside = (igVec[d] > 2 * size[d] - 1);
-                                const Tg t = igVec[d] * hs_m[d] + isOutside * origin[d];
-                                s += (t*t);
+                                const Tg t     = igVec[d] * hs_m[d] + isOutside * origin[d];
+                                s += (t * t);
                             }
                             s = Kokkos::sqrt(s);
 
@@ -1002,7 +1089,8 @@ namespace ippl {
                             // if (0,0,0), assign L^2/2 (analytical limit of sinc)
                             const bool isOrig    = (checkVal == 0);
                             const Tg analyticLim = -L_sum * L_sum * 0.5;
-                            const Tg value = -2.0 * (Kokkos::sin(0.5 * L_sum * s) / (s + isOrig * 1.0))
+                            const Tg value       = -2.0
+                                             * (Kokkos::sin(0.5 * L_sum * s) / (s + isOrig * 1.0))
                                              * (Kokkos::sin(0.5 * L_sum * s) / (s + isOrig * 1.0));
 
                             apply(view_g, args) = (!isOrig) * value + isOrig * analyticLim;
@@ -1024,8 +1112,8 @@ namespace ippl {
                             Tg s = 0;
                             for (unsigned d = 0; d < Dim; ++d) {
                                 bool isOutside = (igVec[d] > 2 * size[d] - 1);
-                                const Tg t = igVec[d] * hs_m[d] + isOutside * origin[d];
-                                s += (t*t);
+                                const Tg t     = igVec[d] * hs_m[d] + isOutside * origin[d];
+                                s += (t * t);
                             }
                             s = Kokkos::sqrt(s);
 
@@ -1033,13 +1121,14 @@ namespace ippl {
                             // if (0,0,0), assign L^2/2 (analytical limit of sinc)
                             const bool isOrig    = (checkVal == 0);
                             const Tg analyticLim = -L_sum * L_sum * L_sum * L_sum / 8.0;
-                            const Tg value = -((2 - (L_sum * L_sum * s * s)) * Kokkos::cos(L_sum * s)
-                                               + 2 * L_sum * s * Kokkos::sin(L_sum * s) - 2)
-                                             / (2 * s * s * s * s + isOrig * 1.0);
+                            const Tg value =
+                                -((2 - (L_sum * L_sum * s * s)) * Kokkos::cos(L_sum * s)
+                                  + 2 * L_sum * s * Kokkos::sin(L_sum * s) - 2)
+                                / (2 * s * s * s * s + isOrig * 1.0);
 
                             apply(view_g, args) = (!isOrig) * value + isOrig * analyticLim;
                         });
-                    }
+                }
 
                 // start a timer
                 static IpplTimings::TimerRef fft4 = IpplTimings::getTimer("FFT: Precomputation");
@@ -1095,11 +1184,11 @@ namespace ippl {
                             view(s, j, k) = real(view_g(i + 1, j, k));
                             view(i, p, k) = real(view_g(i, j + 1, k));
                             view(i, j, q) = real(view_g(i, j, k + 1));
-                        view(s, j, q) = real(view_g(i + 1, j, k + 1));
-                        view(s, p, k) = real(view_g(i + 1, j + 1, k));
-                        view(i, p, q) = real(view_g(i, j + 1, k + 1));
-                        view(s, p, q) = real(view_g(i + 1, j + 1, k + 1));
-                    });
+                            view(s, j, q) = real(view_g(i + 1, j, k + 1));
+                            view(s, p, k) = real(view_g(i + 1, j + 1, k));
+                            view(i, p, q) = real(view_g(i, j + 1, k + 1));
+                            view(s, p, q) = real(view_g(i + 1, j + 1, k + 1));
+                        });
                 }
                 IpplTimings::stopTimer(ifftshift);
             }
@@ -1150,12 +1239,13 @@ namespace ippl {
                         Tg s = 0;
                         for (unsigned d = 0; d < Dim; ++d) {
                             double t = igVec[d] * hs_m[d];
-                            s += (t*t);
+                            s += (t * t);
                         }
                         s = Kokkos::sqrt(s);
 
                         const bool isOrig = (checkVal == 0);
-                        const double val  = -2.0 * (Kokkos::sin(0.5 * L_sum * s) / (s + isOrig * 1.0))
+                        const double val  = -2.0
+                                           * (Kokkos::sin(0.5 * L_sum * s) / (s + isOrig * 1.0))
                                            * (Kokkos::sin(0.5 * L_sum * s) / (s + isOrig * 1.0));
                         const double analyticLim = -L_sum * L_sum * 0.5;
 
@@ -1228,43 +1318,68 @@ namespace ippl {
         } else {
             // Hockney case
 
-            // calculate square of the mesh spacing for each dimension
-            Vector_t hrsq(hr_m * hr_m);
-
-            // use the grnIField_m helper field to compute Green's function
-            for (unsigned int i = 0; i < Dim; ++i) {
-                grn_mr = grn_mr + grnIField_m[i] * hrsq[i];
-            }
-
-            // Formula of Green's function (2D and 3D supported for Hockney)
-            if (Dim == 2) {
-                grn_mr = log(sqrt(grn_mr)) / (2 * pi);
-            } else if (Dim == 3) {
-                grn_mr = -1.0 / (4.0 * pi * sqrt(grn_mr));
-            }
-
             typename Field_t::view_type view = grn_mr.getView();
             const int nghost                 = grn_mr.getNghost();
             const auto& ldom                 = layout2_m->getLocalNDIndex();
 
-            // Kokkos parallel for loop to find (0,0,0) point and regularize
-            ippl::parallel_for(
-                "Regularize Green's function ", grn_mr.getFieldRangePolicy(),
-                KOKKOS_LAMBDA(const index_array_type& args) {
-                    scalar_type checkVal = 0;
+            if (greensFunctionType == GreenFunction::INTEGRATED) {
+                Vector<int, Dim> nr = nr_m;
+                vector_type hs      = hr_m;
 
-                    // go from local indices to global
-                    Vector<int, Dim> igVec = args - nghost;
-                    for (unsigned d = 0; d < Dim; ++d) {
-                        igVec[d] += ldom[d].first();
-                        checkVal += igVec[d];
-                    }
+                ippl::parallel_for(
+                    "Integrated Green's function ", grn_mr.getFieldRangePolicy(),
+                    KOKKOS_LAMBDA(const index_array_type& args) {
+                        Vector<int, Dim> igVec = args - nghost;
+                        for (unsigned d = 0; d < Dim; ++d) {
+                            igVec[d] += ldom[d].first();
+                        }
 
-                    // if (0,0,0), assign to it 1/(4*pi)
-                    const bool isOrig = (checkVal == 0);
-                    apply(view, args) = isOrig * (-1.0 / (4.0 * pi)) 
-                                        + (!isOrig) * apply(view, args);
-                });
+                        scalar_type offset[Dim];
+                        for (unsigned int d = 0; d < Dim; ++d) {
+                            const int igSigned =
+                                (igVec[d] < nr[d]) ? igVec[d] : igVec[d] - 2 * nr[d];
+                            offset[d] = static_cast<scalar_type>(igSigned) * hs[d];
+                        }
+
+                        const scalar_type avg =
+                            integratedGreenAverage(offset[0], offset[1], offset[2], hs);
+                        apply(view, args) = -avg / (scalar_type(4) * pi);
+                    });
+            } else {
+                // calculate square of the mesh spacing for each dimension
+                Vector_t hrsq(hr_m * hr_m);
+
+                // use the grnIField_m helper field to compute Green's function
+                for (unsigned int i = 0; i < Dim; ++i) {
+                    grn_mr = grn_mr + grnIField_m[i] * hrsq[i];
+                }
+
+                // Formula of Green's function (2D and 3D supported for Hockney)
+                if (Dim == 2) {
+                    grn_mr = log(sqrt(grn_mr)) / (2 * pi);
+                } else if (Dim == 3) {
+                    grn_mr = -1.0 / (4.0 * pi * sqrt(grn_mr));
+                }
+
+                // Kokkos parallel for loop to find (0,0,0) point and regularize
+                ippl::parallel_for(
+                    "Regularize Green's function ", grn_mr.getFieldRangePolicy(),
+                    KOKKOS_LAMBDA(const index_array_type& args) {
+                        scalar_type checkVal = 0;
+
+                        // go from local indices to global
+                        Vector<int, Dim> igVec = args - nghost;
+                        for (unsigned d = 0; d < Dim; ++d) {
+                            igVec[d] += ldom[d].first();
+                            checkVal += igVec[d];
+                        }
+
+                        // if (0,0,0), assign to it 1/(4*pi)
+                        const bool isOrig = (checkVal == 0);
+                        apply(view, args) =
+                            isOrig * (-1.0 / (4.0 * pi)) + (!isOrig) * apply(view, args);
+                    });
+            }
         }
 
         // start a timer
@@ -2096,10 +2211,15 @@ namespace ippl {
     template <typename FieldLHS, typename FieldRHS>
     void FFTOpenPoissonSolver<FieldLHS, FieldRHS>::shiftedGreensFunction(
         const Vector<double, Dim>& shift) {
-        const int alg = this->params_m.template get<int>("algorithm");
+        const int alg                = this->params_m.template get<int>("algorithm");
+        const int greensFunctionType = this->params_m.template get<int>("greens_function");
         if (alg != Algorithm::HOCKNEY) {
             throw IpplException("FFTOpenPoissonSolver::shiftedGreensFunction",
                                 "Shifted Green's function is only implemented for HOCKNEY.");
+        }
+        if ((greensFunctionType == GreenFunction::INTEGRATED) && (Dim != 3)) {
+            throw IpplException("FFTOpenPoissonSolver::shiftedGreensFunction",
+                                "Shifted integrated Green's function is only implemented for 3D.");
         }
 
         // Sync mesh spacing with the current RHS mesh (same logic as solve()'s
@@ -2128,43 +2248,65 @@ namespace ippl {
         Vector_t hs              = hr_m;
         Vector<double, Dim> shft = shift;
 
-        // Regularization threshold (axis-min mesh spacing, squared, quartered).
-        scalar_type hmin2 = hs[0] * hs[0];
-        for (unsigned int d = 1; d < Dim; ++d) {
-            hmin2 = (hs[d] * hs[d] < hmin2) ? (hs[d] * hs[d]) : hmin2;
-        }
-        const scalar_type regThresh = 0.25 * hmin2;
-
         using index_array_type = typename ippl::RangePolicy<Dim>::index_array_type;
-        ippl::parallel_for(
-            "Shifted Green's function", grn_mr.getFieldRangePolicy(),
-            KOKKOS_LAMBDA(const index_array_type& args) {
-                // local -> global indices
-                Vector<int, Dim> igVec = args - nghost;
-                for (unsigned d = 0; d < Dim; ++d) {
-                    igVec[d] += ldom[d].first();
-                }
+        if (greensFunctionType == GreenFunction::INTEGRATED) {
+            ippl::parallel_for(
+                "Shifted integrated Green's function", grn_mr.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const index_array_type& args) {
+                    Vector<int, Dim> igVec = args - nghost;
+                    for (unsigned d = 0; d < Dim; ++d) {
+                        igVec[d] += ldom[d].first();
+                    }
 
-                // Hockney convention: map doubled-grid indices.
-                //   ig in [0, N)   -> offset =  ig        * h
-                //   ig in [N, 2N)  -> offset = (ig - 2N)  * h
-                // Subtract the shift to evaluate the shifted Green's function G(r-s).
-                double rsq = 0.0;
-                for (unsigned int d = 0; d < Dim; ++d) {
-                    const double ig_signed = (igVec[d] < nr[d])
-                                                 ? static_cast<double>(igVec[d])
-                                                 : static_cast<double>(igVec[d] - 2 * nr[d]);
-                    const double xoff      = ig_signed * hs[d] - shft[d];
-                    rsq += xoff * xoff;
-                }
+                    scalar_type offset[Dim];
+                    for (unsigned int d = 0; d < Dim; ++d) {
+                        const int igSigned = (igVec[d] < nr[d]) ? igVec[d] : igVec[d] - 2 * nr[d];
+                        offset[d]          = static_cast<scalar_type>(igSigned) * hs[d]
+                                    - static_cast<scalar_type>(shft[d]);
+                    }
 
-                // Sign convention matches greensFunction() (HOCKNEY): grn_mr stores -G0
-                // so that solve()'s `rho2tr_m = -rho2tr_m * grntr_m` yields +conv(rho,G0)
-                // where G0(r) = 1/(4 pi |r|).
-                const bool nearSing = (rsq < regThresh);
-                const scalar_type r = Kokkos::sqrt(rsq + nearSing * regThresh);
-                apply(view, args)       = -1.0 / (4.0 * pi * r);
-            });
+                    const scalar_type avg =
+                        integratedGreenAverage(offset[0], offset[1], offset[2], hs);
+                    apply(view, args) = -avg / (scalar_type(4) * pi);
+                });
+        } else {
+            // Regularization threshold (axis-min mesh spacing, squared, quartered).
+            scalar_type hmin2 = hs[0] * hs[0];
+            for (unsigned int d = 1; d < Dim; ++d) {
+                hmin2 = (hs[d] * hs[d] < hmin2) ? (hs[d] * hs[d]) : hmin2;
+            }
+            const scalar_type regThresh = 0.25 * hmin2;
+
+            ippl::parallel_for(
+                "Shifted Green's function", grn_mr.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const index_array_type& args) {
+                    // local -> global indices
+                    Vector<int, Dim> igVec = args - nghost;
+                    for (unsigned d = 0; d < Dim; ++d) {
+                        igVec[d] += ldom[d].first();
+                    }
+
+                    // Hockney convention: map doubled-grid indices.
+                    //   ig in [0, N)   -> offset =  ig        * h
+                    //   ig in [N, 2N)  -> offset = (ig - 2N)  * h
+                    // Subtract the shift to evaluate the shifted Green's function G(r-s).
+                    double rsq = 0.0;
+                    for (unsigned int d = 0; d < Dim; ++d) {
+                        const double ig_signed = (igVec[d] < nr[d])
+                                                     ? static_cast<double>(igVec[d])
+                                                     : static_cast<double>(igVec[d] - 2 * nr[d]);
+                        const double xoff      = ig_signed * hs[d] - shft[d];
+                        rsq += xoff * xoff;
+                    }
+
+                    // Sign convention matches greensFunction() (HOCKNEY): grn_mr stores -G0
+                    // so that solve()'s `rho2tr_m = -rho2tr_m * grntr_m` yields +conv(rho,G0)
+                    // where G0(r) = 1/(4 pi |r|).
+                    const bool nearSing = (rsq < regThresh);
+                    const scalar_type r = Kokkos::sqrt(rsq + nearSing * regThresh);
+                    apply(view, args)   = -1.0 / (4.0 * pi * r);
+                });
+        }
 
         // Store Fourier transform of shifted Green's function for convolution in solve()
         static IpplTimings::TimerRef fftsg = IpplTimings::getTimer("FFT: Shifted Green");

--- a/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
+++ b/src/PoissonSolvers/FFTOpenPoissonSolver.hpp
@@ -274,8 +274,8 @@ namespace ippl {
             IpplTimings::stopTimer(initialize_vico);
         }
 
-        // these are fields that are used for calculating the Green's function for Hockney
-        if (alg == Algorithm::HOCKNEY) {
+        // these are fields that are used for calculating the standard Green's function for Hockney
+        if ((alg == Algorithm::HOCKNEY) && (greensFunctionType == GreenFunction::STANDARD)) {
             // start a timer
             static IpplTimings::TimerRef initialize_hockney =
                 IpplTimings::getTimer("Initialize: extra Hockney");

--- a/test/solver/CMakeLists.txt
+++ b/test/solver/CMakeLists.txt
@@ -22,6 +22,10 @@ if(IPPL_ENABLE_FFT)
 
   # tests FFTOpenPoissonSolver
   add_ippl_integration_test(TestGaussian ARGS 16 16 16 pencils a2a no-reorder HOCKNEY LABELS solver integration)
+  add_ippl_integration_test(TestGaussianIntegrated
+    SOURCES TestGaussian.cpp
+    ARGS 16 16 16 pencils a2a no-reorder HOCKNEY INTEGRATED
+    LABELS solver integration)
 
   # tests FFTOpenPoissonSolver::shiftedGreensFunction (Dirichlet image correction)
   add_ippl_integration_test(TestShiftedGreensFunction LABELS solver integration)

--- a/test/solver/CMakeLists.txt
+++ b/test/solver/CMakeLists.txt
@@ -26,6 +26,9 @@ if(IPPL_ENABLE_FFT)
   # tests FFTOpenPoissonSolver::shiftedGreensFunction (Dirichlet image correction)
   add_ippl_integration_test(TestShiftedGreensFunction LABELS solver integration)
 
+  # tests FFTOpenPoissonSolver integrated and shifted integrated Green's functions
+  add_ippl_integration_test(TestIntegratedGreensFunction LABELS solver integration)
+
   # tests the FFTTruncatedGreenPeriodicPoissonSolver
   add_ippl_integration_test(TestFFTTruncatedGreenPeriodicPoissonSolver ARGS 16 16 16 LABELS solver integration)
 

--- a/test/solver/TestGaussian.cpp
+++ b/test/solver/TestGaussian.cpp
@@ -4,20 +4,22 @@
 // The solve is iterated 5 times for the purpose of timing studies.
 //   Usage:
 //     srun ./TestGaussian <nx> <ny> <nz> <reshape> <comm> <reorder>
-//                         <algorithm> --info 5
-//     nx        = No. cell-centered points in the x-direction
-//     ny        = No. cell-centered points in the y-direction
-//     nz        = No. cell-centered points in the z-direction
-//     reshape   = "pencils" or "slabs" (heffte parameter)
-//     comm      = "a2a", "a2av", "p2p", "p2p_pl" (heffte parameter)
-//     reorder   = "reorder" or "no-reorder" (heffte parameter)
-//     algorithm = "HOCKNEY", "VICO", or "DCT_VICO", types of open BC algorithms
+//                         <algorithm> [green_function] --info 5
+//     nx             = No. cell-centered points in the x-direction
+//     ny             = No. cell-centered points in the y-direction
+//     nz             = No. cell-centered points in the z-direction
+//     reshape        = "pencils" or "slabs" (heffte parameter)
+//     comm           = "a2a", "a2av", "p2p", "p2p_pl" (heffte parameter)
+//     reorder        = "reorder" or "no-reorder" (heffte parameter)
+//     algorithm      = "HOCKNEY", "VICO", or "DCT_VICO", types of open BC algorithms
+//     green_function = "STANDARD" or "INTEGRATED" (optional; HOCKNEY only)
 //
 //     For more info on the heffte parameters, see:
 //     https://github.com/icl-utk-edu/heffte
 //
 //     Example:
 //       srun ./TestGaussian 64 64 64 pencils a2a no-reorder HOCKNEY --info 5
+//       srun ./TestGaussian 64 64 64 pencils a2a no-reorder HOCKNEY INTEGRATED --info 5
 //
 //
 
@@ -88,12 +90,14 @@ int main(int argc, char* argv[]) {
         std::string communication = argv[5];  // a2a or p2p
         std::string reordering    = argv[6];  // reorder or no-reorder
 
-        // get the algorithm to be used
-        std::string algorithm = argv[7];  // Hockney or Vico
+        // get the algorithm and Green function to be used
+        std::string algorithm      = argv[7];  // Hockney or Vico
+        std::string greensFunction = (argc > 8) ? argv[8] : "STANDARD";
 
         // print out info and title for the relative error (L2 norm)
         msg << "Test Gaussian, grid = " << nr << ", heffte params: " << reshape << " "
-            << communication << " " << reordering << ", algorithm = " << algorithm << endl;
+            << communication << " " << reordering << ", algorithm = " << algorithm
+            << ", Green function = " << greensFunction << endl;
         msg << "Spacing Error" << endl;  // ErrorEx ErrorEy ErrorEz" << endl;
 
         // domain
@@ -230,6 +234,19 @@ int main(int argc, char* argv[]) {
             params.add("algorithm", Solver_t::DCT_VICO);
         } else {
             throw IpplException("TestGaussian.cpp main()", "Unrecognized algorithm type");
+        }
+
+        // set the real-space Hockney Green function
+        if (greensFunction == "STANDARD") {
+            params.add("greens_function", Solver_t::STANDARD);
+        } else if (greensFunction == "INTEGRATED") {
+            if (algorithm != "HOCKNEY") {
+                throw IpplException("TestGaussian.cpp main()",
+                                    "INTEGRATED Green function is only supported with HOCKNEY");
+            }
+            params.add("greens_function", Solver_t::INTEGRATED);
+        } else {
+            throw IpplException("TestGaussian.cpp main()", "Unrecognized Green function type");
         }
 
         // add output type

--- a/test/solver/TestIntegratedGreensFunction.cpp
+++ b/test/solver/TestIntegratedGreensFunction.cpp
@@ -1,0 +1,220 @@
+//
+// TestIntegratedGreensFunction
+//
+// Validates FFTOpenPoissonSolver with greens_function = INTEGRATED for the 3D
+// Hockney open-boundary solver. A single mesh cell with unit density is
+// convolved with both the unshifted and shifted integrated Green's function.
+//
+
+#include "Ippl.h"
+
+#include <Kokkos_MathematicalConstants.hpp>
+#include <Kokkos_MathematicalFunctions.hpp>
+#include <cmath>
+#include <functional>
+
+#include "PoissonSolvers/FFTOpenPoissonSolver.h"
+
+namespace {
+    KOKKOS_INLINE_FUNCTION double atan_ratio(double numerator, double denominator) {
+        const double pi = Kokkos::numbers::pi_v<double>;
+        if (denominator == 0.0) {
+            if (numerator > 0.0)
+                return 0.5 * pi;
+            if (numerator < 0.0)
+                return -0.5 * pi;
+            return 0.0;
+        }
+        return Kokkos::atan(numerator / denominator);
+    }
+
+    KOKKOS_INLINE_FUNCTION double log_term(double a, double b, double c, double r) {
+        const double coeff = b * c;
+        return (coeff == 0.0) ? 0.0 : coeff * Kokkos::log(a + r);
+    }
+
+    KOKKOS_INLINE_FUNCTION double antiderivative(double x, double y, double z) {
+        const double r2 = x * x + y * y + z * z;
+        if (r2 == 0.0)
+            return 0.0;
+
+        const double r = Kokkos::sqrt(r2);
+        double value   = 0.0;
+        value -= 0.5 * z * z * atan_ratio(x * y, z * r);
+        value -= 0.5 * y * y * atan_ratio(x * z, y * r);
+        value -= 0.5 * x * x * atan_ratio(y * z, x * r);
+        value += log_term(x, y, z, r);
+        value += log_term(y, x, z, r);
+        value += log_term(z, x, y, r);
+        return value;
+    }
+
+    KOKKOS_INLINE_FUNCTION double integrated_average(double x, double y, double z, double hx,
+                                                     double hy, double hz) {
+        const double x0 = x - 0.5 * hx;
+        const double x1 = x + 0.5 * hx;
+        const double y0 = y - 0.5 * hy;
+        const double y1 = y + 0.5 * hy;
+        const double z0 = z - 0.5 * hz;
+        const double z1 = z + 0.5 * hz;
+
+        double integral = antiderivative(x1, y1, z1);
+        integral -= antiderivative(x0, y1, z1);
+        integral -= antiderivative(x1, y0, z1);
+        integral += antiderivative(x0, y0, z1);
+        integral -= antiderivative(x1, y1, z0);
+        integral += antiderivative(x0, y1, z0);
+        integral += antiderivative(x1, y0, z0);
+        integral -= antiderivative(x0, y0, z0);
+
+        return integral / (hx * hy * hz);
+    }
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    ippl::initialize(argc, argv);
+    int exit_code = 0;
+    {
+        Inform msg("TestIntegratedGreensFunction");
+
+        constexpr unsigned int Dim = 3;
+        using Mesh_t               = ippl::UniformCartesian<double, Dim>;
+        using Centering_t          = Mesh_t::DefaultCentering;
+        using field_t              = ippl::Field<double, Dim, Mesh_t, Centering_t>;
+        using fieldV_t = ippl::Field<ippl::Vector<double, Dim>, Dim, Mesh_t, Centering_t>;
+        using Solver_t = ippl::FFTOpenPoissonSolver<fieldV_t, field_t>;
+
+        const int N = 8;
+        ippl::NDIndex<Dim> owned;
+        for (unsigned d = 0; d < Dim; ++d) {
+            owned[d] = ippl::Index(N);
+        }
+
+        std::array<bool, Dim> isParallel;
+        isParallel.fill(true);
+
+        ippl::Vector<double, Dim> hr     = {0.17, 0.23, 0.31};
+        ippl::Vector<double, Dim> origin = {0.0, 0.0, 0.0};
+        Mesh_t mesh(owned, hr, origin);
+        ippl::FieldLayout<Dim> layout(MPI_COMM_WORLD, owned, isParallel);
+
+        field_t rho, rho_clean, phi_unshifted, phi_shifted;
+        rho.initialize(mesh, layout);
+        rho_clean.initialize(mesh, layout);
+        phi_unshifted.initialize(mesh, layout);
+        phi_shifted.initialize(mesh, layout);
+
+        auto initialize_delta = [&]() {
+            auto view        = rho.getView();
+            auto clean       = rho_clean.getView();
+            const int nghost = rho.getNghost();
+            const auto& ldom = layout.getLocalNDIndex();
+            Kokkos::parallel_for(
+                "initialize unit cell density", rho.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k) {
+                    const int ig       = i + ldom[0].first() - nghost;
+                    const int jg       = j + ldom[1].first() - nghost;
+                    const int kg       = k + ldom[2].first() - nghost;
+                    const double value = (ig == 0 && jg == 0 && kg == 0) ? 1.0 : 0.0;
+                    view(i, j, k)      = value;
+                    clean(i, j, k)     = value;
+                });
+        };
+
+        ippl::ParameterList params;
+        params.add("use_pencils", true);
+        params.add("comm", ippl::a2a);
+        params.add("use_reorder", false);
+        params.add("use_heffte_defaults", false);
+        params.add("use_gpu_aware", true);
+        params.add("r2c_direction", 0);
+        params.add("algorithm", Solver_t::HOCKNEY);
+        params.add("greens_function", Solver_t::INTEGRATED);
+        params.add("output_type", Solver_t::SOL);
+
+        initialize_delta();
+        Solver_t solver(rho, params);
+        solver.solve();
+        Kokkos::deep_copy(phi_unshifted.getView(), rho.getView());
+
+        Kokkos::deep_copy(rho.getView(), rho_clean.getView());
+        const ippl::Vector<double, Dim> shift = {0.41, -0.19, 0.37};
+        solver.shiftedGreensFunction(shift);
+        solver.solve();
+        Kokkos::deep_copy(phi_shifted.getView(), rho.getView());
+
+        const double cellVolume = hr[0] * hr[1] * hr[2];
+        const double inv4pi     = 1.0 / (4.0 * Kokkos::numbers::pi_v<double>);
+
+        auto compute_error = [&](field_t& phi, const ippl::Vector<double, Dim>& kernelShift) {
+            auto view        = phi.getView();
+            const int nghost = phi.getNghost();
+            const auto& ldom = layout.getLocalNDIndex();
+            double localErr  = 0.0;
+            double localRef  = 0.0;
+
+            Kokkos::parallel_reduce(
+                "integrated green max error", phi.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k, double& lmax) {
+                    const int ig   = i + ldom[0].first() - nghost;
+                    const int jg   = j + ldom[1].first() - nghost;
+                    const int kg   = k + ldom[2].first() - nghost;
+                    const double x = static_cast<double>(ig) * hr[0] - kernelShift[0];
+                    const double y = static_cast<double>(jg) * hr[1] - kernelShift[1];
+                    const double z = static_cast<double>(kg) * hr[2] - kernelShift[2];
+                    const double expected =
+                        cellVolume * inv4pi * integrated_average(x, y, z, hr[0], hr[1], hr[2]);
+                    const double diff = Kokkos::fabs(view(i, j, k) - expected);
+                    if (diff > lmax)
+                        lmax = diff;
+                },
+                Kokkos::Max<double>(localErr));
+
+            Kokkos::parallel_reduce(
+                "integrated green max reference", phi.getFieldRangePolicy(),
+                KOKKOS_LAMBDA(const int i, const int j, const int k, double& lmax) {
+                    const int ig   = i + ldom[0].first() - nghost;
+                    const int jg   = j + ldom[1].first() - nghost;
+                    const int kg   = k + ldom[2].first() - nghost;
+                    const double x = static_cast<double>(ig) * hr[0] - kernelShift[0];
+                    const double y = static_cast<double>(jg) * hr[1] - kernelShift[1];
+                    const double z = static_cast<double>(kg) * hr[2] - kernelShift[2];
+                    const double expected =
+                        cellVolume * inv4pi * integrated_average(x, y, z, hr[0], hr[1], hr[2]);
+                    const double absv = Kokkos::fabs(expected);
+                    if (absv > lmax)
+                        lmax = absv;
+                },
+                Kokkos::Max<double>(localRef));
+
+            double globalErr = 0.0;
+            double globalRef = 0.0;
+            ippl::Comm->allreduce(localErr, globalErr, 1, std::greater<double>());
+            ippl::Comm->allreduce(localRef, globalRef, 1, std::greater<double>());
+            return std::pair<double, double>(globalErr, globalRef);
+        };
+
+        const ippl::Vector<double, Dim> zeroShift = {0.0, 0.0, 0.0};
+        const auto [unshiftedErr, unshiftedRef]   = compute_error(phi_unshifted, zeroShift);
+        const auto [shiftedErr, shiftedRef]       = compute_error(phi_shifted, shift);
+        const double unshiftedRel                 = unshiftedErr / unshiftedRef;
+        const double shiftedRel                   = shiftedErr / shiftedRef;
+
+        msg << "unshifted max abs error = " << unshiftedErr << ", relative = " << unshiftedRel
+            << endl;
+        msg << "shifted max abs error = " << shiftedErr << ", relative = " << shiftedRel << endl;
+
+        const double tol = 5.0e-12;
+        if (unshiftedRel > tol) {
+            msg << "FAIL: unshifted integrated Green's function error exceeds " << tol << endl;
+            exit_code = 1;
+        } else if (shiftedRel > tol) {
+            msg << "FAIL: shifted integrated Green's function error exceeds " << tol << endl;
+            exit_code = 1;
+        } else {
+            msg << "PASS" << endl;
+        }
+    }
+    ippl::finalize();
+    return exit_code;
+}

--- a/test/solver/TestIntegratedGreensFunction.cpp
+++ b/test/solver/TestIntegratedGreensFunction.cpp
@@ -1,10 +1,39 @@
-//
-// TestIntegratedGreensFunction
-//
-// Validates FFTOpenPoissonSolver with greens_function = INTEGRATED for the 3D
-// Hockney open-boundary solver. A single mesh cell with unit density is
-// convolved with both the unshifted and shifted integrated Green's function.
-//
+/**
+ * @file TestIntegratedGreensFunction.cpp
+ * @brief Regression test for integrated and shifted integrated Hockney kernels.
+ *
+ * This test exercises FFTOpenPoissonSolver with
+ * `greens_function = Solver_t::INTEGRATED`, `algorithm = Solver_t::HOCKNEY`,
+ * and `output_type = Solver_t::SOL`.
+ *
+ * The source is deliberately minimal: one physical mesh cell at the origin is
+ * assigned unit density and every other cell is zero. With IPPL's Hockney solve
+ * normalization, the potential sampled at physical grid offset
+ * @f$\mathbf{r}_{ijk}=(i h_x, j h_y, k h_z)@f$ is expected to be
+ * @f[
+ *   \phi_{ijk} =
+ *   \frac{h_x h_y h_z}{4\pi}
+ *   \frac{1}{h_x h_y h_z}
+ *   \int_{\mathrm{cell}}
+ *   \frac{d^3\mathbf{r}'}{|\mathbf{r}_{ijk}-\mathbf{r}'|}.
+ * @f]
+ *
+ * The shifted case calls FFTOpenPoissonSolver::shiftedGreensFunction() and
+ * checks the translated cell average
+ * @f[
+ *   \phi^s_{ijk} =
+ *   \frac{h_x h_y h_z}{4\pi}
+ *   \frac{1}{h_x h_y h_z}
+ *   \int_{\mathrm{cell}}
+ *   \frac{d^3\mathbf{r}'}{|\mathbf{r}_{ijk}-\mathbf{s}-\mathbf{r}'|}.
+ * @f]
+ *
+ * The reference values are computed independently in this file from the same
+ * closed-form eight-corner antiderivative used by Qiang et al. This is a
+ * deterministic kernel/normalization test rather than a beam-physics
+ * convergence benchmark; it is intended to catch sign, shift, cell-volume, and
+ * distributed-layout mistakes.
+ */
 
 #include "Ippl.h"
 
@@ -16,6 +45,10 @@
 #include "PoissonSolvers/FFTOpenPoissonSolver.h"
 
 namespace {
+    // Principal arctangent used by the closed-form antiderivative. The
+    // denominator can vanish on coordinate planes; returning the limiting
+    // +/-pi/2 value avoids NaNs while preserving atan(numerator/denominator)
+    // semantics.
     KOKKOS_INLINE_FUNCTION double atan_ratio(double numerator, double denominator) {
         const double pi = Kokkos::numbers::pi_v<double>;
         if (denominator == 0.0) {
@@ -28,11 +61,15 @@ namespace {
         return Kokkos::atan(numerator / denominator);
     }
 
+    // Term b*c*log(a+r). The coefficient is exactly zero on coordinate planes,
+    // where a+r can also be zero, so skip the logarithm in that removable case.
     KOKKOS_INLINE_FUNCTION double log_term(double a, double b, double c, double r) {
         const double coeff = b * c;
         return (coeff == 0.0) ? 0.0 : coeff * Kokkos::log(a + r);
     }
 
+    // Antiderivative F(x,y,z) for the volume integral of 1/r over a rectangular
+    // cell. The cell integral is the signed eight-corner difference of F.
     KOKKOS_INLINE_FUNCTION double antiderivative(double x, double y, double z) {
         const double r2 = x * x + y * y + z * z;
         if (r2 == 0.0)
@@ -49,6 +86,9 @@ namespace {
         return value;
     }
 
+    // Average of 1/r over a cell of size hx*hy*hz centered at (x,y,z). This
+    // helper deliberately returns the average without the 1/(4*pi) prefactor;
+    // the test applies that prefactor at the same point where the solver does.
     KOKKOS_INLINE_FUNCTION double integrated_average(double x, double y, double z, double hx,
                                                      double hy, double hz) {
         const double x0 = x - 0.5 * hx;
@@ -104,6 +144,9 @@ int main(int argc, char* argv[]) {
         phi_unshifted.initialize(mesh, layout);
         phi_shifted.initialize(mesh, layout);
 
+        // Put unit density in the global origin cell. The physical source
+        // charge is therefore rho * cellVolume = cellVolume, which is why the
+        // expected potential below carries an explicit cellVolume factor.
         auto initialize_delta = [&]() {
             auto view        = rho.getView();
             auto clean       = rho_clean.getView();
@@ -146,6 +189,9 @@ int main(int argc, char* argv[]) {
         const double cellVolume = hr[0] * hr[1] * hr[2];
         const double inv4pi     = 1.0 / (4.0 * Kokkos::numbers::pi_v<double>);
 
+        // Compare a solved potential against the analytical integrated kernel
+        // on the physical N^3 domain. kernelShift = 0 tests greensFunction();
+        // kernelShift = shift tests shiftedGreensFunction(shift).
         auto compute_error = [&](field_t& phi, const ippl::Vector<double, Dim>& kernelShift) {
             auto view        = phi.getView();
             const int nghost = phi.getNghost();
@@ -162,6 +208,8 @@ int main(int argc, char* argv[]) {
                     const double x = static_cast<double>(ig) * hr[0] - kernelShift[0];
                     const double y = static_cast<double>(jg) * hr[1] - kernelShift[1];
                     const double z = static_cast<double>(kg) * hr[2] - kernelShift[2];
+                    // solve() multiplies the inverse FFT result by the cell
+                    // volume. The integrated kernel itself is a cell average.
                     const double expected =
                         cellVolume * inv4pi * integrated_average(x, y, z, hr[0], hr[1], hr[2]);
                     const double diff = Kokkos::fabs(view(i, j, k) - expected);
@@ -204,6 +252,9 @@ int main(int argc, char* argv[]) {
             << endl;
         msg << "shifted max abs error = " << shiftedErr << ", relative = " << shiftedRel << endl;
 
+        // This is an exact closed-form kernel check up to FFT and floating-point
+        // roundoff, so the tolerance can be much tighter than a physics
+        // convergence test.
         const double tol = 5.0e-12;
         if (unshiftedRel > tol) {
             msg << "FAIL: unshifted integrated Green's function error exceeds " << tol << endl;


### PR DESCRIPTION
## Summary

This PR adds an integrated Green function option to `FFTOpenPoissonSolver` for the 3D Hockney open-boundary FFT solver, addressing issue #556. Closes #556.

The new option follows the cell-averaged Green function approach used in OPAL and described by Qiang et al. Instead of sampling the singular free-space kernel at grid points, the integrated kernel averages `1/r` over a source cell using the closed-form eight-corner antiderivative.

## Main Changes

- Added `FFTOpenPoissonSolver::GreenFunction` with:
  - `STANDARD`
  - `INTEGRATED`

- Added solver parameter:

  ```cpp
  params.add("greens_function", Solver_t::INTEGRATED);
  ```

- Kept the default as `STANDARD` to preserve existing IPPL behaviour and backward compatibility.

- Implemented the integrated Green function for:
  - `algorithm == HOCKNEY`
  - `Dim == 3`

- Added shifted integrated Green support through the existing:

  ```cpp
  shiftedGreensFunction(shift)
  ```

  If `greens_function == INTEGRATED`, the shifted kernel applies the translation before evaluating the cell average.

- Added validation and error handling for unsupported combinations:
  - integrated Green with non-Hockney algorithms
  - integrated Green in non-3D configurations

- Avoided allocating the standard Hockney helper fields for the integrated path, since the integrated kernel is computed directly from the closed-form expression.

## Documentation

- Added Doxygen documentation with:
  - standard and integrated Green formulas
  - shifted kernel behavior
  - current limitations
  - references to Qiang et al. and LBNL-59098
  - [manual](https://ippl-framework.github.io/Manual/sections/poisson-solvers/#hockney-green-function-models) is updated 

## Tests
Added and updated solver tests:

- `TestIntegratedGreensFunction`
  - verifies the unshifted integrated kernel against the closed-form reference
  - verifies the shifted integrated kernel through `shiftedGreensFunction(shift)`

- `TestGaussian`
  - extended with an optional `green_function` argument
  - remains backward compatible when the argument is omitted

- `TestGaussianIntegrated`
  - new integrated-kernel runtime smoke test using the Gaussian solver setup

## Verification

The following checks passed locally:

```bash
cmake --build build --target TestGaussian TestGaussianIntegrated TestIntegratedGreensFunction TestShiftedGreensFunction -j 8

ctest --test-dir build -R '^TestGaussian$' --output-on-failure
ctest --test-dir build -R '^TestGaussianIntegrated$' --output-on-failure
ctest --test-dir build -R '^TestIntegratedGreensFunction$' --output-on-failure
ctest --test-dir build -R '^TestShiftedGreensFunction$' --output-on-failure

mpirun -np 2 build/test/solver/TestGaussian 16 16 16 pencils a2a no-reorder HOCKNEY
mpirun -np 4 build/test/solver/TestGaussian 16 16 16 pencils a2a no-reorder HOCKNEY

mpirun -np 2 build/test/solver/TestGaussianIntegrated 16 16 16 pencils a2a no-reorder HOCKNEY INTEGRATED
mpirun -np 4 build/test/solver/TestGaussianIntegrated 16 16 16 pencils a2a no-reorder HOCKNEY INTEGRATED

mpirun -np 2 build/test/solver/TestIntegratedGreensFunction
mpirun -np 4 build/test/solver/TestIntegratedGreensFunction

mpirun -np 2 build/test/solver/TestShiftedGreensFunction
mpirun -np 4 build/test/solver/TestShiftedGreensFunction

git diff --check
```

## Current Limitations

- Integrated Green support is currently limited to 3D Hockney open-boundary FFT solves.
