### PR TITLE
Changes Kokkos 520

### DIFF
--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -140,7 +140,6 @@
         "Kokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE": "OFF",
         "Kokkos_ENABLE_DEBUG": "OFF",
         "Kokkos_ENABLE_DEBUG_BOUNDS_CHECK": "OFF",
-        "Kokkos_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK": "ON",
         "Kokkos_ENABLE_DEPRECATED_CODE": "OFF",
         "Kokkos_ENABLE_EXAMPLES": "OFF",
         "Kokkos_ENABLE_HPX_ASYNC_DISPATCH": "OFF",

--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -133,7 +133,6 @@
         "Kokkos_ENABLE_SERIAL": "ON",
         "Kokkos_ENABLE_HIP": "ON",
         "Kokkos_ENABLE_SYCL": "OFF",
-        "Kokkos_ENABLE_OPENMPTARGET": "OFF",
         "Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION": "OFF",
         "Kokkos_ENABLE_COMPILER_WARNINGS": "OFF",
         "Kokkos_ENABLE_COMPLEX_ALIGN": "ON",

--- a/src/Field/BareField.hpp
+++ b/src/Field/BareField.hpp
@@ -103,7 +103,7 @@ namespace ippl {
     template <typename T, unsigned Dim, class... ViewArgs>
     BareField<T, Dim, ViewArgs...> BareField<T, Dim, ViewArgs...>::deepCopy() const {
         BareField<T, Dim, ViewArgs...> copy(*layout_m, nghost_m);
-        Kokkos::deep_copy(copy.dview_m, dview_m);
+        detail::deepCopyIfDifferent(copy.dview_m, dview_m);
         return copy;
     }
 

--- a/src/Field/Field.hpp
+++ b/src/Field/Field.hpp
@@ -35,7 +35,7 @@ namespace ippl {
     Field<T, Dim, Mesh, Centering, ViewArgs...>::deepCopy() const {
         Field<T, Dim, Mesh, Centering, ViewArgs...> copy(*mesh_m, this->getLayout(),
                                                          this->getNghost());
-        Kokkos::deep_copy(copy.getView(), this->getView());
+        detail::deepCopyIfDifferent(copy.getView(), this->getView());
 
         return copy;
     }

--- a/src/LinearSolvers/Multigrid.h
+++ b/src/LinearSolvers/Multigrid.h
@@ -196,7 +196,7 @@ namespace ippl {
             }
 
             // Write the result into the caller-provided buffer
-            Kokkos::deep_copy(result.getView(), L_[0].u.getView());
+            detail::deepCopyIfDifferent(result.getView(), L_[0].u.getView());
 
             IpplTimings::stopTimer(mg);
         }

--- a/src/LinearSolvers/Preconditioner.h
+++ b/src/LinearSolvers/Preconditioner.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Expression/IpplOperations.h"  // get the function apply()
+#include "Utility/ViewUtils.h"
 
 // Expands to a lambda that acts as a wrapper for a differential operator
 // fun: the function for which to create the wrapper, such as ippl::laplace
@@ -47,7 +48,7 @@ namespace ippl {
         // avoids per-call Field allocations and per-call deep copies in PCG.
         // The default (identity) preconditioner copies u into result.
         virtual void operator()(Field& u, Field& result) {
-            Kokkos::deep_copy(result.getView(), u.getView());
+            detail::deepCopyIfDifferent(result.getView(), u.getView());
         }
 
         // Allocate any scratch fields the preconditioner needs. Called once
@@ -292,13 +293,13 @@ namespace ippl {
             x_m     = 2.0 * rho_m[1] / delta_m * (2.0 * r - A_m / theta_m);
             if (degree_m == 0) {
                 // result = x_old
-                Kokkos::deep_copy(result.getView(), x_old_m.getView());
+                detail::deepCopyIfDifferent(result.getView(), x_old_m.getView());
                 return;
             }
 
             if (degree_m == 1) {
                 // result = x
-                Kokkos::deep_copy(result.getView(), x_m.getView());
+                detail::deepCopyIfDifferent(result.getView(), x_m.getView());
                 return;
             }
             for (unsigned int i = 2; i < degree_m + 1; ++i) {
@@ -307,8 +308,8 @@ namespace ippl {
                 // Write the new x value into result (the caller's buffer);
                 // x_old gets a deep copy of the previous x.
                 result = rho_m[i] * (2 * sigma_m * x_m - rho_m[i - 1] * x_old_m + z_m);
-                Kokkos::deep_copy(x_old_m.getView(), x_m.getView());
-                Kokkos::deep_copy(x_m.getView(), result.getView());
+                detail::deepCopyIfDifferent(x_old_m.getView(), x_m.getView());
+                detail::deepCopyIfDifferent(x_m.getView(), result.getView());
             }
         }
 
@@ -470,7 +471,7 @@ namespace ippl {
                 } else {
                     result = g_old_m + inverse_diagonal_m(result);
                 }
-                Kokkos::deep_copy(g_old_m.getView(), result.getView());
+                detail::deepCopyIfDifferent(g_old_m.getView(), result.getView());
             }
         }
 

--- a/src/MaxwellSolvers/FDTDSolverBase.h
+++ b/src/MaxwellSolvers/FDTDSolverBase.h
@@ -9,6 +9,7 @@ using std::size_t;
 #include "MaxwellSolvers/Maxwell.h"
 #include "Meshes/UniformCartesian.h"
 #include "Particle/ParticleBase.h"
+#include "Utility/ViewUtils.h"
 
 namespace ippl {
     enum fdtd_bc {

--- a/src/MaxwellSolvers/FDTDSolverBase.hpp
+++ b/src/MaxwellSolvers/FDTDSolverBase.hpp
@@ -59,8 +59,8 @@ namespace ippl {
     template <typename EMField, typename SourceField, fdtd_bc boundary_conditions>
     void FDTDSolverBase<EMField, SourceField, boundary_conditions>::timeShift() {
         // Look into this, maybe cyclic swap is better
-        Kokkos::deep_copy(this->A_nm1.getView(), this->A_n.getView());
-        Kokkos::deep_copy(this->A_n.getView(), this->A_np1.getView());
+        detail::deepCopyIfDifferent(this->A_nm1.getView(), this->A_n.getView());
+        detail::deepCopyIfDifferent(this->A_n.getView(), this->A_np1.getView());
     }
 
     /**

--- a/src/Utility/TypeUtils.h
+++ b/src/Utility/TypeUtils.h
@@ -222,8 +222,8 @@ namespace ippl {
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
                 ,
-                Kokkos::Experimental::SYCLDeviceUSMSpace, Kokkos::Experimental::SYCLHostUSMSpace,
-                Kokkos::Experimental::SYCLSharedUSMSpace
+                Kokkos::SYCLDeviceUSMSpace, Kokkos::SYCLHostUSMSpace,
+                Kokkos::SYCLSharedUSMSpace
 #endif
                 >;
 
@@ -254,7 +254,7 @@ namespace ippl {
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
                                                               ,
-                                                              Kokkos::Experimental::SYCL
+                                                              Kokkos::SYCL
 #endif
 #ifdef KOKKOS_ENABLE_HPX
                                                               ,

--- a/src/Utility/TypeUtils.h
+++ b/src/Utility/TypeUtils.h
@@ -232,10 +232,6 @@ namespace ippl {
                                                               ,
                                                               Kokkos::OpenMP
 #endif
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-                                                              ,
-                                                              Kokkos::OpenMPTarget
-#endif
 #ifdef KOKKOS_ENABLE_THREADS
                                                               ,
                                                               Kokkos::Threads

--- a/src/Utility/ViewUtils.h
+++ b/src/Utility/ViewUtils.h
@@ -74,6 +74,18 @@ namespace ippl {
         }
 
         /*!
+         * Guard view-to-view copies against identical source and destination views.
+         *
+         * Kokkos 5.2 aborts on identical view arguments to Kokkos::deep_copy().
+         */
+        template <typename DstView, typename SrcView>
+        void deepCopyIfDifferent(const DstView& dst, const SrcView& src) {
+            if (static_cast<const void*>(dst.data()) != static_cast<const void*>(src.data())) {
+                Kokkos::deep_copy(dst, src);
+            }
+        }
+
+        /*!
          * Writes a view to an output stream
          * @tparam T view data type
          * @tparam Dim view dimension


### PR DESCRIPTION
```md
## Summary

This MR updates IPPL for Kokkos 5.2 compatibility and removes stale Kokkos configuration/API usage.

The changes are intentionally split into small compatibility updates:

1. Update the default Kokkos recipe to 5.2.0.
2. Replace deprecated Kokkos `Experimental::SYCL*` memory-space names with the non-experimental Kokkos 5 names.
3. Guard alias-prone view-to-view deep copies against the new Kokkos 5.2 behavior that aborts on identical source and destination views.
4. Remove dead OpenMPTarget references, since the old `Kokkos::OpenMPTarget` execution space / `Kokkos_ENABLE_OPENMPTARGET` option is no longer part of the supported Kokkos 5.x surface used by IPPL.

## Details

### Kokkos 5.2 recipe

The local/default Kokkos recipe is updated to use Kokkos 5.2.0.

This keeps the branch aligned with the current Kokkos 5.x compatibility work and lets IPPL exercise the latest behavior changes during regular configure/build testing.

### SYCL memory-space names

Kokkos 5.x deprecates the old experimental SYCL memory-space aliases.

This MR replaces:

- `Kokkos::Experimental::SYCLDeviceUSMSpace`
- `Kokkos::Experimental::SYCLHostUSMSpace`
- `Kokkos::Experimental::SYCLSharedUSMSpace`

with:

- `Kokkos::SYCLDeviceUSMSpace`
- `Kokkos::SYCLHostUSMSpace`
- `Kokkos::SYCLSharedUSMSpace`

This affects the IPPL type utilities that enumerate supported Kokkos memory spaces.

### Identical-view `deep_copy` guard

Kokkos 5.2 changed `Kokkos::deep_copy()` behavior for identical source and destination views. Instead of silently doing nothing, Kokkos now aborts.

IPPL has several field-to-field copy paths where aliasing can occur naturally through caller-provided result fields or solver scratch fields. To preserve the previous no-op semantics for self-copies, this MR adds:

```cpp
ippl::detail::deepCopyIfDifferent(dst, src)
```

The helper compares the underlying view data pointers and only calls `Kokkos::deep_copy()` when source and destination refer to different allocations.

The helper is used in:

- `Field::deepCopy()`
- `BareField::deepCopy()`
- identity and polynomial/Richardson preconditioner copies
- multigrid result copies
- FDTD time-shift copies

Normal `Kokkos::deep_copy()` behavior is unchanged for distinct views.

### OpenMPTarget cleanup

The stale OpenMPTarget support references are removed:

- `Kokkos::OpenMPTarget` is removed from the IPPL execution-space type list.
- `Kokkos_ENABLE_OPENMPTARGET` is removed from the user preset configuration.

This keeps IPPL’s Kokkos execution-space enumeration aligned with the currently supported Kokkos 5.x API surface.

## Validation

Configured and built locally with Kokkos 5.2.0, OpenMP, GCC debug build:

```bash
cmake --build /Users/adelmann/git/ippl/build-kokkos-5.2.0-openmp-gcc-debug -j 8
```

Result:

```text
100% build completed successfully
```

Relevant tests for the `deep_copy` changes passed:

```text
BareField
Field
TestLaplace
TestCurl
TestHessian
```

Scatter/gather-related tests were also run while checking the branch state:

```text
KernelGatherScatterTest
Binning
TestCurrentDeposition
GatherScatterTest
TestScatter
TestGather
```

All passed.

