### PR TITLE
Reduce size of binary build artefacts to help CI with debug builds

### DIFF
--- a/ci/cscs/cuda/build_sm90.yml
+++ b/ci/cscs/cuda/build_sm90.yml
@@ -51,7 +51,7 @@ variables:
 # ---------------------------------------------------------
 # cuda build debug
 # ---------------------------------------------------------
-ippl-build-cuda12-sm90-debug:
+ippl-build-cuda13-sm90-debug:
   extends: .ippl-build-cuda-common
   variables:
     BUILD_DIR: "build-$CI_COMMIT_SHORT_SHA-debug"
@@ -60,7 +60,7 @@ ippl-build-cuda12-sm90-debug:
 # ---------------------------------------------------------
 # cuda build release
 # ---------------------------------------------------------
-ippl-build-cuda12-sm90-release:
+ippl-build-cuda13-sm90-release:
   extends: .ippl-build-cuda-common
   variables:
     BUILD_DIR: "build-$CI_COMMIT_SHORT_SHA-release"

--- a/ci/cscs/cuda/build_sm90.yml
+++ b/ci/cscs/cuda/build_sm90.yml
@@ -20,6 +20,7 @@ variables:
   image: "${CUDA_UENV}"
   variables:
     SLURM_JOB_NUM_NODES: 1
+    SLURM_TIMELIMIT: "0:30:00"
   before_script:
     - !reference [.pr-number-extractor, before_script]
     - export BUILD_PATH=$(pwd)/$BUILD_DIR

--- a/ci/cscs/cuda/build_sm90.yml
+++ b/ci/cscs/cuda/build_sm90.yml
@@ -42,6 +42,8 @@ variables:
       -DMPIEXEC_MAX_NUMPROCS=4
     - echo "Build directory size (before cleanup):" $(du -sh $BUILD_PATH | cut -f1)
     - find $BUILD_PATH -name \*.o -delete
+    - find $BUILD_PATH/bin -type f -exec strip {} +
+    - find $BUILD_PATH/lib -type f -exec strip {} +
     - echo "Build directory size (cleaned for artefacts):" $(du -sh $BUILD_PATH | cut -f1)
   artifacts:
     paths:

--- a/ci/cscs/cuda/run_sm90.yml
+++ b/ci/cscs/cuda/run_sm90.yml
@@ -48,8 +48,8 @@ variables:
 # ---------------------------------------------------------
 # 1 rank debug
 # ---------------------------------------------------------
-ippl-test-cuda12-sm90-debug-1-rank:
-  needs: ["ippl-build-cuda12-sm90-debug"]
+ippl-test-cuda13-sm90-debug-1-rank:
+  needs: ["ippl-build-cuda13-sm90-debug"]
   extends: .ippl-test-cuda-common
   variables:
     SLURM_NTASKS: 1
@@ -61,8 +61,8 @@ ippl-test-cuda12-sm90-debug-1-rank:
 # ---------------------------------------------------------
 # 1 rank release
 # ---------------------------------------------------------
-ippl-test-cuda12-sm90-release-1-rank:
-  needs: ["ippl-build-cuda12-sm90-release"]
+ippl-test-cuda13-sm90-release-1-rank:
+  needs: ["ippl-build-cuda13-sm90-release"]
   extends: .ippl-test-cuda-common
   variables:
     SLURM_NTASKS: 1
@@ -74,8 +74,8 @@ ippl-test-cuda12-sm90-release-1-rank:
 # ---------------------------------------------------------
 # 4 ranks release
 # ---------------------------------------------------------
-ippl-test-cuda12-sm90-release-4-ranks:
-  needs: ["ippl-build-cuda12-sm90-release"]
+ippl-test-cuda13-sm90-release-4-ranks:
+  needs: ["ippl-build-cuda13-sm90-release"]
   extends: .ippl-test-cuda-common
   variables:
     SLURM_NTASKS: 4
@@ -87,8 +87,8 @@ ippl-test-cuda12-sm90-release-4-ranks:
 # ---------------------------------------------------------
 # 4 ranks release : known failing tests
 # ---------------------------------------------------------
-# ippl-test-cuda12-sm90-release-failing-4-ranks:
-#   needs: ["ippl-build-cuda12-sm90-release"]
+# ippl-test-cuda13-sm90-release-failing-4-ranks:
+#   needs: ["ippl-build-cuda13-sm90-release"]
 #   extends: .ippl-test-cuda-common
 #   variables:
 #     SLURM_NTASKS: 4

--- a/ci/cscs/openmp/build_openmp.yml
+++ b/ci/cscs/openmp/build_openmp.yml
@@ -19,6 +19,7 @@ variables:
   image: "${EIGER_UENV}"
   variables:
     SLURM_JOB_NUM_NODES: 1
+    SLURM_TIMELIMIT: "0:30:00"
   before_script:
     - !reference [.pr-number-extractor, before_script]
     - export BUILD_PATH=$(pwd)/$BUILD_DIR

--- a/ci/cscs/openmp/build_openmp.yml
+++ b/ci/cscs/openmp/build_openmp.yml
@@ -44,6 +44,8 @@ variables:
       -DMPIEXEC_MAX_NUMPROCS=4
     - echo "Build directory size (before cleanup):" $(du -sh $BUILD_PATH | cut -f1)
     - find $BUILD_PATH -name \*.o -delete
+    - find $BUILD_PATH/bin -type f -exec strip {} +
+    - find $BUILD_PATH/lib -type f -exec strip {} +
     - echo "Build directory size (cleaned for artefacts):" $(du -sh $BUILD_PATH | cut -f1)
   artifacts:
     paths:

--- a/ci/cscs/rocm/build_rocm-6.3.yml
+++ b/ci/cscs/rocm/build_rocm-6.3.yml
@@ -47,6 +47,8 @@ variables:
     # -DHeffte_ENABLE_GPU_AWARE_MPI=OFF
     - echo "Build directory size (before cleanup):" $(du -sh $BUILD_PATH | cut -f1)
     - find $BUILD_PATH -name \*.o -delete
+    - find $BUILD_PATH/bin -type f -exec strip {} +
+    - find $BUILD_PATH/lib -type f -exec strip {} +
     - echo "Build directory size (cleaned for artefacts):" $(du -sh $BUILD_PATH | cut -f1)
   artifacts:
     paths:

--- a/ci/cscs/rocm/build_rocm-6.3.yml
+++ b/ci/cscs/rocm/build_rocm-6.3.yml
@@ -19,6 +19,7 @@ variables:
   image: "${ROCM6_3_UENV}"
   variables:
     SLURM_JOB_NUM_NODES: 1
+    SLURM_TIMELIMIT: "0:30:00"
   before_script:
     - !reference [.pr-number-extractor, before_script]
     - export BUILD_PATH=$(pwd)/$BUILD_DIR


### PR DESCRIPTION
This should fix the 1GB limit for artefacts. 
Flyby changes are renaming the pipelines to use cuda13 instead of 12 and also increasing the time limit from 15 to 30 mins