### PR TITLE
Reapply "Add Electrostatic PIF Alpine examples"

### DIFF
--- a/alpine/CMakeLists.txt
+++ b/alpine/CMakeLists.txt
@@ -31,4 +31,8 @@ endif()
 add_alpine_example(PenningTrap)
 add_alpine_example(BumponTailInstability)
 
+if(IPPL_ENABLE_FFT)
+  add_subdirectory(ElectrostaticPIF)
+endif()
+
 add_subdirectory(validation)

--- a/alpine/ElectrostaticPIF/BumponTailInstabilityPIF.cpp
+++ b/alpine/ElectrostaticPIF/BumponTailInstabilityPIF.cpp
@@ -1,0 +1,376 @@
+// Electrostatic Two-stream/Bump-on-tail instability test with Particle-in-Fourier schemes
+//   Usage:
+//     srun ./BumponTailInstabilityPIF <nx> <ny> <nz> <Np> <Nt> <dt> <ShapeType> <degree> <tol>
+//     --info 5 nx       = No. of Fourier modes in the x-direction ny       = No. of Fourier modes
+//     in the y-direction nz       = No. of Fourier modes in the z-direction Np       = Total no. of
+//     macro-particles in the simulation Nt       = Number of time steps dt       = Time stepsize
+//     ShapeType = Shape function type B-spline only for the moment
+//     degree = B-spline degree (-1 for delta function)
+//     tol = tolerance of NUFFT
+//     Example:
+//     srun ./BumponTailInstabilityPIF 32 32 32 655360 20 0.05 B-spline 1 1e-4 --info 5
+//
+// Copyright (c) 2023, Sriramkrishnan Muralikrishnan,
+// Jülich Supercomputing Centre, Jülich, Germany.
+// All rights reserved
+//
+// This file is part of IPPL.
+//
+// IPPL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with IPPL. If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include <Kokkos_Random.hpp>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "Utility/IpplTimings.h"
+
+#include "ChargedParticlesPIF.hpp"
+
+template <typename T>
+struct Newton1D {
+    double tol   = 1e-12;
+    int max_iter = 20;
+    double pi    = Kokkos::numbers::pi_v<double>;
+
+    T k, delta, u;
+
+    KOKKOS_INLINE_FUNCTION Newton1D() {}
+
+    KOKKOS_INLINE_FUNCTION Newton1D(const T& k_, const T& delta_, const T& u_)
+        : k(k_)
+        , delta(delta_)
+        , u(u_) {}
+
+    KOKKOS_INLINE_FUNCTION ~Newton1D() {}
+
+    KOKKOS_INLINE_FUNCTION T f(T& x) {
+        T F;
+        F = x + (delta * (Kokkos::sin(k * x) / k)) - u;
+        return F;
+    }
+
+    KOKKOS_INLINE_FUNCTION T fprime(T& x) {
+        T Fprime;
+        Fprime = 1 + (delta * Kokkos::cos(k * x));
+        return Fprime;
+    }
+
+    KOKKOS_FUNCTION
+    void solve(T& x) {
+        int iterations = 0;
+        while (iterations < max_iter && Kokkos::fabs(f(x)) > tol) {
+            x = x - (f(x) / fprime(x));
+            iterations += 1;
+        }
+    }
+};
+
+template <typename T, class GeneratorPool, unsigned Dim>
+struct generate_random {
+    using view_type  = typename ippl::detail::ViewType<T, 1>::view_type;
+    using value_type = typename T::value_type;
+    // Output View for the random numbers
+    view_type x, v;
+
+    // The GeneratorPool
+    GeneratorPool rand_pool;
+
+    value_type delta, sigma, muBulk, muBeam;
+    size_type nlocBulk;
+
+    T k, minU, maxU;
+
+    // Initialize all members
+    generate_random(view_type x_, view_type v_, GeneratorPool rand_pool_, value_type& delta_, T& k_,
+                    value_type& sigma_, value_type& muBulk_, value_type& muBeam_,
+                    size_type& nlocBulk_, T& minU_, T& maxU_)
+        : x(x_)
+        , v(v_)
+        , rand_pool(rand_pool_)
+        , delta(delta_)
+        , sigma(sigma_)
+        , muBulk(muBulk_)
+        , muBeam(muBeam_)
+        , nlocBulk(nlocBulk_)
+        , k(k_)
+        , minU(minU_)
+        , maxU(maxU_) {}
+
+    KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const {
+        // Get a random number state from the pool for the active thread
+        typename GeneratorPool::generator_type rand_gen = rand_pool.get_state();
+
+        bool isBeam = (i >= nlocBulk);
+
+        value_type muZ = (value_type)(((!isBeam) * muBulk) + (isBeam * muBeam));
+
+        for (unsigned d = 0; d < Dim - 1; ++d) {
+            x(i)[d] = rand_gen.drand(minU[d], maxU[d]);
+            v(i)[d] = rand_gen.normal(0.0, sigma);
+        }
+        v(i)[Dim - 1] = rand_gen.normal(muZ, sigma);
+
+        value_type u  = rand_gen.drand(minU[Dim - 1], maxU[Dim - 1]);
+        x(i)[Dim - 1] = u / (1 + delta);
+        Newton1D<value_type> solver(k[Dim - 1], delta, u);
+        solver.solve(x(i)[Dim - 1]);
+
+        // Give the state back, which will allow another thread to acquire it
+        rand_pool.free_state(rand_gen);
+    }
+};
+
+double CDF(const double& x, const double& delta, const double& k, const unsigned& dim) {
+    bool isDimZ = (dim == (Dim - 1));
+    double cdf  = x + (double)(isDimZ * ((delta / k) * std::sin(k * x)));
+    return cdf;
+}
+
+const char* TestName = "TwoStreamInstabilityPIF";
+
+int main(int argc, char* argv[]) {
+    ippl::initialize(argc, argv);
+    {
+        Inform msg(TestName);
+        Inform msg2all(TestName, INFORM_ALL_NODES);
+
+        ippl::Vector<int, Dim> nr = {std::atoi(argv[1]), std::atoi(argv[2]), std::atoi(argv[3])};
+
+        static IpplTimings::TimerRef mainTimer        = IpplTimings::getTimer("mainTimer");
+        static IpplTimings::TimerRef particleCreation = IpplTimings::getTimer("particlesCreation");
+        static IpplTimings::TimerRef dumpDataTimer    = IpplTimings::getTimer("dumpData");
+        static IpplTimings::TimerRef PTimer           = IpplTimings::getTimer("kick");
+        static IpplTimings::TimerRef RTimer           = IpplTimings::getTimer("drift");
+        static IpplTimings::TimerRef BCTimer          = IpplTimings::getTimer("particleBC");
+        static IpplTimings::TimerRef initializeShapeFunctionPIF =
+            IpplTimings::getTimer("initializeShapeFunctionPIF");
+
+        IpplTimings::startTimer(mainTimer);
+
+        const size_type totalP = std::atoll(argv[4]);
+        const unsigned int nt  = std::atoi(argv[5]);
+        const double dt        = std::atof(argv[6]);
+
+        using bunch_type = ChargedParticlesPIF<PLayout_t>;
+
+        std::unique_ptr<bunch_type> P;
+
+        ippl::NDIndex<Dim> domain;
+        for (unsigned i = 0; i < Dim; i++) {
+            domain[i] = ippl::Index(nr[i]);
+        }
+
+        std::array<bool, Dim> isParallel;  // Specifies SERIAL, PARALLEL dims
+        isParallel.fill(false);
+
+        // create mesh and layout objects for this problem domain
+        Vector_t kw;
+        double sigma, muBulk, muBeam, epsilon, delta;
+
+        if (std::strcmp(TestName, "TwoStreamInstabilityPIF") == 0) {
+            // Parameters for two stream instability as in
+            //  https://www.frontiersin.org/articles/10.3389/fphy.2018.00105/full
+            kw      = {0.5, 0.5, 0.5};
+            sigma   = 0.1;
+            epsilon = 0.5;
+            muBulk  = -pi / 2.0;
+            muBeam  = pi / 2.0;
+            delta   = 0.01;
+        } else if (std::strcmp(TestName, "BumponTailInstabilityPIF") == 0) {
+            kw      = {0.21, 0.21, 0.21};
+            sigma   = 1.0 / std::sqrt(2.0);
+            epsilon = 0.1;
+            muBulk  = 0.0;
+            muBeam  = 4.0;
+            delta   = 0.01;
+        } else {
+            // Default value is two stream instability
+            kw      = {0.5, 0.5, 0.5};
+            sigma   = 0.1;
+            epsilon = 0.5;
+            muBulk  = -pi / 2.0;
+            muBeam  = pi / 2.0;
+            delta   = 0.01;
+        }
+
+        Vector_t rmin(0.0);
+        Vector_t rmax   = 2 * pi / kw;
+        Vector_t length = rmax - rmin;
+        double dx       = rmax[0] / nr[0];
+        double dy       = rmax[1] / nr[1];
+        double dz       = rmax[2] / nr[2];
+
+        Vector_t hr     = {dx, dy, dz};
+        Vector_t origin = {rmin[0], rmin[1], rmin[2]};
+
+        Mesh_t mesh(domain, hr, origin);
+        FieldLayout_t FL(*ippl::Comm, domain, isParallel);
+        PLayout_t PL(FL, mesh);
+
+        double factorConf         = 1.0 / ippl::Comm->size();
+        double factorVelBulk      = 1.0 - epsilon;
+        double factorVelBeam      = 1.0 - factorVelBulk;
+        size_type nlocBulk        = (size_type)(factorConf * factorVelBulk * totalP);
+        size_type nlocBeam        = (size_type)(factorConf * factorVelBeam * totalP);
+        size_type nloc            = nlocBulk + nlocBeam;
+        size_type Total_particles = 0;
+
+        MPI_Allreduce(&nloc, &Total_particles, 1, MPI_UNSIGNED_LONG, MPI_SUM,
+                      ippl::Comm->getCommunicator());
+
+        msg << TestName << endl
+            << "nt " << nt << " Np= " << Total_particles << " Fourier modes = " << nr << endl;
+
+        // Q = -\int\int f dx dv
+        double Q = -rmax[0] * rmax[1] * rmax[2];
+        P        = std::make_unique<bunch_type>(PL, hr, rmin, rmax, isParallel, Q, Total_particles);
+
+        P->nr_m = nr;
+
+        P->rho_m.initialize(mesh, FL);
+        P->Sk_m.initialize(mesh, FL);
+
+        ////////////////////////////////////////////////////////////
+        // Initialize an FFT object for getting rho in real space and
+        // doing charge conservation check
+
+        ippl::ParameterList fftParams;
+        fftParams.add("use_heffte_defaults", false);
+        fftParams.add("use_pencils", true);
+        fftParams.add("use_reorder", false);
+        fftParams.add("use_gpu_aware", true);
+        fftParams.add("comm", ippl::p2p_pl);
+        fftParams.add("r2c_direction", 0);
+
+        ippl::NDIndex<Dim> domainPIFhalf;
+
+        for (unsigned d = 0; d < Dim; ++d) {
+            domainPIFhalf[d] = ippl::Index(domain[d].length());
+        }
+
+        FieldLayout_t FLPIFhalf(*ippl::Comm, domainPIFhalf, isParallel);
+
+        ippl::Vector<double, 3> hDummy      = {1.0, 1.0, 1.0};
+        ippl::Vector<double, 3> originDummy = {0.0, 0.0, 0.0};
+        Mesh_t meshPIFhalf(domainPIFhalf, hDummy, originDummy);
+
+        ippl::Vector<double, 3> hFourier      = {2 * pi / length[0], 2 * pi / length[1],
+                                                 2 * pi / length[2]};
+        ippl::Vector<double, 3> originFourier = {-pi / hr[0], -pi / hr[1], -pi / hr[2]};
+        Mesh_t meshFourier(domain, hFourier, originFourier);
+
+        P->rhoPIFreal_m.initialize(mesh, FL);
+        P->rhoPIFhalf_m.initialize(meshPIFhalf, FLPIFhalf);
+        P->rhoPIFFourierMag_m.initialize(meshFourier, FL);
+
+        // P->fft_mp = std::make_shared<FFT_t>(FL, FLPIFhalf, fftParams);
+        // P->fft_mp = std::make_shared<FFT_t>(FLPIFhalf, fftParams);
+
+        ////////////////////////////////////////////////////////////
+
+        P->time_m = 0.0;
+
+        P->shapetype_m   = argv[7];
+        P->shapedegree_m = std::atoi(argv[8]);
+
+        IpplTimings::startTimer(particleCreation);
+
+        Vector_t minU, maxU;
+        for (unsigned d = 0; d < Dim; ++d) {
+            minU[d] = CDF(rmin[d], delta, kw[d], d);
+            maxU[d] = CDF(rmax[d], delta, kw[d], d);
+        }
+
+
+        P->create(nloc);
+        Kokkos::Random_XorShift64_Pool<> rand_pool64((size_type)(42 + 100 * ippl::Comm->rank()));
+        Kokkos::parallel_for(nloc, generate_random<Vector_t, Kokkos::Random_XorShift64_Pool<>, Dim>(
+                                       P->R.getView(), P->P.getView(), rand_pool64, delta, kw,
+                                       sigma, muBulk, muBeam, nlocBulk, minU, maxU));
+
+        Kokkos::fence();
+        ippl::Comm->barrier();
+        IpplTimings::stopTimer(particleCreation);
+
+        P->q = P->Q_m / Total_particles;
+        msg << "particles created and initial conditions assigned " << endl;
+
+        IpplTimings::startTimer(initializeShapeFunctionPIF);
+        P->initializeShapeFunctionPIF();
+        IpplTimings::stopTimer(initializeShapeFunctionPIF);
+
+        double tol = std::atof(argv[9]);
+        P->initNUFFT(FL, tol);
+
+        P->scatter();
+
+        P->gather();
+
+        IpplTimings::startTimer(dumpDataTimer);
+        P->dumpBumponTail();
+        P->dumpEnergy();
+        IpplTimings::stopTimer(dumpDataTimer);
+
+        // begin main timestep loop
+        msg << "Starting iterations ..." << endl;
+        for (unsigned int it = 0; it < nt; it++) {
+            // LeapFrog time stepping https://en.wikipedia.org/wiki/Leapfrog_integration
+            // Here, we assume a constant charge-to-mass ratio of -1 for
+            // all the particles hence eliminating the need to store mass as
+            // an attribute
+            // kick
+
+            IpplTimings::startTimer(PTimer);
+            P->P = P->P - 0.5 * dt * P->E;
+            IpplTimings::stopTimer(PTimer);
+
+            // drift
+            IpplTimings::startTimer(RTimer);
+            P->R = P->R + dt * P->P;
+            IpplTimings::stopTimer(RTimer);
+
+            // Apply particle BC
+            IpplTimings::startTimer(BCTimer);
+            PL.applyBC(P->R, PL.getRegionLayout().getDomain());
+            IpplTimings::stopTimer(BCTimer);
+
+            // scatter the charge onto the underlying grid
+            P->scatter();
+
+            // Solve for and gather E field
+            P->gather();
+
+            // kick
+            IpplTimings::startTimer(PTimer);
+            P->P = P->P - 0.5 * dt * P->E;
+            IpplTimings::stopTimer(PTimer);
+
+            P->time_m += dt;
+            IpplTimings::startTimer(dumpDataTimer);
+            P->dumpBumponTail();
+            P->dumpEnergy();
+            IpplTimings::stopTimer(dumpDataTimer);
+            msg << "Finished time step: " << it + 1 << " time: " << P->time_m << endl;
+        }
+
+        msg << "BumponTailInstability: End." << endl;
+        IpplTimings::stopTimer(mainTimer);
+        IpplTimings::print();
+        IpplTimings::print(std::string("timing.dat"));
+    }
+    ippl::finalize();
+
+    return 0;
+}

