### PR TITLE
Update project account for CI

### DIFF
--- a/ci/tests/compile-and-test-juwels.yml
+++ b/ci/tests/compile-and-test-juwels.yml
@@ -11,7 +11,7 @@ compile-and-test-juwels:
     SLURM_TIME: "00:40:00"
     SLURM_CPUS_PER_TASK: "6"
     CMAKE_BUILD_TYPE: "Release"
-    PROJECT_NAME: "hai_1073"
+    PROJECT_NAME: "cstma"
 
     RUN_TESTS: "true" # "true" → run tests; "false" → compile only
     PLATFORM: "cuda" # or "openmp"
@@ -21,14 +21,14 @@ compile-and-test-juwels:
   script: |
     set -Eeuo pipefail
 
-    if [[ -z "${SCRATCH_hai_1073:-}" ]]; then
-      echo "❌ ERROR: \$SCRATCH_hai_1073 not set after jutil activation." >&2
+    if [[ -z "${SCRATCH_cstma:-}" ]]; then
+      echo "❌ ERROR: \$SCRATCH_cstma not set after jutil activation." >&2
       exit 1
     fi
 
-    echo "📦 SCRATCH = ${SCRATCH_hai_1073}"
+    echo "📦 SCRATCH = ${SCRATCH_cstma}"
 
-    export BUILD_DIR="${SCRATCH_hai_1073}/.builds/${CI_PIPELINE_ID}/${CI_JOB_ID}"
+    export BUILD_DIR="${SCRATCH_cstma}/.builds/${CI_PIPELINE_ID}/${CI_JOB_ID}"
 
     echo "📁 BUILD_DIR = ${BUILD_DIR}"
 

--- a/ci/tests/compile-and-test-juwels.yml
+++ b/ci/tests/compile-and-test-juwels.yml
@@ -21,14 +21,14 @@ compile-and-test-juwels:
   script: |
     set -Eeuo pipefail
 
-    if [[ -z "${SCRATCH_cstma:-}" ]]; then
+    if [[ -z "${SCRATCH_ccstma:-}" ]]; then
       echo "❌ ERROR: \$SCRATCH_cstma not set after jutil activation." >&2
       exit 1
     fi
 
-    echo "📦 SCRATCH = ${SCRATCH_cstma}"
+    echo "📦 SCRATCH = ${SCRATCH_ccstma}"
 
-    export BUILD_DIR="${SCRATCH_cstma}/.builds/${CI_PIPELINE_ID}/${CI_JOB_ID}"
+    export BUILD_DIR="${SCRATCH_ccstma}/.builds/${CI_PIPELINE_ID}/${CI_JOB_ID}"
 
     echo "📁 BUILD_DIR = ${BUILD_DIR}"
 


### PR DESCRIPTION
The previous project account will expire soon for Jülich CI, so this PR updates to a different account so we can keep running it.