### PR TITLE
Fix OpenMP compiler warnings in FFT and archive deserialization

### DIFF
--- a/demos/fel/MithraBunch.h
+++ b/demos/fel/MithraBunch.h
@@ -155,7 +155,7 @@ struct Charge {
      * flag can be used for better boosting the bunch to the moving frame. We need to consider it to
      * be double, because this flag needs to be communicated during bunch update.
      */
-    Double e;
+    Double e = 0.0;
 };
 template <typename scalar>
 using ChargeVector = std::list<Charge<scalar>>;
@@ -183,7 +183,9 @@ void initializeBunchEllipsoid(BunchInitialize<Double> bunchInit, ChargeVector<Do
     FieldVector<Double> t(0.0);
     Double t0;  //, g;
     Double zmin = 1e100;
-    Double Ne, bF, bFi;
+    Double Ne;
+    Double bF = bunchInit.bF_;
+    Double bFi;
     unsigned int bmi;
     std::vector<Double> randomNumbers;
 

--- a/src/Communicate/Archive.hpp
+++ b/src/Communicate/Archive.hpp
@@ -337,10 +337,8 @@ namespace ippl {
                 "Archive::deserialize()", mdrange_t({0, 0}, {(long int)nrecvs, Dim}),
                 KOKKOS_LAMBDA(const size_type i, const size_t d) {
                     const char* src = base + (Dim * i + d) * size + readpos;
-                    T value;
-                    char* dst = reinterpret_cast<char*>(&value);
+                    char* dst       = reinterpret_cast<char*>(&view.data()[i](d));
                     copyBytes(dst, src, size);
-                    view.data()[i](d) = value;
                 });
             Kokkos::fence();
             readpos_m += Dim * size * nrecvs;
@@ -394,10 +392,8 @@ namespace ippl {
                 "Archive::deserialize(offset, vector)", mdrange_t({0, 0}, {(long int)nrecvs, Dim}),
                 KOKKOS_LAMBDA(const size_type i, const size_t d) {
                     const char* src = base + (Dim * i + d) * size + readpos;
-                    T value;
-                    char* dst = reinterpret_cast<char*>(&value);
+                    char* dst = reinterpret_cast<char*>(&view.data()[offset + i](d));
                     copyBytes(dst, src, size);
-                    view.data()[offset + i](d) = value;
                 });
             Kokkos::fence();
             readpos_m += Dim * size * nrecvs;

--- a/src/FFT/Transform/PrunedCC.h
+++ b/src/FFT/Transform/PrunedCC.h
@@ -425,10 +425,12 @@ namespace ippl {
             (Dim == 3) ? static_cast<long>(owned[Dim == 3 ? 2 : 0].length()) : 1L;
         const long g0 = static_cast<long>(gDomFull[0].length());
         const long g1 = static_cast<long>(gDomFull[1].length());
-        const long g2 = (Dim == 3) ? static_cast<long>(gDomFull[Dim == 3 ? 2 : 0].length()) : 1L;
+        [[maybe_unused]] const long g2 =
+            (Dim == 3) ? static_cast<long>(gDomFull[Dim == 3 ? 2 : 0].length()) : 1L;
         const long m0 = static_cast<long>(modes[0]);
         const long m1 = static_cast<long>(modes[1]);
-        const long m2 = (Dim == 3) ? static_cast<long>(modes[Dim == 3 ? 2 : 0]) : 1L;
+        [[maybe_unused]] const long m2 =
+            (Dim == 3) ? static_cast<long>(modes[Dim == 3 ? 2 : 0]) : 1L;
         const int lf0 = localFirst[0];
         const int lf1 = localFirst[1];
         const int lf2 = (Dim == 3) ? localFirst[Dim == 3 ? 2 : 0] : 0;

--- a/src/Particle/ParticleAttrib.hpp
+++ b/src/Particle/ParticleAttrib.hpp
@@ -18,6 +18,7 @@
 #include <Kokkos_MathematicalConstants.hpp>
 
 #include <cmath>
+#include <utility>
 
 #include "Communicate/DataTypes.h"
 
@@ -157,7 +158,7 @@ namespace ippl {
 
         // using policy_type = Kokkos::RangePolicy<execution_space>;
         const bool useHashView = hash_array.extent(0) > 0;
-        if (useHashView && (iteration_policy.end() > hash_array.extent(0))) {
+        if (useHashView && std::cmp_greater(iteration_policy.end(), hash_array.extent(0))) {
             Inform m("scatter");
             m << "Hash array was passed to scatter, but size does not match iteration policy."
               << endl;


### PR DESCRIPTION
**Title**

Fix OpenMP & HIP compiler warnings in FFT and archive deserialization

**PR description**

## Summary

This PR fixes compiler warnings reported by the OpenMP & HIP builds without disabling warnings or adding compiler-specific switches.

- Mark the 3D-only `g2` and `m2` variables in `PrunedCC.h` as `[[maybe_unused]]`.
- Remove temporary scalar values from vector archive deserialization.
- Copy serialized bytes directly into the destination vector components.
- Apply the archive change to both regular and offset deserialization.

This addresses the warnings from:

- [[Pruned FFT build](https://my.cdash.org/builds/3912523/build)](https://my.cdash.org/builds/3912523/build)
- [[Archive deserialization build](https://my.cdash.org/builds/3912517/build)](https://my.cdash.org/builds/3912517/build)

## Testing

All green at https://my.cdash.org/index.php?project=IPPL

Release OpenMP build with GCC 15.2:

- 1 MPI rank: 41/41 unit tests passed
- 2 MPI ranks: 41/41 unit tests passed
- 4 MPI ranks: 40/41 unit tests passed

At four ranks, `NedelecSpace` fails because its test domain supports at most three partitions. All communication, particle-update, FFT, and NUFFT tests passed at four ranks.

The reported `PrunedCC.h` and `Archive.hpp` warnings no longer appear.

## ToDo
A separate PR for the G200 these are architectural

