### PR TITLE
Improve Landau test setup/cleanup and validation

### DIFF
--- a/demos/alpine/CMakeLists.txt
+++ b/demos/alpine/CMakeLists.txt
@@ -5,7 +5,6 @@
 # -----------------------------------------------------------------------------
 message(STATUS "Configuring demos/alpine/")
 
-
 add_subdirectory(ExamplesWithoutPicManager)
 
 function(add_alpine_example name)
@@ -18,13 +17,27 @@ endfunction()
 
 if(IPPL_ENABLE_TESTS)
   # cmake-format: off
-  # Landau will write a CSV file to the data directory that we will validate later
-  make_directory("${PROJECT_BINARY_DIR}/demos/alpine/data")
+
+  set(LANDAU_RANKS 2)
+  set(LANDAU_CSV "${PROJECT_BINARY_DIR}/demos/alpine/data/FieldLandau_${LANDAU_RANKS}_manager.csv")
+
+  # Create the data directory and remove any stale CSV so the LandauDamping
+  # fixture starts clean. We use bash instead of ${CMAKE_COMMAND} because the
+  # build and test phases may run with different uenv mount points, making the
+  # absolute cmake path from the build phase unavailable at test time.
+  add_test(NAME LandauDampingInit
+    COMMAND bash -c "mkdir -p '${PROJECT_BINARY_DIR}/demos/alpine/data' && rm -f '${LANDAU_CSV}'")
+  set_tests_properties(LandauDampingInit PROPERTIES FIXTURES_SETUP landau_fixture)
+
   # Add the test
-  add_ippl_integration_test(LandauDamping
+  add_ippl_integration_test(LandauDamping 
     ARGS "16" "16" "16" "10000000" "25" "FFT" "0.01" "LeapFrog" "--overallocate" "2.0" "--info" "10"
     LABELS alpine integration
+    NUM_PROCS ${LANDAU_RANKS}
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/demos/alpine/")
+
+  set_tests_properties(LandauDamping PROPERTIES FIXTURES_REQUIRED landau_fixture)
+    
   # cmake-format: on
 else()
   add_alpine_example(LandauDamping)


### PR DESCRIPTION
Cleanup Landau validation
improvement is that pre-test - we clean the output, then run the test, then validate the test. This prevents a collision if the test is run twice causing the previous results to contaminate the new results. 