--- a/alpine/ElectrostaticPIF/CMakeLists.txt
+++ b/alpine/ElectrostaticPIF/CMakeLists.txt
@@ -1,0 +1,32 @@
+file (RELATIVE_PATH _relPath "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
+message (STATUS "Adding index test found in ${_relPath}")
+
+include_directories (
+        ${CMAKE_SOURCE_DIR}/src
+)
+
+set (COMPILE_FLAGS ${OPAL_CXX_FLAGS})
+
+if(IPPL_ENABLE_FINUFFT)
+    set(PIF_FINUFFT_LIBS finufft)
+    if(TARGET cufinufft)
+        list(APPEND PIF_FINUFFT_LIBS cufinufft)
+    endif()
+endif()
+
+foreach(_pif_target IN ITEMS LandauDampingPIF BumponTailInstabilityPIF PenningTrapPIF)
+    add_executable(${_pif_target} ${_pif_target}.cpp)
+    target_link_libraries(${_pif_target} PRIVATE IPPL::ippl ${PIF_FINUFFT_LIBS})
+endforeach()
+
+# LandauDampingPIF supports both the upsampled (default) and the pruned NUFFT
+# pipelines via an optional 10th positional argument ("pruned"); no separate
+# executable is required.
+# vi: set et ts=4 sw=4 sts=4:
+
+# Local Variables:
+# mode: cmake
+# cmake-tab-width: 4
+# indent-tabs-mode: nil
+# require-final-newline: nil
+# End:

--- a/alpine/ElectrostaticPIF/ChargedParticlesPIF.hpp
+++ b/alpine/ElectrostaticPIF/ChargedParticlesPIF.hpp
@@ -1,0 +1,634 @@
+// ChargedParticlesPIF header file
+//   Defines a particle attribute for charged particles to be used in
+//   test programs
+//
+// Copyright (c) 2021 Paul Scherrer Institut, Villigen PSI, Switzerland
+// All rights reserved
+//
+// This file is part of IPPL.
+//
+// IPPL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with IPPL. If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include "Ippl.h"
+
+#include <Kokkos_MathematicalConstants.hpp>
+#include <Kokkos_MathematicalFunctions.hpp>
+
+// dimension of our positions
+constexpr unsigned Dim = 3;
+using Mesh_t = ippl::UniformCartesian<double, Dim>;
+using Centering_t = Mesh_t::DefaultCentering;
+using ExecSpace_t = Kokkos::DefaultExecutionSpace;
+
+// some typedefs
+typedef ippl::ParticleSpatialLayout<double, Dim, Mesh_t, ExecSpace_t> PLayout_t;
+typedef ippl::FieldLayout<Dim> FieldLayout_t;
+
+using size_type = ippl::detail::size_type;
+
+template <typename T, unsigned Dim>
+using Vector = ippl::Vector<T, Dim>;
+
+template <typename T, unsigned Dim, class Mesh, class Centering>
+using Field = ippl::Field<T, Dim, Mesh, Centering>;
+
+template <typename T>
+using ParticleAttrib = ippl::ParticleAttrib<T, ExecSpace_t>;
+
+typedef Vector<double, Dim> Vector_t;
+typedef Field<double, Dim, Mesh_t, Centering_t> Field_t;
+typedef Field<Kokkos::complex<double>, Dim, Mesh_t, Centering_t> CxField_t;
+typedef Field<Vector_t, Dim, Mesh_t, Centering_t>::uniform_type VField_t;
+
+typedef ippl::FFT<ippl::CCTransform, CxField_t> FFT_t;
+
+const double pi = Kokkos::numbers::pi_v<double>;
+
+// Test programs have to define this variable for VTK dump purposes
+extern const char* TestName;
+
+void dumpVTK(Field_t& rho, int nx, int ny, int nz, int iteration, double dx, double dy, double dz) {
+    typename Field_t::view_type::host_mirror_type host_view = rho.getHostMirror();
+
+    std::stringstream fname;
+    fname << "data/scalar_";
+    fname << std::setw(4) << std::setfill('0') << iteration;
+    fname << ".vtk";
+
+    Kokkos::deep_copy(host_view, rho.getView());
+
+    Inform vtkout(NULL, fname.str().c_str(), Inform::OVERWRITE);
+    vtkout.precision(10);
+    vtkout.setf(std::ios::scientific, std::ios::floatfield);
+
+    // start with header
+    vtkout << "# vtk DataFile Version 2.0" << endl;
+    vtkout << TestName << endl;
+    vtkout << "ASCII" << endl;
+    vtkout << "DATASET STRUCTURED_POINTS" << endl;
+    vtkout << "DIMENSIONS " << nx + 3 << " " << ny + 3 << " " << nz + 3 << endl;
+    vtkout << "ORIGIN " << -dx << " " << -dy << " " << -dz << endl;
+    vtkout << "SPACING " << dx << " " << dy << " " << dz << endl;
+    vtkout << "CELL_DATA " << (nx + 2) * (ny + 2) * (nz + 2) << endl;
+
+    vtkout << "SCALARS Rho float" << endl;
+    vtkout << "LOOKUP_TABLE default" << endl;
+    for (int z = 0; z < nz + 2; z++) {
+        for (int y = 0; y < ny + 2; y++) {
+            for (int x = 0; x < nx + 2; x++) {
+                vtkout << host_view(x, y, z) << endl;
+            }
+        }
+    }
+}
+
+/*!
+ * @class ChargedParticlesPIF
+ * @brief Particle bunch used by the Particle-in-Fourier example apps.
+ *
+ * Holds Fourier-mode density fields (@c rho_m, @c rhoDFT_m, ...), the
+ * forward / inverse NUFFT plans, and per-particle attributes for charge,
+ * velocity, and the gathered electric field. Used by LandauDampingPIF /
+ * BumponTailInstabilityPIF / PenningTrapPIF.
+ *
+ * Supports two NUFFT pipelines, selected via @c useUpsampledInputs (default
+ * @c true): the upsampled pipeline transforms a 2x grid for accuracy; the
+ * "pruned" pipeline (false) transforms only the lowest n_modes per axis on
+ * the original grid for speed. Construct with @c useUpsampledInputs=false
+ * for the pruned variant.
+ *
+ * @tparam PLayout Particle spatial layout type (typically
+ *                 ippl::ParticleSpatialLayout<double, 3, Mesh_t, ExecSpace_t>).
+ */
+template <class PLayout>
+class ChargedParticlesPIF : public ippl::ParticleBase<PLayout> {
+public:
+    CxField_t rho_m;
+    CxField_t rhoPIFhalf_m;
+    Field_t rhoPIFreal_m;
+    Field_t rhoPIFFourierMag_m;
+    CxField_t rhoDFT_m;
+    Field_t Sk_m;
+
+    Vector<int, Dim> nr_m;
+
+    std::array<bool, Dim> decomp_m;
+
+    Vector_t hr_m;
+    Vector_t rmin_m;
+    Vector_t rmax_m;
+
+    double Q_m;
+
+    size_type Np_m;
+
+    double time_m;
+
+    double rhoNorm_m;
+
+    std::string shapetype_m;
+
+    int shapedegree_m;
+    //std::shared_ptr<FFT_t> fft_mp;
+
+    // NUFFT pipeline selector: true -> 2x-upsampled grid (default);
+    // false -> "pruned" mode (only the lowest n_modes per axis transformed).
+    bool useUpsampledInputs_m = true;
+
+    std::shared_ptr<ippl::FFT<ippl::NUFFTransform, Field_t>> nufftType1_mp, nufftType2_mp;
+
+public:
+    ParticleAttrib<double> q;                                        // charge
+    typename ippl::ParticleBase<PLayout>::particle_position_type P;  // particle velocity
+    typename ippl::ParticleBase<PLayout>::particle_position_type
+        E;  // electric field at particle position
+
+    /*
+      This constructor is mandatory for all derived classes from
+      ParticleBase as the bunch buffer uses this
+    */
+    ChargedParticlesPIF(PLayout& pl)
+        : ippl::ParticleBase<PLayout>(pl) {
+        // register the particle attributes
+        this->addAttribute(q);
+        this->addAttribute(P);
+        this->addAttribute(E);
+    }
+
+    ChargedParticlesPIF(PLayout& pl, Vector_t hr, Vector_t rmin, Vector_t rmax,
+                        std::array<bool, Dim> decomp, double Q, size_type Np,
+                        bool useUpsampledInputs = true)
+        : ippl::ParticleBase<PLayout>(pl)
+        , hr_m(hr)
+        , rmin_m(rmin)
+        , rmax_m(rmax)
+        , Q_m(Q)
+        , Np_m(Np)
+        , useUpsampledInputs_m(useUpsampledInputs) {
+        // register the particle attributes
+        this->addAttribute(q);
+        this->addAttribute(P);
+        this->addAttribute(E);
+        setupBCs();
+        for (unsigned int i = 0; i < Dim; i++)
+            decomp_m[i] = decomp[i];
+    }
+
+    ~ChargedParticlesPIF() {}
+
+    void setupBCs() { setBCAllPeriodic(); }
+
+    void initNUFFT(FieldLayout_t& FL, double& tol) {
+        ippl::ParameterList fftParams1, fftParams2;
+
+        fftParams1.add("tolerance", tol);
+        fftParams2.add("tolerance", tol);
+#ifdef FINUFFT_USE_CUDA
+        fftParams1.add("gpu_method", 2);
+        fftParams1.add("gpu_sort", 0);
+        fftParams1.add("gpu_kerevalmeth", 1);
+        fftParams1.add("gpu_binsizex", 8);
+        fftParams1.add("gpu_binsizey", 8);
+        fftParams1.add("gpu_binsizez", 2);
+        fftParams1.add("gpu_maxsubprobsize", 1024);
+
+        fftParams2.add("gpu_method", 2);
+        fftParams2.add("gpu_sort", 0);
+        fftParams2.add("gpu_kerevalmeth", 1);
+        fftParams2.add("gpu_binsizex", 8);
+        fftParams2.add("gpu_binsizey", 8);
+        fftParams2.add("gpu_binsizez", 2);
+        fftParams2.add("gpu_maxsubprobsize", 1024);
+
+#else
+        fftParams1.add("spread_kerevalmeth", 1);
+        fftParams1.add("spread_sort", 2);
+        fftParams1.add("nthreads", 0);
+
+        fftParams2.add("spread_kerevalmeth", 1);
+        fftParams2.add("spread_sort", 2);
+        fftParams2.add("nthreads", 0);
+#endif
+
+        fftParams1.add("use_finufft_defaults", false);
+        fftParams2.add("use_finufft_defaults", false);
+        fftParams1.add("use_kokkos_nufft", false);
+        fftParams2.add("use_kokkos_nufft", false);
+        fftParams1.add("use_upsampled_inputs", useUpsampledInputs_m);
+        fftParams2.add("use_upsampled_inputs", useUpsampledInputs_m);
+        // fftParams.add("use_cufinufft_defaults", true);
+
+        nufftType1_mp = std::make_shared<ippl::FFT<ippl::NUFFTransform, Field_t>>(
+            FL, this->getLocalNum(), 1, fftParams1);
+        nufftType2_mp = std::make_shared<ippl::FFT<ippl::NUFFTransform, Field_t>>(
+            FL, this->getLocalNum(), 2, fftParams2);
+    }
+
+    void gather() {
+        gatherPIFNUFFT(this->E, rho_m, Sk_m, this->R, nufftType2_mp.get(), q);
+        // gatherPIFNUDFT(this->E, rho_m, Sk_m, this->R);
+
+        // Set the charge back to original as we used this view as a
+        // temporary buffer during gather
+        q = Q_m / Np_m;
+    }
+
+    void scatter() {
+        Inform m("scatter ");
+        rho_m = {0.0, 0.0};
+        scatterPIFNUFFT(q, rho_m, Sk_m, this->R, nufftType1_mp.get());
+        // rho_m = {0.0, 0.0};
+        // scatterPIFNUDFT(q, rho_m, Sk_m, this->R);
+
+        // dumpFieldData();
+
+        rho_m =
+            rho_m / ((rmax_m[0] - rmin_m[0]) * (rmax_m[1] - rmin_m[1]) * (rmax_m[2] - rmin_m[2]));
+    }
+
+    void dumpLandau() {
+        double fieldEnergy = 0.0;
+        double ExAmp       = 0.0;
+
+        auto rhoview       = rho_m.getView();
+        const int nghost   = rho_m.getNghost();
+        using mdrange_type = Kokkos::MDRangePolicy<Kokkos::Rank<Dim>, ExecSpace_t>;
+
+        const FieldLayout_t& layout   = rho_m.getLayout();
+        const Mesh_t& mesh            = rho_m.get_mesh();
+        const Vector<double, Dim>& dx = mesh.getMeshSpacing();
+        const auto& domain            = layout.getDomain();
+        Vector<double, Dim> Len;
+        Vector<int, Dim> N;
+
+        for (unsigned d = 0; d < Dim; ++d) {
+            N[d]   = domain[d].length();
+            Len[d] = dx[d] * N[d];
+        }
+
+        Kokkos::complex<double> imag = {0.0, 1.0};
+        constexpr double pi          = Kokkos::numbers::pi_v<double>;
+        Kokkos::parallel_reduce(
+            "Ex energy and Max", mdrange_type({0, 0, 0}, {N[0], N[1], N[2]}),
+            KOKKOS_LAMBDA(const int i, const int j, const int k, double& tlSum, double& tlMax) {
+                Vector<int, 3> iVec = {i, j, k};
+                Vector<double, 3> kVec;
+                double Dr = 0.0;
+                for (size_t d = 0; d < Dim; ++d) {
+                    //kVec[d] = 2 * pi / Len[d] * (iVec[d] - (N[d] / 2));
+                    bool shift            = (iVec[d] > (N[d] / 2));
+                    kVec[d]               = 2 * pi / Len[d] * (iVec[d] - shift * N[d]);
+                    Dr += kVec[d] * kVec[d];
+                }
+
+                Kokkos::complex<double> Ek = {0.0, 0.0};
+                auto rho                   = rhoview(i + nghost, j + nghost, k + nghost);
+                bool isNotZero             = (Dr != 0.0);
+                double factor              = isNotZero * (1.0 / (Dr + ((!isNotZero) * 1.0)));
+                Ek                         = -(imag * kVec[0] * rho * factor);
+                double myVal               = Ek.real() * Ek.real() + Ek.imag() * Ek.imag();
+
+                tlSum += myVal;
+
+                double myValMax = Kokkos::sqrt(myVal);
+
+                if (myValMax > tlMax)
+                    tlMax = myValMax;
+            },
+            Kokkos::Sum<double>(fieldEnergy), Kokkos::Max<double>(ExAmp));
+
+        Kokkos::fence();
+        double volume = (rmax_m[0] - rmin_m[0]) * (rmax_m[1] - rmin_m[1]) * (rmax_m[2] - rmin_m[2]);
+        fieldEnergy *= volume;
+
+        if (ippl::Comm->rank() == 0) {
+            std::stringstream fname;
+            fname << "data/FieldLandau_";
+            fname << ippl::Comm->size();
+            fname << ".csv";
+
+            Inform csvout(NULL, fname.str().c_str(), Inform::APPEND);
+            csvout.precision(10);
+            csvout.setf(std::ios::scientific, std::ios::floatfield);
+
+            if (time_m == 0.0) {
+                csvout << "time, Ex_field_energy, Ex_max_norm" << endl;
+            }
+
+            csvout << time_m << " " << fieldEnergy << " " << ExAmp << endl;
+        }
+
+        ippl::Comm->barrier();
+    }
+
+    void dumpBumponTail() {
+        double fieldEnergy = 0.0;
+        double EzAmp       = 0.0;
+
+        auto rhoview       = rho_m.getView();
+        const int nghost   = rho_m.getNghost();
+        using mdrange_type = Kokkos::MDRangePolicy<Kokkos::Rank<Dim>, ExecSpace_t>;
+
+        const FieldLayout_t& layout   = rho_m.getLayout();
+        const Mesh_t& mesh            = rho_m.get_mesh();
+        const Vector<double, Dim>& dx = mesh.getMeshSpacing();
+        const auto& domain            = layout.getDomain();
+        const auto& lDom   = layout.getLocalNDIndex();
+        Vector<double, Dim> Len;
+        Vector<int, Dim> N;
+
+        for (unsigned d = 0; d < Dim; ++d) {
+            N[d]   = domain[d].length();
+            Len[d] = dx[d] * N[d];
+        }
+
+        Kokkos::complex<double> imag = {0.0, 1.0};
+        constexpr double pi          = Kokkos::numbers::pi_v<double>;
+        Kokkos::parallel_reduce(
+            "Ez energy and Max", mdrange_type({nghost, nghost, nghost}, {rhoview.extent(0)-nghost, rhoview.extent(1)-nghost, rhoview.extent(2)-nghost}),
+            KOKKOS_LAMBDA(const int i, const int j, const int k, double& tlSum, double& tlMax) {
+                Vector<int, 3> iVec = {i, j, k};
+                for (unsigned d = 0; d < Dim; ++d) {
+                    iVec[d] = iVec[d] - nghost + lDom[d].first();
+                }
+                Vector<double, 3> kVec;
+                double Dr = 0.0;
+                for (size_t d = 0; d < Dim; ++d) {
+                    //kVec[d] = 2 * pi / Len[d] * (iVec[d] - (N[d] / 2));
+                    bool shift            = (iVec[d] > (N[d] / 2));
+                    kVec[d]               = 2 * pi / Len[d] * (iVec[d] - shift * N[d]);
+                    Dr += kVec[d] * kVec[d];
+                }
+
+                Kokkos::complex<double> Ek = {0.0, 0.0};
+                auto rho                   = rhoview(i, j, k);
+                bool isNotZero             = (Dr != 0.0);
+                double factor              = isNotZero * (1.0 / (Dr + ((!isNotZero) * 1.0)));
+                Ek                         = -(imag * kVec[2] * rho * factor);
+                double myVal               = Ek.real() * Ek.real() + Ek.imag() * Ek.imag();
+
+                tlSum += myVal;
+
+                double myValMax = Kokkos::sqrt(myVal);
+
+                if (myValMax > tlMax)
+                    tlMax = myValMax;
+            },
+            Kokkos::Sum<double>(fieldEnergy), Kokkos::Max<double>(EzAmp));
+
+        Kokkos::fence();
+        double globalfieldEnergy = 0.0;
+        double globalEzAmp = 0.0;
+        ippl::Comm->reduce(fieldEnergy, globalfieldEnergy, 1, std::plus<double>());
+        ippl::Comm->reduce(EzAmp, globalEzAmp, 1, std::greater<double>());
+        double volume = (rmax_m[0] - rmin_m[0]) * (rmax_m[1] - rmin_m[1]) * (rmax_m[2] - rmin_m[2]);
+        globalfieldEnergy *= volume;
+
+        if (ippl::Comm->rank() == 0) {
+            std::stringstream fname;
+            fname << "data/FieldBumponTail_";
+            fname << ippl::Comm->size();
+            fname << ".csv";
+
+            Inform csvout(NULL, fname.str().c_str(), Inform::APPEND);
+            csvout.precision(10);
+            csvout.setf(std::ios::scientific, std::ios::floatfield);
+
+            if (time_m == 0.0) {
+                csvout << "time, Ez_field_energy, Ez_max_norm" << endl;
+            }
+
+            csvout << time_m << " " << globalfieldEnergy << " " << globalEzAmp << endl;
+        }
+
+        ippl::Comm->barrier();
+    }
+
+    void dumpEnergy() {
+        double potentialEnergy, kineticEnergy;
+        double temp = 0.0;
+
+        auto rhoview       = rho_m.getView();
+        const int nghost   = rho_m.getNghost();
+        using mdrange_type = Kokkos::MDRangePolicy<Kokkos::Rank<Dim>, ExecSpace_t>;
+
+        const FieldLayout_t& layout   = rho_m.getLayout();
+        const Mesh_t& mesh            = rho_m.get_mesh();
+        const Vector<double, Dim>& dx = mesh.getMeshSpacing();
+        const auto& domain            = layout.getDomain();
+        const auto& lDom   = layout.getLocalNDIndex();
+        Vector<double, Dim> Len;
+        Vector<int, Dim> N;
+
+        for (unsigned d = 0; d < Dim; ++d) {
+            N[d]   = domain[d].length();
+            Len[d] = dx[d] * N[d];
+        }
+
+        Kokkos::complex<double> imag = {0.0, 1.0};
+        constexpr double pi          = Kokkos::numbers::pi_v<double>;
+        Kokkos::parallel_reduce(
+            "Potential energy", mdrange_type({nghost, nghost, nghost}, {rhoview.extent(0)-nghost, rhoview.extent(1)-nghost, rhoview.extent(2)-nghost}),
+            KOKKOS_LAMBDA(const int i, const int j, const int k, double& valL) {
+                Vector<int, 3> iVec = {i, j, k};
+                for (unsigned d = 0; d < Dim; ++d) {
+                    iVec[d] = iVec[d] - nghost + lDom[d].first();
+                }
+                Vector<double, 3> kVec;
+                double Dr = 0.0;
+                for (size_t d = 0; d < Dim; ++d) {
+                    //kVec[d] = 2 * pi / Len[d] * (iVec[d] - (N[d] / 2));
+                    bool shift            = (iVec[d] > (N[d] / 2));
+                    kVec[d]               = 2 * pi / Len[d] * (iVec[d] - shift * N[d]);
+                    Dr += kVec[d] * kVec[d];
+                }
+
+                Kokkos::complex<double> Ek = {0.0, 0.0};
+                double myVal               = 0.0;
+                auto rho                   = rhoview(i, j, k);
+                for (size_t d = 0; d < Dim; ++d) {
+                    bool isNotZero = (Dr != 0.0);
+                    double factor  = isNotZero * (1.0 / (Dr + ((!isNotZero) * 1.0)));
+                    Ek             = -(imag * kVec[d] * rho * factor);
+                    myVal += Ek.real() * Ek.real() + Ek.imag() * Ek.imag();
+                }
+
+                valL += myVal;
+            },
+            Kokkos::Sum<double>(temp));
+
+        double globaltemp = 0.0;
+        ippl::Comm->reduce(temp, globaltemp, 1, std::plus<double>());
+        double volume = (rmax_m[0] - rmin_m[0]) * (rmax_m[1] - rmin_m[1]) * (rmax_m[2] - rmin_m[2]);
+        potentialEnergy = 0.5 * globaltemp * volume;
+
+        auto Pview = P.getView();
+        auto qView = q.getView();
+
+        temp = 0.0;
+
+        Kokkos::parallel_reduce(
+            "Kinetic Energy", this->getLocalNum(),
+            KOKKOS_LAMBDA(const int i, double& valL) {
+                double myVal = dot(Pview(i), Pview(i)).apply();
+                myVal *= -qView(i);
+                valL += myVal;
+            },
+            Kokkos::Sum<double>(temp));
+
+        temp *= 0.5;
+        globaltemp = 0.0;
+        MPI_Reduce(&temp, &globaltemp, 1, MPI_DOUBLE, MPI_SUM, 0, ippl::Comm->getCommunicator());
+
+        kineticEnergy = globaltemp;
+
+        Vector_t totalMomentum = 0.0;
+
+        for (size_t d = 0; d < Dim; ++d) {
+            double tempD = 0.0;
+            Kokkos::parallel_reduce(
+                "Total Momentum", this->getLocalNum(),
+                KOKKOS_LAMBDA(const int i, double& valL) { valL += (-qView(i)) * Pview(i)[d]; },
+                Kokkos::Sum<double>(tempD));
+            totalMomentum[d] = tempD;
+        }
+
+        Vector_t globalMom;
+
+        double magMomentum = 0.0;
+        for (size_t d = 0; d < Dim; ++d) {
+            MPI_Allreduce(&totalMomentum[d], &globalMom[d], 1, MPI_DOUBLE, MPI_SUM,
+                          ippl::Comm->getCommunicator());
+            magMomentum += globalMom[d] * globalMom[d];
+        }
+
+        magMomentum = std::sqrt(magMomentum);
+
+        if (ippl::Comm->rank() == 0) {
+            std::stringstream fname;
+            fname << "data/Energy_";
+            fname << ippl::Comm->size();
+            fname << ".csv";
+
+            Inform csvout(NULL, fname.str().c_str(), Inform::APPEND);
+            csvout.precision(17);
+            csvout.setf(std::ios::scientific, std::ios::floatfield);
+
+            if (time_m == 0.0) {
+                //csvout << "time, Potential energy, Kinetic energy, Total energy Total charge Total "
+                //          "Momentum"
+                csvout << "time, Potential energy, Kinetic energy, Total energy Total "
+                          "Momentum"
+                       << endl;
+            }
+
+            //csvout << time_m << " " << potentialEnergy << " " << kineticEnergy << " "
+            //       << potentialEnergy + kineticEnergy << " " << charge << " " << magMomentum
+            //       << endl;
+            csvout << time_m << " " << potentialEnergy << " " << kineticEnergy << " "
+                   << potentialEnergy + kineticEnergy << " " << magMomentum
+                   << endl;
+        }
+
+        ippl::Comm->barrier();
+    }
+
+    void initializeShapeFunctionPIF() {
+        using mdrange_type  = Kokkos::MDRangePolicy<Kokkos::Rank<3>, ExecSpace_t>;
+        auto Skview         = Sk_m.getView();
+        auto N              = nr_m;
+        const int nghost    = Sk_m.getNghost();
+        const Mesh_t& mesh  = rho_m.get_mesh();
+        const Vector_t& dx  = mesh.getMeshSpacing();
+        const Vector_t& Len = rmax_m - rmin_m;
+        const double pi     = Kokkos::numbers::pi_v<double>;
+        int order           = shapedegree_m + 1;
+        const FieldLayout_t& layout = Sk_m.getLayout();
+        const auto& lDom   = layout.getLocalNDIndex();
+        if (shapetype_m == "Gaussian") {
+            throw IpplException("initializeShapeFunctionPIF",
+                                "Gaussian shape function not implemented yet");
+
+        } else if (shapetype_m == "B-spline") {
+            Kokkos::parallel_for(
+                "B-spline shape functions",
+                mdrange_type({nghost, nghost, nghost},
+                             {Skview.extent(0) - nghost, Skview.extent(1) - nghost,
+                              Skview.extent(2) - nghost}),
+                KOKKOS_LAMBDA(const int i, const int j, const int k) {
+                    Vector<int, 3> iVec = {i, j, k};
+                    for (unsigned d = 0; d < Dim; ++d) {
+                        iVec[d] = iVec[d] - nghost + lDom[d].first();
+                    }
+                    Vector<double, 3> kVec;
+                    double Sk = 1.0;
+                    for (size_t d = 0; d < Dim; ++d) {
+                        //kVec[d]        = 2 * pi / Len[d] * (iVec[d] - (N[d] / 2));
+                        bool shift            = (iVec[d] > (N[d] / 2));
+                        kVec[d]               = 2 * pi / Len[d] * (iVec[d] - shift * N[d]);
+                        //Actual mesh spacing is twice the upsampled one
+                        double khbytwo = (kVec[d] * dx[d] / 2) * 2;
+                        bool isNotZero = (khbytwo != 0.0);
+                        double factor  = (1.0 / (khbytwo + ((!isNotZero) * 1.0)));
+                        double arg =
+                            isNotZero * (Kokkos::sin(khbytwo) * factor) + (!isNotZero) * 1.0;
+                        // Fourier transform of CIC
+                        Sk *= Kokkos::pow(arg, order);
+                    }
+                    Skview(i, j, k) = Sk;
+                });
+
+        } else {
+            throw IpplException("initializeShapeFunctionPIF", "Unrecognized shape function type");
+        }
+    }
+
+    void dumpFieldData() {
+        typename CxField_t::view_type::host_mirror_type rhoNUFFT_host = rho_m.getHostMirror();
+        typename Field_t::view_type::host_mirror_type rhoNUFFT_real   = rhoPIFreal_m.getHostMirror();
+        Kokkos::deep_copy(rhoNUFFT_host, rho_m.getView());
+        Kokkos::deep_copy(rhoNUFFT_real, rhoPIFreal_m.getView());
+        const int nghost = rho_m.getNghost();
+        std::stringstream pname;
+        pname << "data/FieldFFT_";
+        pname << ippl::Comm->rank();
+        pname << ".csv";
+        Inform pcsvout(NULL, pname.str().c_str(), Inform::OVERWRITE, ippl::Comm->rank());
+        pcsvout.precision(10);
+        pcsvout.setf(std::ios::scientific, std::ios::floatfield);
+        pcsvout << "rho" << endl;
+        for (int i = 0; i < nr_m[0]; i++) {
+            for (int j = 0; j < nr_m[1]; j++) {
+                for (int k = 0; k < nr_m[2]; k++) {
+                    pcsvout << rhoNUFFT_host(i + nghost, j + nghost, k + nghost) << endl;
+                }
+            }
+        }
+        std::stringstream pname2;
+        pname2 << "data/Fieldreal_";
+        pname2 << ippl::Comm->rank();
+        pname2 << ".csv";
+        Inform pcsvout2(NULL, pname2.str().c_str(), Inform::OVERWRITE, ippl::Comm->rank());
+        pcsvout2.precision(10);
+        pcsvout2.setf(std::ios::scientific, std::ios::floatfield);
+        pcsvout2 << "rho" << endl;
+        for (int i = 0; i < nr_m[0]; i++) {
+            for (int j = 0; j < nr_m[1]; j++) {
+                for (int k = 0; k < nr_m[2]; k++) {
+                    pcsvout2 << rhoNUFFT_real(i + nghost, j + nghost, k + nghost) << endl;
+                }
+            }
+        }
+        ippl::Comm->barrier();
+    }
+
+private:
+    void setBCAllPeriodic() { this->setParticleBC(ippl::BC::PERIODIC); }
+};

--- a/alpine/ElectrostaticPIF/ChargedParticlesPIF.hpp
+++ b/alpine/ElectrostaticPIF/ChargedParticlesPIF.hpp
@@ -217,10 +217,13 @@ public:
         fftParams2.add("nthreads", 0);
 #endif
 
-        fftParams1.add("use_finufft_defaults", false);
-        fftParams2.add("use_finufft_defaults", false);
-        fftParams1.add("use_kokkos_nufft", false);
-        fftParams2.add("use_kokkos_nufft", false);
+        bool useFinufft = false;
+        fftParams1.add("use_finufft", useFinufft);
+        fftParams2.add("use_finufft", useFinufft);
+        //Finufft does not work with upsampled inputs
+        if(useFinufft) {
+            useUpsampledInputs_m = false;
+        }
         fftParams1.add("use_upsampled_inputs", useUpsampledInputs_m);
         fftParams2.add("use_upsampled_inputs", useUpsampledInputs_m);
         // fftParams.add("use_cufinufft_defaults", true);

--- a/alpine/ElectrostaticPIF/ChargedParticlesPIF.hpp
+++ b/alpine/ElectrostaticPIF/ChargedParticlesPIF.hpp
@@ -141,6 +141,7 @@ public:
     // NUFFT pipeline selector: true -> 2x-upsampled grid (default);
     // false -> "pruned" mode (only the lowest n_modes per axis transformed).
     bool useUpsampledInputs_m = true;
+    bool useFinufft_m = false;
 
     std::shared_ptr<ippl::FFT<ippl::NUFFTransform, Field_t>> nufftType1_mp, nufftType2_mp;
 
@@ -164,14 +165,15 @@ public:
 
     ChargedParticlesPIF(PLayout& pl, Vector_t hr, Vector_t rmin, Vector_t rmax,
                         std::array<bool, Dim> decomp, double Q, size_type Np,
-                        bool useUpsampledInputs = true)
+                        bool useUpsampledInputs = true, bool useFinufft = false)
         : ippl::ParticleBase<PLayout>(pl)
         , hr_m(hr)
         , rmin_m(rmin)
         , rmax_m(rmax)
         , Q_m(Q)
         , Np_m(Np)
-        , useUpsampledInputs_m(useUpsampledInputs) {
+        , useUpsampledInputs_m(useUpsampledInputs) 
+        , useFinufft_m(useFinufft) {
         // register the particle attributes
         this->addAttribute(q);
         this->addAttribute(P);
@@ -191,21 +193,13 @@ public:
         fftParams1.add("tolerance", tol);
         fftParams2.add("tolerance", tol);
 #ifdef FINUFFT_USE_CUDA
-        fftParams1.add("gpu_method", 2);
+        fftParams1.add("gpu_method", 3);
         fftParams1.add("gpu_sort", 0);
         fftParams1.add("gpu_kerevalmeth", 1);
         fftParams1.add("gpu_binsizex", 8);
         fftParams1.add("gpu_binsizey", 8);
         fftParams1.add("gpu_binsizez", 2);
         fftParams1.add("gpu_maxsubprobsize", 1024);
-
-        fftParams2.add("gpu_method", 2);
-        fftParams2.add("gpu_sort", 0);
-        fftParams2.add("gpu_kerevalmeth", 1);
-        fftParams2.add("gpu_binsizex", 8);
-        fftParams2.add("gpu_binsizey", 8);
-        fftParams2.add("gpu_binsizez", 2);
-        fftParams2.add("gpu_maxsubprobsize", 1024);
 
 #else
         fftParams1.add("spread_kerevalmeth", 1);
@@ -216,17 +210,10 @@ public:
         fftParams2.add("spread_sort", 2);
         fftParams2.add("nthreads", 0);
 #endif
-
-        bool useFinufft = false;
-        fftParams1.add("use_finufft", useFinufft);
-        fftParams2.add("use_finufft", useFinufft);
-        //Finufft does not work with upsampled inputs
-        if(useFinufft) {
-            useUpsampledInputs_m = false;
-        }
+        fftParams1.add("use_finufft", useFinufft_m);
+        fftParams2.add("use_finufft", useFinufft_m);
         fftParams1.add("use_upsampled_inputs", useUpsampledInputs_m);
         fftParams2.add("use_upsampled_inputs", useUpsampledInputs_m);
-        // fftParams.add("use_cufinufft_defaults", true);
 
         nufftType1_mp = std::make_shared<ippl::FFT<ippl::NUFFTransform, Field_t>>(
             FL, this->getLocalNum(), 1, fftParams1);

--- a/alpine/ElectrostaticPIF/ChargedParticlesPIF.hpp
+++ b/alpine/ElectrostaticPIF/ChargedParticlesPIF.hpp
@@ -552,6 +552,17 @@ public:
         int order           = shapedegree_m + 1;
         const FieldLayout_t& layout = Sk_m.getLayout();
         const auto& lDom   = layout.getLocalNDIndex();
+        Vector_t dxShape;
+        //Actual mesh spacing is twice the upsampled one if we do not
+        //use pruned option
+        for (size_t d = 0; d < Dim; ++d) {
+            if(useUpsampledInputs_m) {
+                dxShape[d] = 2.0 * dx[d];
+            }
+            else {
+                dxShape[d] = dx[d];
+            }
+        }
         if (shapetype_m == "Gaussian") {
             throw IpplException("initializeShapeFunctionPIF",
                                 "Gaussian shape function not implemented yet");
@@ -573,8 +584,7 @@ public:
                         //kVec[d]        = 2 * pi / Len[d] * (iVec[d] - (N[d] / 2));
                         bool shift            = (iVec[d] > (N[d] / 2));
                         kVec[d]               = 2 * pi / Len[d] * (iVec[d] - shift * N[d]);
-                        //Actual mesh spacing is twice the upsampled one
-                        double khbytwo = (kVec[d] * dx[d] / 2) * 2;
+                        double khbytwo = kVec[d] * dxShape[d] / 2;
                         bool isNotZero = (khbytwo != 0.0);
                         double factor  = (1.0 / (khbytwo + ((!isNotZero) * 1.0)));
                         double arg =

--- a/alpine/ElectrostaticPIF/LandauDampingPIF.cpp
+++ b/alpine/ElectrostaticPIF/LandauDampingPIF.cpp
@@ -1,0 +1,357 @@
+// Electrostatic Landau damping test with Particle-in-Fourier schemes
+//   Usage:
+//     srun ./LandauDampingPIF <nx> <ny> <nz> <Np> <Nt> <dt> <ShapeType> <degree> <tol> --info 5
+//     nx       = No. of Fourier modes in the x-direction
+//     ny       = No. of Fourier modes in the y-direction
+//     nz       = No. of Fourier modes in the z-direction
+//     Np       = Total no. of macro-particles in the simulation
+//     Nt       = Number of time steps
+//     dt       = Time stepsize
+//     ShapeType = Shape function type B-spline only for the moment
+//     degree = B-spline degree (-1 for delta function)
+//     tol = tolerance of NUFFT
+//     Example:
+//     srun ./LandauDampingPIF 32 32 32 655360 20 0.05 B-spline 1 1e-4 --info 5
+//
+// Copyright (c) 2022, Sriramkrishnan Muralikrishnan,
+// Jülich Supercomputing Centre, Jülich, Germany.
+// All rights reserved
+//
+// This file is part of IPPL.
+//
+// IPPL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with IPPL. If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include <Kokkos_Random.hpp>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "Utility/IpplTimings.h"
+
+#include "ChargedParticlesPIF.hpp"
+
+template <typename T>
+struct Newton1D {
+    double tol   = 1e-12;
+    int max_iter = 20;
+    double pi    = Kokkos::numbers::pi_v<double>;
+
+    T k, alpha, u;
+
+    KOKKOS_INLINE_FUNCTION Newton1D() {}
+
+    KOKKOS_INLINE_FUNCTION Newton1D(const T& k_, const T& alpha_, const T& u_)
+        : k(k_)
+        , alpha(alpha_)
+        , u(u_) {}
+
+    KOKKOS_INLINE_FUNCTION ~Newton1D() {}
+
+    KOKKOS_INLINE_FUNCTION T f(T& x) {
+        T F;
+        F = x + (alpha * (Kokkos::sin(k * x) / k)) - u;
+        return F;
+    }
+
+    KOKKOS_INLINE_FUNCTION T fprime(T& x) {
+        T Fprime;
+        Fprime = 1 + (alpha * Kokkos::cos(k * x));
+        return Fprime;
+    }
+
+    KOKKOS_FUNCTION
+    void solve(T& x) {
+        int iterations = 0;
+        while (iterations < max_iter && Kokkos::fabs(f(x)) > tol) {
+            x = x - (f(x) / fprime(x));
+            iterations += 1;
+        }
+    }
+};
+
+template <typename T, class GeneratorPool, unsigned Dim>
+struct generate_random {
+    using view_type  = typename ippl::detail::ViewType<T, 1>::view_type;
+    using value_type = typename T::value_type;
+    // Output View for the random numbers
+    view_type x, v;
+
+    // The GeneratorPool
+    GeneratorPool rand_pool;
+
+    value_type alpha;
+
+    T k, minU, maxU;
+
+    // Initialize all members
+    generate_random(view_type x_, view_type v_, GeneratorPool rand_pool_, value_type& alpha_, T& k_,
+                    T& minU_, T& maxU_)
+        : x(x_)
+        , v(v_)
+        , rand_pool(rand_pool_)
+        , alpha(alpha_)
+        , k(k_)
+        , minU(minU_)
+        , maxU(maxU_) {}
+
+    KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const {
+        // Get a random number state from the pool for the active thread
+        typename GeneratorPool::generator_type rand_gen = rand_pool.get_state();
+
+        value_type u;
+        for (unsigned d = 0; d < Dim; ++d) {
+            u       = rand_gen.drand(minU[d], maxU[d]);
+            x(i)[d] = u / (1 + alpha);
+            Newton1D<value_type> solver(k[d], alpha, u);
+            solver.solve(x(i)[d]);
+            v(i)[d] = rand_gen.normal(0.0, 1.0);
+        }
+
+        // Give the state back, which will allow another thread to acquire it
+        rand_pool.free_state(rand_gen);
+    }
+};
+
+double CDF(const double& x, const double& alpha, const double& k) {
+    double cdf = x + (alpha / k) * std::sin(k * x);
+    return cdf;
+}
+
+KOKKOS_FUNCTION
+double PDF(const Vector_t& xvec, const double& alpha, const Vector_t& kw, const unsigned Dim) {
+    double pdf = 1.0;
+
+    for (unsigned d = 0; d < Dim; ++d) {
+        pdf *= (1.0 + alpha * Kokkos::cos(kw[d] * xvec[d]));
+    }
+    return pdf;
+}
+
+const char* TestName = "LandauDampingPIF";
+
+int main(int argc, char* argv[]) {
+    ippl::initialize(argc, argv);
+    {
+        Inform msg("LandauDampingPIF");
+        Inform msg2all("LandauDampingPIF", INFORM_ALL_NODES);
+
+        // Optional 10th positional argument selects the NUFFT pipeline:
+        //   "pruned"     -> only the lowest n_modes per axis are transformed
+        //                   on the original grid (cheaper, slightly less
+        //                   accurate).
+        //   anything else / absent -> upsampled pipeline on a 2x grid
+        //                             (default, matches the original example).
+        const bool useUpsampledInputs =
+            !(argc > 10 && std::string(argv[10]) == "pruned");
+
+        ippl::Vector<int, Dim> nr = {std::atoi(argv[1]), std::atoi(argv[2]), std::atoi(argv[3])};
+        ippl::Vector<int, Dim> nrOrig;
+
+        static IpplTimings::TimerRef mainTimer        = IpplTimings::getTimer("mainTimer");
+        static IpplTimings::TimerRef particleCreation = IpplTimings::getTimer("particlesCreation");
+        static IpplTimings::TimerRef dumpDataTimer    = IpplTimings::getTimer("dumpData");
+        static IpplTimings::TimerRef PTimer           = IpplTimings::getTimer("kick");
+        static IpplTimings::TimerRef RTimer           = IpplTimings::getTimer("drift");
+        static IpplTimings::TimerRef initializeShapeFunctionPIF =
+            IpplTimings::getTimer("initializeShapeFunctionPIF");
+
+
+        const size_type totalP = std::atoll(argv[4]);
+        const unsigned int nt  = std::atoi(argv[5]);
+        const double dt        = std::atof(argv[6]);
+
+        double factor             = 1.0 / ippl::Comm->size();
+        size_type nloc            = (size_type)(factor * totalP);
+        size_type Total_particles = 0;
+
+        MPI_Allreduce(&nloc, &Total_particles, 1, MPI_UNSIGNED_LONG, MPI_SUM, ippl::Comm->getCommunicator());
+
+        msg << "Landau damping" << endl
+            << "nt " << nt << " Np= " << Total_particles << " Fourier modes = " << nr << endl;
+
+        using bunch_type = ChargedParticlesPIF<PLayout_t>;
+
+        std::unique_ptr<bunch_type> P;
+
+        // Upsampled mode runs all transforms on a 2x grid (nr doubled);
+        // pruned mode keeps the original grid. nrOrig is the user-supplied
+        // resolution and is what the particle layout / NUFFT plans get bound
+        // to in either mode, but in upsampled mode the field storage and
+        // FieldLayout use the doubled nr to give the FFT room to upsample.
+        ippl::NDIndex<Dim> domain;
+        ippl::NDIndex<Dim> domainOrig;
+        for (unsigned i = 0; i < Dim; i++) {
+            nrOrig[i] = nr[i];
+            if (useUpsampledInputs) {
+                nr[i] = 2 * nr[i];
+            }
+            domain[i]     = ippl::Index(nr[i]);
+            domainOrig[i] = ippl::Index(nrOrig[i]);
+        }
+
+        std::array<bool, Dim> isParallel;  // Specifies SERIAL, PARALLEL dims
+        isParallel.fill(true);
+
+        // create mesh and layout objects for this problem domain
+        Vector_t kw  = {0.5, 0.5, 0.5};
+        double alpha = 0.05;
+        Vector_t rmin(0.0);
+        Vector_t rmax   = 2 * pi / kw;
+        Vector_t length = rmax - rmin;
+        double dx       = length[0] / nr[0];
+        double dy       = length[1] / nr[1];
+        double dz       = length[2] / nr[2];
+
+        Vector_t hr     = {dx, dy, dz};
+        Vector_t hrOrig = useUpsampledInputs ? Vector_t{2.0 * hr} : hr;
+        Vector_t origin = {rmin[0], rmin[1], rmin[2]};
+
+        const bool isAllPeriodic = true;
+        Mesh_t mesh(domain, hr, origin);
+        Mesh_t meshOrig(domainOrig, hrOrig, origin);
+
+        FieldLayout_t FL(*ippl::Comm, domain, isParallel, isAllPeriodic);
+        FieldLayout_t FLOrig(*ippl::Comm, domainOrig, isParallel, isAllPeriodic);
+
+        // Particle layout binds to the original (un-upsampled) field layout so
+        // particle positions and the NUFFT plan see the same resolution; the
+        // upsampled FL is only used for the rho/Sk field storage.
+        PLayout_t PL(FLOrig, meshOrig);
+
+        // Q = -\int\int f dx dv
+        double Q = -length[0] * length[1] * length[2];
+        P        = std::make_unique<bunch_type>(PL, hr, rmin, rmax, isParallel, Q,
+                                                Total_particles, useUpsampledInputs);
+
+        P->nr_m = nr;
+
+        P->rho_m.initialize(mesh, FL);
+        P->rhoDFT_m.initialize(mesh, FL);
+        P->Sk_m.initialize(mesh, FL);
+
+        ////////////////////////////////////////////////////////////
+        // Initialize an FFT object for getting rho in real space and
+        // doing charge conservation check
+
+        P->time_m = 0.0;
+
+        P->shapetype_m   = argv[7];
+        P->shapedegree_m = std::atoi(argv[8]);
+
+        IpplTimings::startTimer(particleCreation);
+
+        Vector_t minU, maxU;
+        for (unsigned d = 0; d < Dim; ++d) {
+            minU[d] = CDF(rmin[d], alpha, kw[d]);
+            maxU[d] = CDF(rmax[d], alpha, kw[d]);
+        }
+
+
+        P->create(nloc);
+        Kokkos::Random_XorShift64_Pool<> rand_pool64((size_type)(42 + 100 * ippl::Comm->rank()));
+        Kokkos::parallel_for(
+            nloc, generate_random<Vector_t, Kokkos::Random_XorShift64_Pool<>, Dim>(
+                      P->R.getView(), P->P.getView(), rand_pool64, alpha, kw, minU, maxU));
+
+        Kokkos::fence();
+        ippl::Comm->barrier();
+        IpplTimings::stopTimer(particleCreation);
+
+        P->q = P->Q_m / Total_particles;
+        msg << "particles created and initial conditions assigned " << endl;
+
+        IpplTimings::startTimer(initializeShapeFunctionPIF);
+        P->initializeShapeFunctionPIF();
+        IpplTimings::stopTimer(initializeShapeFunctionPIF);
+        msg << "After init shape function " << endl;
+
+        double tol = std::atof(argv[9]);
+        P->initNUFFT(FLOrig, tol);
+        msg << "After init NUFFT " << endl;
+
+        P->update();
+        msg << "After update " << endl;
+        P->scatter();
+        msg << "After scatter " << endl;
+
+        P->gather();
+        msg << "After gather " << endl;
+
+        IpplTimings::startTimer(dumpDataTimer);
+        P->dumpBumponTail();
+        P->dumpEnergy();
+        IpplTimings::stopTimer(dumpDataTimer);
+
+        // begin main timestep loop
+        msg << "Starting iterations ..." << endl;
+        int warmup = 3;
+        for (int it = -warmup; it < (int)nt; it++) {
+            if (it == 0) {
+                IpplTimings::resetAllTimers();
+                IpplTimings::startTimer(mainTimer);
+            }
+            // LeapFrog time stepping https://en.wikipedia.org/wiki/Leapfrog_integration
+            // Here, we assume a constant charge-to-mass ratio of -1 for
+            // all the particles hence eliminating the need to store mass as
+            // an attribute
+            // kick
+
+            IpplTimings::startTimer(PTimer);
+            P->P = P->P - 0.5 * dt * P->E;
+            IpplTimings::stopTimer(PTimer);
+
+            // drift
+            IpplTimings::startTimer(RTimer);
+            P->R = P->R + dt * P->P;
+            IpplTimings::stopTimer(RTimer);
+
+            // Apply particle BC
+            //IpplTimings::startTimer(BCTimer);
+            //PL.applyBC(P->R, PL.getRegionLayout().getDomain());
+            //IpplTimings::stopTimer(BCTimer);
+
+            P->update();
+            // scatter the charge onto the underlying grid
+            P->scatter();
+
+            // Solve for and gather E field
+            P->gather();
+
+            // kick
+            IpplTimings::startTimer(PTimer);
+            P->P = P->P - 0.5 * dt * P->E;
+            IpplTimings::stopTimer(PTimer);
+
+            P->time_m += dt;
+            IpplTimings::startTimer(dumpDataTimer);
+            P->dumpBumponTail();
+            P->dumpEnergy();
+            IpplTimings::stopTimer(dumpDataTimer);
+            msg << "Finished time step: " << it + 1 << " time: " << P->time_m << endl;
+        }
+
+        msg << "LandauDamping: End." << endl;
+        IpplTimings::stopTimer(mainTimer);
+        IpplTimings::print();
+        IpplTimings::print(std::string("timing.dat"));
+
+        std::string res_file  = useUpsampledInputs ? "LandauDampingPIF" : "LandauDampingPIFPruned";
+        res_file += std::to_string(ippl::Comm->size());
+        res_file += ".csv";
+        IpplTimings::dumpToCSV(res_file);
+    }
+    ippl::finalize();
+
+    return 0;
+}

--- a/alpine/ElectrostaticPIF/LandauDampingPIF.cpp
+++ b/alpine/ElectrostaticPIF/LandauDampingPIF.cpp
@@ -1,6 +1,6 @@
 // Electrostatic Landau damping test with Particle-in-Fourier schemes
 //   Usage:
-//     srun ./LandauDampingPIF <nx> <ny> <nz> <Np> <Nt> <dt> <ShapeType> <degree> <tol> --info 5
+//     srun ./LandauDampingPIF <nx> <ny> <nz> <Np> <Nt> <dt> <ShapeType> <degree> <tol> <output_type> --info 5
 //     nx       = No. of Fourier modes in the x-direction
 //     ny       = No. of Fourier modes in the y-direction
 //     nz       = No. of Fourier modes in the z-direction
@@ -10,6 +10,8 @@
 //     ShapeType = Shape function type B-spline only for the moment
 //     degree = B-spline degree (-1 for delta function)
 //     tol = tolerance of NUFFT
+//     output_type = optional output type argument which if set to 'pruned' returns the output on 
+//     original requested modes whereas by default it returns on an 2x upsampled modes 
 //     Example:
 //     srun ./LandauDampingPIF 32 32 32 655360 20 0.05 B-spline 1 1e-4 --info 5
 //

--- a/alpine/ElectrostaticPIF/LandauDampingPIF.cpp
+++ b/alpine/ElectrostaticPIF/LandauDampingPIF.cpp
@@ -1,6 +1,7 @@
 // Electrostatic Landau damping test with Particle-in-Fourier schemes
 //   Usage:
-//     srun ./LandauDampingPIF <nx> <ny> <nz> <Np> <Nt> <dt> <ShapeType> <degree> <tol> <output_type> --info 5
+//     srun ./LandauDampingPIF <nx> <ny> <nz> <Np> <Nt> <dt> <ShapeType> <degree> 
+//                             <tol> <output_type> <nufft_library> --info 5
 //     nx       = No. of Fourier modes in the x-direction
 //     ny       = No. of Fourier modes in the y-direction
 //     nz       = No. of Fourier modes in the z-direction
@@ -12,6 +13,10 @@
 //     tol = tolerance of NUFFT
 //     output_type = optional output type argument which if set to 'pruned' returns the output on 
 //     original requested modes whereas by default it returns on an 2x upsampled modes 
+//     nufft_library = optional argument to select the external FINUFFT library for NUFFTs 
+//     instead of the native version. If IPPL is built with FINUFFT and if the argument is 
+//     set to 'useFinufft' then FINUFFT will be used for the NUFFTs. If no argumet or any other 
+//     argument the native version will be used. 
 //     Example:
 //     srun ./LandauDampingPIF 32 32 32 655360 20 0.05 B-spline 1 1e-4 --info 5
 //
@@ -156,6 +161,17 @@ int main(int argc, char* argv[]) {
         //                             (default, matches the original example).
         const bool useUpsampledInputs =
             !(argc > 10 && std::string(argv[10]) == "pruned");
+        // Optional 11th positional argument selects the external FINUFFT 
+        // library for performing NUFFTs instead of the native path. But
+        // IPPL needs to be built with FINUFFT for this. 
+        const bool useFinufft = 
+            (argc > 11 && std::string(argv[11]) == "useFinufft");
+
+        if(useFinufft && useUpsampledInputs) {
+            throw IpplException("LandauDampingPIF",
+                                "Set the output type to be pruned with Finufft.");
+
+        }
 
         ippl::Vector<int, Dim> nr = {std::atoi(argv[1]), std::atoi(argv[2]), std::atoi(argv[3])};
         ippl::Vector<int, Dim> nrOrig;
@@ -234,7 +250,8 @@ int main(int argc, char* argv[]) {
         // Q = -\int\int f dx dv
         double Q = -length[0] * length[1] * length[2];
         P        = std::make_unique<bunch_type>(PL, hr, rmin, rmax, isParallel, Q,
-                                                Total_particles, useUpsampledInputs);
+                                                Total_particles, 
+                                                useUpsampledInputs, useFinufft);
 
         P->nr_m = nr;
 

--- a/alpine/ElectrostaticPIF/PenningTrapPIF.cpp
+++ b/alpine/ElectrostaticPIF/PenningTrapPIF.cpp
@@ -1,0 +1,419 @@
+// Electrostatic Penning trap test with Particle-in-Fourier schemes
+//   Usage:
+//     srun ./PenningTrapPIF <nx> <ny> <nz> <Np> <Nt> <dt> <ShapeType> <degree> <tol> --info 5
+//     nx       = No. of Fourier modes in the x-direction
+//     ny       = No. of Fourier modes in the y-direction
+//     nz       = No. of Fourier modes in the z-direction
+//     Np       = Total no. of macro-particles in the simulation
+//     Nt       = Number of time steps
+//     dt       = Time stepsize
+//     ShapeType = Shape function type B-spline only for the moment
+//     degree = B-spline degree (-1 for delta function)
+//     tol = tolerance of NUFFT
+//     Example:
+//     srun ./PenningTrapPIF 32 32 32 655360 20 0.05 B-spline 1 1e-4 --info 5
+//
+// Copyright (c) 2023, Sriramkrishnan Muralikrishnan,
+// Jülich Supercomputing Centre, Jülich, Germany.
+// All rights reserved
+//
+// This file is part of IPPL.
+//
+// IPPL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with IPPL. If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include <Kokkos_Random.hpp>
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "Utility/IpplTimings.h"
+
+#include "ChargedParticlesPIF.hpp"
+
+#ifdef ENABLE_CATALYST
+#include "CatalystAdaptor.h"
+#endif
+
+template <typename T>
+struct Newton1D {
+    double tol   = 1e-12;
+    int max_iter = 20;
+    double pi    = Kokkos::numbers::pi_v<double>;
+
+    T mu, sigma, u;
+
+    KOKKOS_INLINE_FUNCTION Newton1D() {}
+
+    KOKKOS_INLINE_FUNCTION Newton1D(const T& mu_, const T& sigma_, const T& u_)
+        : mu(mu_)
+        , sigma(sigma_)
+        , u(u_) {}
+
+    KOKKOS_INLINE_FUNCTION ~Newton1D() {}
+
+    KOKKOS_INLINE_FUNCTION T f(T& x) {
+        T F;
+        F = Kokkos::erf((x - mu) / (sigma * Kokkos::sqrt(2.0))) - 2 * u + 1;
+        return F;
+    }
+
+    KOKKOS_INLINE_FUNCTION T fprime(T& x) {
+        T Fprime;
+        Fprime =
+            (1 / sigma) * Kokkos::sqrt(2 / pi)
+            * Kokkos::exp(-0.5 * (Kokkos::pow(((x - mu) / sigma), 2)));
+        return Fprime;
+    }
+
+    KOKKOS_FUNCTION
+    void solve(T& x) {
+        int iterations = 0;
+        while ((iterations < max_iter) && (Kokkos::fabs(f(x)) > tol)) {
+            x = x - (f(x) / fprime(x));
+            iterations += 1;
+        }
+    }
+};
+
+template <typename T, class GeneratorPool, unsigned Dim>
+struct generate_random {
+    using view_type  = typename ippl::detail::ViewType<T, 1>::view_type;
+    using value_type = typename T::value_type;
+    // Output View for the random numbers
+    view_type x, v;
+
+    // The GeneratorPool
+    GeneratorPool rand_pool;
+
+    T mu, sigma, minU, maxU;
+
+    double pi = Kokkos::numbers::pi_v<double>;
+
+    // Initialize all members
+    generate_random(view_type x_, view_type v_, GeneratorPool rand_pool_, T& mu_, T& sigma_,
+                    T& minU_, T& maxU_)
+        : x(x_)
+        , v(v_)
+        , rand_pool(rand_pool_)
+        , mu(mu_)
+        , sigma(sigma_)
+        , minU(minU_)
+        , maxU(maxU_) {}
+
+    KOKKOS_INLINE_FUNCTION void operator()(const size_t i) const {
+        // Get a random number state from the pool for the active thread
+        typename GeneratorPool::generator_type rand_gen = rand_pool.get_state();
+
+        value_type u;
+        for (unsigned d = 0; d < Dim; ++d) {
+            u       = rand_gen.drand(minU[d], maxU[d]);
+            x(i)[d] = (Kokkos::sqrt(pi / 2) * (2 * u - 1)) * sigma[d] + mu[d];
+            Newton1D<value_type> solver(mu[d], sigma[d], u);
+            solver.solve(x(i)[d]);
+            v(i)[d] = rand_gen.normal(0.0, 1.0);
+        }
+
+        // Give the state back, which will allow another thread to acquire it
+        rand_pool.free_state(rand_gen);
+    }
+};
+
+double CDF(const double& x, const double& mu, const double& sigma) {
+    double cdf = 0.5 * (1.0 + std::erf((x - mu) / (sigma * std::sqrt(2))));
+    return cdf;
+}
+
+const char* TestName = "PenningTrapPIF";
+
+int main(int argc, char* argv[]) {
+    ippl::initialize(argc, argv);
+    {
+#ifdef ENABLE_CATALYST
+        char* script = nullptr;
+        for (int i = 1; i < argc; ++i) {
+            if (std::string(argv[i]) == "--pvscript" && i + 1 < argc) {
+                script = argv[i + 1];
+                i++;
+            }
+        }
+        char* reducedArgv[] = {argv[0], script};
+        CatalystAdaptor::Initialize(2, reducedArgv);
+#endif
+        Inform msg(TestName);
+        Inform msg2all(TestName, INFORM_ALL_NODES);
+
+        ippl::Vector<int, Dim> nr = {std::atoi(argv[1]), std::atoi(argv[2]), std::atoi(argv[3])};
+
+        static IpplTimings::TimerRef mainTimer        = IpplTimings::getTimer("mainTimer");
+        static IpplTimings::TimerRef particleCreation = IpplTimings::getTimer("particlesCreation");
+        static IpplTimings::TimerRef dumpDataTimer    = IpplTimings::getTimer("dumpData");
+        static IpplTimings::TimerRef PTimer           = IpplTimings::getTimer("kick");
+        static IpplTimings::TimerRef RTimer           = IpplTimings::getTimer("drift");
+        static IpplTimings::TimerRef BCTimer          = IpplTimings::getTimer("particleBC");
+        static IpplTimings::TimerRef initializeShapeFunctionPIF =
+            IpplTimings::getTimer("initializeShapeFunctionPIF");
+
+        IpplTimings::startTimer(mainTimer);
+
+        const size_type totalP = std::atoll(argv[4]);
+        const unsigned int nt  = std::atoi(argv[5]);
+        const double dt        = std::atof(argv[6]);
+
+        double factor             = 1.0 / ippl::Comm->size();
+        size_type nloc            = (size_type)(factor * totalP);
+        size_type Total_particles = 0;
+
+        MPI_Allreduce(&nloc, &Total_particles, 1, MPI_UNSIGNED_LONG, MPI_SUM,
+                      ippl::Comm->getCommunicator());
+
+        msg << TestName << endl
+            << "nt " << nt << " Np= " << Total_particles << " Fourier modes = " << nr << endl;
+
+        using bunch_type = ChargedParticlesPIF<PLayout_t>;
+
+        std::shared_ptr<bunch_type> P;
+
+        ippl::NDIndex<Dim> domain;
+        for (unsigned i = 0; i < Dim; i++) {
+            domain[i] = ippl::Index(nr[i]);
+        }
+
+        std::array<bool, Dim> isParallel;  // Specifies SERIAL, PARALLEL dims
+        isParallel.fill(false);
+
+        // create mesh and layout objects for this problem domain
+        Vector_t rmin(0.0);
+        Vector_t rmax(25.0);
+        double dx = rmax[0] / nr[0];
+        double dy = rmax[1] / nr[1];
+        double dz = rmax[2] / nr[2];
+
+        Vector_t length = rmax - rmin;
+
+        Vector_t mu, sd;
+
+        for (unsigned d = 0; d < Dim; d++) {
+            mu[d] = 0.5 * length[d];
+        }
+        // sd[0] = 0.15*length[0];
+        // sd[1] = 0.05*length[1];
+        // sd[2] = 0.20*length[2];
+        sd[0] = 0.10 * 20.0;  // length[0];
+        sd[1] = 0.05 * 20.0;  // length[1];
+        sd[2] = 0.15 * 20.0;  // length[2];
+
+        Vector_t hr     = {dx, dy, dz};
+        Vector_t origin = {rmin[0], rmin[1], rmin[2]};
+
+        Mesh_t mesh(domain, hr, origin);
+        FieldLayout_t FL(*ippl::Comm, domain, isParallel);
+        PLayout_t PL(FL, mesh);
+
+        double Q    = -1562.5;
+        double Bext = 5.0;
+        // P = std::make_unique<bunch_type>(PL,hr,rmin,rmax,decomp,Q,Total_particles);
+        P = std::make_shared<bunch_type>(PL, hr, rmin, rmax, isParallel, Q, Total_particles);
+
+        P->nr_m = nr;
+
+        P->rho_m.initialize(mesh, FL);
+        P->Sk_m.initialize(mesh, FL);
+
+        ////////////////////////////////////////////////////////////
+        // Initialize an FFT object for getting rho in real space and
+        // doing charge conservation check
+
+        ippl::ParameterList fftParams;
+        fftParams.add("use_heffte_defaults", false);
+        fftParams.add("use_pencils", true);
+        fftParams.add("use_reorder", false);
+        fftParams.add("use_gpu_aware", true);
+        fftParams.add("comm", ippl::p2p_pl);
+        fftParams.add("r2c_direction", 0);
+
+        ippl::NDIndex<Dim> domainPIFhalf;
+
+        for (unsigned d = 0; d < Dim; ++d) {
+            domainPIFhalf[d] = ippl::Index(domain[d].length());
+        }
+
+        FieldLayout_t FLPIFhalf(*ippl::Comm, domainPIFhalf, isParallel);
+
+        ippl::Vector<double, 3> hDummy      = {1.0, 1.0, 1.0};
+        ippl::Vector<double, 3> originDummy = {0.0, 0.0, 0.0};
+        Mesh_t meshPIFhalf(domainPIFhalf, hDummy, originDummy);
+
+        ippl::Vector<double, 3> hFourier      = {2 * pi / length[0], 2 * pi / length[1],
+                                                 2 * pi / length[2]};
+        ippl::Vector<double, 3> originFourier = {-pi / hr[0], -pi / hr[1], -pi / hr[2]};
+        Mesh_t meshFourier(domain, hFourier, originFourier);
+
+        P->rhoPIFreal_m.initialize(mesh, FL);
+        P->rhoPIFhalf_m.initialize(meshPIFhalf, FLPIFhalf);
+        P->rhoPIFFourierMag_m.initialize(meshFourier, FL);
+
+        P->time_m = 0.0;
+
+        P->shapetype_m   = argv[7];
+        P->shapedegree_m = std::atoi(argv[8]);
+
+        IpplTimings::startTimer(particleCreation);
+
+        Vector_t minU, maxU;
+        for (unsigned d = 0; d < Dim; ++d) {
+            minU[d] = CDF(rmin[d], mu[d], sd[d]);
+            maxU[d] = CDF(rmax[d], mu[d], sd[d]);
+        }
+
+
+        P->create(nloc);
+        Kokkos::Random_XorShift64_Pool<> rand_pool64((size_type)(42 + 100 * ippl::Comm->rank()));
+        Kokkos::parallel_for(nloc,
+                             generate_random<Vector_t, Kokkos::Random_XorShift64_Pool<>, Dim>(
+                                 P->R.getView(), P->P.getView(), rand_pool64, mu, sd, minU, maxU));
+
+        Kokkos::fence();
+        ippl::Comm->barrier();
+        IpplTimings::stopTimer(particleCreation);
+
+        P->q = P->Q_m / Total_particles;
+        msg << "particles created and initial conditions assigned " << endl;
+
+        IpplTimings::startTimer(initializeShapeFunctionPIF);
+        P->initializeShapeFunctionPIF();
+        IpplTimings::stopTimer(initializeShapeFunctionPIF);
+
+        double tol = std::atof(argv[9]);
+        P->initNUFFT(FL, tol);
+
+        P->scatter();
+
+        P->gather();
+
+        IpplTimings::startTimer(dumpDataTimer);
+        // P->dumpEnergy();
+#ifdef ENABLE_CATALYST
+        P->rhoPIFreal_m = (1 / (hr[0] * hr[1] * hr[2])) * P->rhoPIFreal_m;
+        std::vector<CatalystAdaptor::FieldPair> fields = {
+            {"rhoK", CatalystAdaptor::FieldVariant(&P->rhoPIFFourierMag_m)},
+            {"rhoR", CatalystAdaptor::FieldVariant(&P->rhoPIFreal_m)}};
+        CatalystAdaptor::Execute(0, P->time_m, Ippl::Comm->rank(), P, fields);
+#endif
+        IpplTimings::stopTimer(dumpDataTimer);
+
+        double alpha = -0.5 * dt;
+        double DrInv = 1.0 / (1 + (std::pow((alpha * Bext), 2)));
+        // begin main timestep loop
+        msg << "Starting iterations ..." << endl;
+        for (unsigned int it = 0; it < nt; it++) {
+            // Staggered Leap frog or Boris algorithm as per
+            // https://www.sciencedirect.com/science/article/pii/S2590055219300526
+            // eqns 4(a)-4(c). Note we don't use the Boris trick here and do
+            // the analytical matrix inversion which is not complex in this case.
+            // Here, we assume a constant charge-to-mass ratio of -1 for
+            // all the particles hence eliminating the need to store mass as
+            // an attribute
+            // kick
+            IpplTimings::startTimer(PTimer);
+            auto Rview = P->R.getView();
+            auto Pview = P->P.getView();
+            auto Eview = P->E.getView();
+            double V0  = 30 * rmax[2];
+            Kokkos::parallel_for(
+                "Kick1", P->getLocalNum(), KOKKOS_LAMBDA(const size_t j) {
+                    double Eext_x =
+                        -(Rview(j)[0] - 0.5 * rmax[0]) * (V0 / (2 * Kokkos::pow(rmax[2], 2)));
+                    double Eext_y =
+                        -(Rview(j)[1] - 0.5 * rmax[1]) * (V0 / (2 * Kokkos::pow(rmax[2], 2)));
+                    double Eext_z = (Rview(j)[2] - 0.5 * rmax[2]) * (V0 / (Kokkos::pow(rmax[2], 2)));
+
+                    Eext_x += Eview(j)[0];
+                    Eext_y += Eview(j)[1];
+                    Eext_z += Eview(j)[2];
+
+                    Pview(j)[0] += alpha * (Eext_x + Pview(j)[1] * Bext);
+                    Pview(j)[1] += alpha * (Eext_y - Pview(j)[0] * Bext);
+                    Pview(j)[2] += alpha * Eext_z;
+                });
+            IpplTimings::stopTimer(PTimer);
+
+            // drift
+            IpplTimings::startTimer(RTimer);
+            P->R = P->R + dt * P->P;
+            IpplTimings::stopTimer(RTimer);
+
+            // Apply particle BC
+            IpplTimings::startTimer(BCTimer);
+            PL.applyBC(P->R, PL.getRegionLayout().getDomain());
+            IpplTimings::stopTimer(BCTimer);
+
+            // scatter the charge onto the underlying grid
+            P->scatter();
+
+            // Solve for and gather E field
+            P->gather();
+
+            // kick
+            IpplTimings::startTimer(PTimer);
+            auto R2view = P->R.getView();
+            auto P2view = P->P.getView();
+            auto E2view = P->E.getView();
+            Kokkos::parallel_for(
+                "Kick2", P->getLocalNum(), KOKKOS_LAMBDA(const size_t j) {
+                    double Eext_x =
+                        -(R2view(j)[0] - 0.5 * rmax[0]) * (V0 / (2 * Kokkos::pow(rmax[2], 2)));
+                    double Eext_y =
+                        -(R2view(j)[1] - 0.5 * rmax[1]) * (V0 / (2 * Kokkos::pow(rmax[2], 2)));
+                    double Eext_z = (R2view(j)[2] - 0.5 * rmax[2]) * (V0 / (Kokkos::pow(rmax[2], 2)));
+
+                    Eext_x += E2view(j)[0];
+                    Eext_y += E2view(j)[1];
+                    Eext_z += E2view(j)[2];
+
+                    P2view(j)[0] =
+                        DrInv
+                        * (P2view(j)[0]
+                           + alpha * (Eext_x + P2view(j)[1] * Bext + alpha * Bext * Eext_y));
+                    P2view(j)[1] =
+                        DrInv
+                        * (P2view(j)[1]
+                           + alpha * (Eext_y - P2view(j)[0] * Bext - alpha * Bext * Eext_x));
+                    P2view(j)[2] += alpha * Eext_z;
+                });
+            IpplTimings::stopTimer(PTimer);
+
+            P->time_m += dt;
+            IpplTimings::startTimer(dumpDataTimer);
+            // P->dumpEnergy();
+#ifdef ENABLE_CATALYST
+            P->rhoPIFreal_m = (1 / (hr[0] * hr[1] * hr[2])) * P->rhoPIFreal_m;
+            CatalystAdaptor::Execute(it, P->time_m, Ippl::Comm->rank(), P, fields);
+#endif
+            IpplTimings::stopTimer(dumpDataTimer);
+            msg << "Finished time step: " << it + 1 << " time: " << P->time_m << endl;
+        }
+
+        msg << TestName << " End." << endl;
+
+#ifdef ENABLE_CATALYST
+        CatalystAdaptor::Finalize();
+#endif
+
+        IpplTimings::stopTimer(mainTimer);
+        IpplTimings::print();
+        IpplTimings::print(std::string("timing.dat"));
+    }
+    ippl::finalize();
+    return 0;
+}

--- a/src/FFT/Transform/NUFFT.hpp
+++ b/src/FFT/Transform/NUFFT.hpp
@@ -346,6 +346,7 @@ namespace ippl {
 
         FinufftOpts_t opts;
         Traits_t::defaultOpts(&opts);
+        opts.modeord = 1;//Similar to Heffte ordering
 
 #ifdef ENABLE_GPU_NUFFT
         opts.gpu_method         = params.get<int>("gpu_method", opts.gpu_method);

--- a/src/FFT/Transform/NUFFT.hpp
+++ b/src/FFT/Transform/NUFFT.hpp
@@ -346,7 +346,6 @@ namespace ippl {
 
         FinufftOpts_t opts;
         Traits_t::defaultOpts(&opts);
-        opts.modeord = 1;//Similar to Heffte ordering
 
 #ifdef ENABLE_GPU_NUFFT
         opts.gpu_method         = params.get<int>("gpu_method", opts.gpu_method);

--- a/src/Interpolation/Scatter/ScatterConfig.h
+++ b/src/Interpolation/Scatter/ScatterConfig.h
@@ -183,7 +183,7 @@ namespace ippl {
             struct ScatterConfigDefault<Dim, Kokkos::Cuda> {
                 static ScatterConfig<Dim> get() {
                     ScatterConfig<Dim> config;
-                    config.method    = ScatterMethod::Atomic;
+                    config.method    = ScatterMethod::OutputFocused;
                     config.sort      = false;
                     config.team_size = 32;
 

--- a/src/Particle/ParticleAttrib.h
+++ b/src/Particle/ParticleAttrib.h
@@ -230,6 +230,20 @@ namespace ippl {
         void gather(Field& f, const ParticleAttrib<Vector<P2, Field::dim>, Properties...>& pp,
                     const bool addToAttribute = false);
 
+#ifdef IPPL_ENABLE_FFT
+        template <unsigned Dim, class M, class C, typename P2, typename P3, typename P4>
+        void scatterPIFNUFFT(Field<P2, Dim, M, C>& f, Field<P3, Dim, M, C>& Sk,
+                             const ParticleAttrib<Vector<P4, Dim>, Properties...>& pp,
+                             FFT<NUFFTransform, Field<P3, Dim, M, C>>* nufft,
+                             const MPI_Comm& spaceComm) const;
+
+        template <unsigned Dim, class M, class C, typename P2, typename P3, typename P4>
+        void gatherPIFNUFFT(Field<P2, Dim, M, C>& f, Field<P3, Dim, M, C>& Sk,
+                            const ParticleAttrib<Vector<P4, Dim>, Properties...>& pp,
+                            FFT<NUFFTransform, Field<P3, Dim, M, C>>* nufft,
+                            ParticleAttrib<P4, Properties...>& q);
+#endif
+
         T sum();
         T max();
         T min();

--- a/src/Particle/ParticleAttrib.hpp
+++ b/src/Particle/ParticleAttrib.hpp
@@ -15,6 +15,10 @@
 //
 #include "Ippl.h"
 
+#include <Kokkos_MathematicalConstants.hpp>
+
+#include <cmath>
+
 #include "Communicate/DataTypes.h"
 
 #include "Utility/BufferView.h"
@@ -351,6 +355,157 @@ namespace ippl {
                        const bool addToAttribute = false) {
         attrib.gather(f, pp, addToAttribute);
     }
+
+#ifdef IPPL_ENABLE_FFT
+    template <typename T, class... Properties>
+    template <unsigned Dim, class M, class C, class FT, class ST, class PT>
+    void ParticleAttrib<T, Properties...>::scatterPIFNUFFT(
+        Field<FT, Dim, M, C>& f, Field<ST, Dim, M, C>& Sk,
+        const ParticleAttrib<Vector<PT, Dim>, Properties...>& pp,
+        FFT<NUFFTransform, Field<ST, Dim, M, C>>* nufft, const MPI_Comm&) const {
+        static IpplTimings::TimerRef scatterPIFNUFFTTimer =
+            IpplTimings::getTimer("ScatterPIFNUFFT");
+        IpplTimings::startTimer(scatterPIFNUFFTTimer);
+
+        auto q = *this;
+
+        typename Field<FT, Dim, M, C>::uniform_type tempField;
+
+        FieldLayout<Dim>& layout = f.getLayout();
+        M& mesh                  = f.get_mesh();
+
+        tempField.initialize(mesh, layout);
+        tempField = 0.0;
+
+        nufft->transform(pp, q, tempField);
+
+        using view_type                                 = typename Field<FT, Dim, M, C>::view_type;
+        view_type fview                                 = f.getView();
+        view_type viewLocal                             = tempField.getView();
+        typename Field<ST, Dim, M, C>::view_type Skview = Sk.getView();
+        const int nghost                                = f.getNghost();
+
+        IpplTimings::stopTimer(scatterPIFNUFFTTimer);
+
+        Kokkos::deep_copy(fview, viewLocal);
+
+        IpplTimings::startTimer(scatterPIFNUFFTTimer);
+
+        using mdrange_type = Kokkos::MDRangePolicy<Kokkos::Rank<3>, execution_space>;
+        Kokkos::parallel_for(
+            "Multiply with shape functions",
+            mdrange_type(
+                {nghost, nghost, nghost},
+                {fview.extent(0) - nghost, fview.extent(1) - nghost, fview.extent(2) - nghost}),
+            KOKKOS_LAMBDA(const size_t i, const size_t j, const size_t k) {
+                fview(i, j, k) *= Skview(i, j, k);
+            });
+
+        IpplTimings::stopTimer(scatterPIFNUFFTTimer);
+    }
+
+    template <typename T, class... Properties>
+    template <unsigned Dim, class M, class C, class FT, class ST, class PT>
+    void ParticleAttrib<T, Properties...>::gatherPIFNUFFT(
+        Field<FT, Dim, M, C>& f, Field<ST, Dim, M, C>& Sk,
+        const ParticleAttrib<Vector<PT, Dim>, Properties...>& pp,
+        FFT<NUFFTransform, Field<ST, Dim, M, C>>* nufft, ParticleAttrib<PT, Properties...>& q) {
+        static IpplTimings::TimerRef gatherPIFNUFFTTimer =
+            IpplTimings::getTimer("GatherPIFNUFFT");
+        IpplTimings::startTimer(gatherPIFNUFFTTimer);
+
+        typename Field<FT, Dim, M, C>::uniform_type tempField;
+
+        FieldLayout<Dim>& layout = f.getLayout();
+        M& mesh                  = f.get_mesh();
+        const auto& lDom         = layout.getLocalNDIndex();
+
+        tempField.initialize(mesh, layout);
+
+        using view_type                                 = typename Field<FT, Dim, M, C>::view_type;
+        using vector_type                               = typename M::vector_type;
+        view_type fview                                 = f.getView();
+        view_type tempview                              = tempField.getView();
+        auto qview                                      = q.getView();
+        typename Field<ST, Dim, M, C>::view_type Skview = Sk.getView();
+        const int nghost                                = f.getNghost();
+        const vector_type& dx                           = mesh.getMeshSpacing();
+        const auto& domain                              = layout.getDomain();
+        vector_type Len;
+        Vector<int, Dim> N;
+
+        for (unsigned d = 0; d < Dim; ++d) {
+            N[d]   = domain[d].length();
+            Len[d] = dx[d] * N[d];
+        }
+
+        constexpr double pi          = Kokkos::numbers::pi_v<double>;
+        Kokkos::complex<double> imag = {0.0, 1.0};
+        size_t Np                    = *(this->localNum_mp);
+
+        using mdrange_type = Kokkos::MDRangePolicy<Kokkos::Rank<3>, execution_space>;
+
+        auto dview = dview_m;
+
+        for (size_t gd = 0; gd < Dim; ++gd) {
+            Kokkos::parallel_for(
+                "Gather NUFFT",
+                mdrange_type(
+                    {nghost, nghost, nghost},
+                    {fview.extent(0) - nghost, fview.extent(1) - nghost,
+                     fview.extent(2) - nghost}),
+                KOKKOS_LAMBDA(const int i, const int j, const int k) {
+                    Vector<int, 3> iVec = {i, j, k};
+                    for (unsigned d = 0; d < Dim; ++d) {
+                        iVec[d] = iVec[d] - nghost + lDom[d].first();
+                    }
+                    Vector<double, 3> kVec;
+
+                    double Dr = 0.0;
+                    for (size_t d = 0; d < Dim; ++d) {
+                        bool shift = (iVec[d] > (N[d] / 2));
+                        kVec[d]    = 2 * pi / Len[d] * (iVec[d] - shift * N[d]);
+                        Dr += kVec[d] * kVec[d];
+                    }
+
+                    tempview(i, j, k) = fview(i, j, k);
+
+                    bool isNotZero = (Dr != 0.0);
+                    double factor  = isNotZero * (1.0 / (Dr + ((!isNotZero) * 1.0)));
+
+                    tempview(i, j, k) *= -Skview(i, j, k) * (imag * kVec[gd] * factor);
+                });
+
+            nufft->transform(pp, q, tempField);
+
+            Kokkos::parallel_for(
+                "Assign E gather NUFFT", Np,
+                KOKKOS_LAMBDA(const size_t i) { dview(i)[gd] = qview(i); });
+        }
+
+        IpplTimings::stopTimer(gatherPIFNUFFTTimer);
+    }
+
+    template <typename P1, unsigned Dim, class M, class C, typename P2, typename P3, typename P4,
+              class... Properties>
+    inline void gatherPIFNUFFT(ParticleAttrib<P1, Properties...>& attrib, Field<P2, Dim, M, C>& f,
+                               Field<P3, Dim, M, C>& Sk,
+                               const ParticleAttrib<Vector<P4, Dim>, Properties...>& pp,
+                               ippl::FFT<ippl::NUFFTransform, Field<P3, Dim, M, C>>* nufft,
+                               ParticleAttrib<P4, Properties...>& q) {
+        attrib.gatherPIFNUFFT(f, Sk, pp, nufft, q);
+    }
+
+    template <typename P1, unsigned Dim, class M, class C, typename P2, typename P3, typename P4,
+              class... Properties>
+    inline void scatterPIFNUFFT(const ParticleAttrib<P1, Properties...>& attrib,
+                                Field<P2, Dim, M, C>& f, Field<P3, Dim, M, C>& Sk,
+                                const ParticleAttrib<Vector<P4, Dim>, Properties...>& pp,
+                                FFT<NUFFTransform, Field<P3, Dim, M, C>>* nufft,
+                                const MPI_Comm& spaceComm = MPI_COMM_WORLD) {
+        attrib.scatterPIFNUFFT(f, Sk, pp, nufft, spaceComm);
+    }
+#endif  // IPPL_ENABLE_FFT
 
 #define DefineParticleReduction(fun, name, op, MPI_Op)            \
     template <typename T, class... Properties>                    \

--- a/test/FFT/TestGaussianNUFFT.cpp
+++ b/test/FFT/TestGaussianNUFFT.cpp
@@ -357,7 +357,6 @@ namespace {
         ippl::ParameterList params;
         params.add("tolerance", 1.0e-6);
         params.add("use_upsampled_inputs", false);
-        params.add("use_kokkos_nufft", false);
         params.add("sort", true);
         params.add("tile_size_3d", 6);
         params.add("z_tiles", 1);
@@ -375,7 +374,6 @@ namespace {
             }
 #endif
             params.add("use_finufft", true);
-            params.add("use_finufft_defaults", false);
 #endif
         } else {
             throw IpplException("TestGaussianNUFFT", "Unknown NUFFT backend");

--- a/unit_tests/FFT/NUFFTTestUtils.h
+++ b/unit_tests/FFT/NUFFTTestUtils.h
@@ -253,8 +253,6 @@ namespace ippl {
                 params.add("tolerance", tolerance);
                 params.add("use_upsampled_inputs", useUpsampling);
                 params.add("use_finufft", true);
-                params.add("use_finufft_defaults", false);
-                params.add("use_kokkos_nufft", false);
 
 #ifdef ENABLE_GPU_NUFFT
                 params.add("gpu_method", 1);


### PR DESCRIPTION
## Summary

This PR adds the Electrostatic Particle-in-Fourier (PIF) Alpine examples on top of the NUFFT infrastructure that is now available on `master`.

The change is intentionally scoped to the PIF layer only. Current `master` remains the ground truth; this PR only adds the missing PIF example code and the small `ParticleAttrib` hooks needed to call the NUFFT scatter/gather path.

This reverts commit 7b8d451ddc4e88e69199084ee1ab43b3df8e0ef0 (accidentally commit to master).

## Added Functionality

### Electrostatic PIF Alpine examples

Adds a new `alpine/ElectrostaticPIF` directory with:

- `LandauDampingPIF`
- `BumponTailInstabilityPIF`
- `PenningTrapPIF`
- shared `ChargedParticlesPIF.hpp` support code

The examples exercise electrostatic particle-field coupling through Particle-in-Fourier methods using the existing IPPL FFT/NUFFT infrastructure.

`LandauDampingPIF` supports both:

- the default upsampled NUFFT path
- the pruned NUFFT path via the optional `pruned` positional argument

Example:

```bash
mpirun -n 2 ./alpine/ElectrostaticPIF/LandauDampingPIF \
  8 8 8 256 1 0.05 B-spline 1 1e-4 pruned --info 0
```

### CMake integration

Adds `alpine/ElectrostaticPIF` when `IPPL_ENABLE_FFT=ON`.

The PIF examples link FINUFFT/cuFINUFFT only when the corresponding targets are available. This keeps builds with `-DIPPL_ENABLE_FINUFFT=OFF` valid.

### ParticleAttrib PIF NUFFT hooks

Adds FFT-guarded `ParticleAttrib` entry points for:

- `scatterPIFNUFFT`
- `gatherPIFNUFFT`

These connect particle charge/position attributes to the `NUFFTransform` path and apply the PIF shape function in Fourier space.

## Porting Adjustments For Current Master

The imported PIF code was adapted minimally to match current `master` and Kokkos 5 conventions:

- use explicit execution-space `Kokkos::MDRangePolicy`
- keep `ParticleSpatialLayout` and `ParticleAttrib` on a consistent execution space
- replace device-reachable `std::` math calls with `Kokkos::` math calls
- use `Kokkos::numbers::pi_v<double>` instead of `std::acos(-1.0)` in Kokkos-reachable code
- avoid the old `Kokkos::deep_copy(execution_space{}, ...)` form

## Validation

Configured with:

```bash
cmake -S . -B build-pr501-pif-final-openmp \
  -DCMAKE_BUILD_TYPE=Release \
  -DIPPL_PLATFORMS=OPENMP \
  -DIPPL_ENABLE_FFT=ON \
  -DIPPL_ENABLE_FINUFFT=OFF \
  -DIPPL_ENABLE_ALPINE=ON \
  -DIPPL_ENABLE_UNIT_TESTS=ON \
  -DIPPL_ENABLE_TESTS=ON
```

Built successfully:

- `LandauDampingPIF`
- `BumponTailInstabilityPIF`
- `PenningTrapPIF`
- `TestGaussianNUFFT`
- `ParticleSendRecv`
- `GatherScatterTest`
- `ParticleUpdate`
- `KernelGatherScatterTest`
- `ParticleUpdateNonuniform`

Focused CTest subset passed:

```text
100% tests passed, 0 tests failed out of 6

KernelGatherScatterTest
ParticleSendRecv
GatherScatterTest
ParticleUpdate
ParticleUpdateNonuniform
TestGaussianNUFFT
```

Smoke-tested examples:

```text
LandauDampingPIF: passed on 1 rank
LandauDampingPIF: passed on 2 ranks
LandauDampingPIF pruned mode: passed on 2 ranks
BumponTailInstabilityPIF: passed on 1 rank
PenningTrapPIF: passed on 1 rank
```

## Known Limitation

`BumponTailInstabilityPIF` and `PenningTrapPIF` currently use a non-parallel `FieldLayout` setup in the imported example code. With small local smoke-test domains they abort on 2 ranks because the domain cannot be partitioned over multiple ranks.

That behavior is left unchanged in this PR because the goal here is a faithful, additive PIF port on top of current `master`, not a broader example-layout refactor.

## Out Of Scope

This PR does not change:

- the NUFFT implementation itself
- FINUFFT/cuFINUFFT dependency handling
- general particle communication/update infrastructure
- PIF example physics or domain-decomposition design beyond the minimal changes needed to compile and run on current `master`
