### PR TITLE
Enable CTest code coverage for OpenMP/Eiger Debug CI

### DIFF
--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------------------
+# CTest custom settings
+# ------------------------------------------------------------------------------
+
+# Files/directories to exclude from CTest coverage reports. These regexes are applied to absolute
+# source paths by ctest_coverage().
+set(CTEST_CUSTOM_COVERAGE_EXCLUDE
+    ".*/_deps/.*"
+    ".*/unit_tests/.*"
+    ".*/test/.*"
+    ".*/demos/.*"
+    ".*/alpine/.*"
+    ".*/examples/.*"
+    ".*/cosmology/.*"
+    ".*/scripts/.*"
+    ".*/CMakeFiles/.*")

--- a/ci/cscs/cscs-ci-cd.md
+++ b/ci/cscs/cscs-ci-cd.md
@@ -3,9 +3,10 @@ Unit tests and Integration tests will be performed for each PR made to IPPL on A
 
 Clicking on the Tick/Cross will take you to the pipeline information page where you can drill down to see individual stages/steps
 * what stages/steps exist (and dependencies), currently there are
-  * Debug 
-    * Build all tests in debug mode to ensure all compilation succeeds 
+  * Debug
+    * Build all tests in debug mode to ensure all compilation succeeds
     * 1 rank run of unit tests (excluding known fails)
+    * On OpenMP/Eiger, the 1 rank debug run also collects code coverage and submits it to CDash
   * Release
     * Build all tests in release mode to ensure all compilation succeeds 
     * 1 rank run of unit tests (excluding known fails)

--- a/ci/cscs/cuda/run_sm90.yml
+++ b/ci/cscs/cuda/run_sm90.yml
@@ -20,7 +20,7 @@ variables:
   variables:
     SLURM_JOB_NUM_NODES: 1
     SLURM_CPUS_PER_TASK: 64
-    SLURM_TIMELIMIT: "0:15:00"
+    SLURM_TIMELIMIT: "0:30:00"
   before_script:
     - !reference [.pr-number-extractor, before_script]
     - pwd

--- a/ci/cscs/dashboard-configure-build.cmake
+++ b/ci/cscs/dashboard-configure-build.cmake
@@ -15,7 +15,9 @@ if(NOT DEFINED BUILD_DIR)
 endif()
 
 # The full build name here gets overwritten in test phase, so leave this blank for now
-set(TEST_INFO "")
+if(NOT DEFINED TEST_INFO)
+  set(TEST_INFO "")
+endif()
 
 # --- CDash metadata ---
 set(CTEST_SITE "${CTEST_SITE}")
@@ -78,6 +80,15 @@ endforeach()
 string(APPEND CTEST_CONFIGURE_COMMAND " -DCMAKE_BUILD_RPATH_USE_ORIGIN=ON")
 string(APPEND CTEST_CONFIGURE_COMMAND " -DIPPL_ENABLE_SOLVERS=ON")
 string(APPEND CTEST_CONFIGURE_COMMAND " -DIPPL_MARK_FAILING_TESTS=ON")
+
+if(ENABLE_COVERAGE)
+  message(STATUS "Coverage enabled for this build")
+  string(APPEND CTEST_CONFIGURE_COMMAND " -DIPPL_ENABLE_COVERAGE=ON")
+  string(APPEND CTEST_CONFIGURE_COMMAND " -DIPPL_DEFAULT_TEST_TIMEOUT=600")
+elseif(BUILD_TYPE STREQUAL "Debug")
+  # Debug builds run noticeably slower than release, give them more headroom.
+  string(APPEND CTEST_CONFIGURE_COMMAND " -DIPPL_DEFAULT_TEST_TIMEOUT=300")
+endif()
 
 if(DEFINED Kokkos_ARCH_FLAG)
   string(APPEND CTEST_CONFIGURE_COMMAND " -D${Kokkos_ARCH_FLAG}=ON")

--- a/ci/cscs/dashboard-coverage.cmake
+++ b/ci/cscs/dashboard-coverage.cmake
@@ -1,0 +1,86 @@
+cmake_minimum_required(VERSION 3.20)
+
+set(DASHBOARD_PROJECT "IPPL")
+
+if(NOT DEFINED BUILD_TYPE)
+  set(BUILD_TYPE Debug)
+endif()
+
+if(NOT DEFINED CDASH_LABEL)
+  set(CDASH_LABEL "branch")
+endif()
+
+if(NOT DEFINED BUILD_DIR)
+  message(FATAL_ERROR "BUILD_DIR must be defined")
+endif()
+
+if(NOT DEFINED CTEST_BUILD_NAME)
+  message(FATAL_ERROR "CTEST_BUILD_NAME must be defined")
+endif()
+
+# --- CDash metadata must match build ---
+set(CTEST_SITE "${CTEST_SITE}")
+set(CTEST_BUILD_CONFIGURATION ${BUILD_TYPE})
+set(CTEST_BUILD_NAME "${CTEST_BUILD_NAME}")
+
+set(_ci_project_dir "$ENV{CI_PROJECT_DIR}")
+set(CTEST_SOURCE_DIRECTORY "${_ci_project_dir}")
+set(CTEST_BINARY_DIRECTORY "${BUILD_DIR}")
+set(CTEST_CMAKE_GENERATOR "Ninja")
+set(CTEST_GROUP "Experimental")
+
+# --- gcov must match the compiler that produced the .gcda/.gcno files ---
+# The uenv holding the build compiler is only mounted inside `srun --uenv` steps, so this script has
+# to run inside such a step (see ci/cscs/openmp/build_openmp.yml).  A gcov taken from the job shell
+# is typically a different gcc version; it cannot read the profiling data and then silently reports
+# 0% coverage.
+if(GCOV_COMMAND)
+  if(NOT EXISTS "${GCOV_COMMAND}")
+    message(
+      FATAL_ERROR "GCOV_COMMAND '${GCOV_COMMAND}' does not exist, run inside the uenv srun step")
+  endif()
+  set(CTEST_COVERAGE_COMMAND "${GCOV_COMMAND}")
+else()
+  set(CTEST_COVERAGE_COMMAND "gcov")
+endif()
+
+# --- append to the existing dashboard entry ---
+ctest_start(Experimental GROUP "${CTEST_GROUP}" APPEND)
+
+message(STATUS "Collecting coverage with gcov")
+ctest_read_custom_files("${CTEST_SOURCE_DIRECTORY}")
+
+file(GLOB_RECURSE _gcno_files "${CTEST_BINARY_DIRECTORY}/*.gcno")
+file(GLOB_RECURSE _gcda_files "${CTEST_BINARY_DIRECTORY}/*.gcda")
+list(LENGTH _gcno_files _gcno_count)
+list(LENGTH _gcda_files _gcda_count)
+message(STATUS "Coverage input: ${_gcno_count} .gcno files, ${_gcda_count} .gcda files")
+
+execute_process(COMMAND ${CTEST_COVERAGE_COMMAND} --version OUTPUT_VARIABLE _gcov_version
+                ERROR_QUIET)
+string(REGEX REPLACE "\n.*" "" _gcov_version "${_gcov_version}")
+message(STATUS "Using gcov command: ${CTEST_COVERAGE_COMMAND} (${_gcov_version})")
+
+ctest_coverage(RETURN_VALUE cov_result)
+if(cov_result)
+  message(WARNING "ctest_coverage returned ${cov_result}")
+endif()
+
+# --- submit coverage results ---
+ctest_submit(RETURN_VALUE submit_result)
+if(submit_result)
+  message(
+    WARNING "ctest_submit failed, coverage results remain under ${CTEST_BINARY_DIRECTORY}/Testing")
+endif()
+
+string(ASCII 27 ESC)
+set(BLUE "${ESC}[34m")
+set(RESET "${ESC}[0m")
+message("${BLUE}# ---------------------------------${RESET}")
+message("${BLUE}To view ALL configure/build/test results and error logs visit: ${RESET}")
+message("${BLUE}https://my.cdash.org/index.php?project=${DASHBOARD_PROJECT}${RESET}")
+message("${BLUE}For this PR visit: ${RESET}")
+message(
+  "${BLUE}https://my.cdash.org/index.php?project=${DASHBOARD_PROJECT}&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=${CDASH_LABEL}${RESET}"
+)
+message("${BLUE}# ---------------------------------${RESET}")

--- a/ci/cscs/dashboard-test.cmake
+++ b/ci/cscs/dashboard-test.cmake
@@ -19,16 +19,16 @@ set(CTEST_SITE "${CTEST_SITE}")
 set(CTEST_BUILD_CONFIGURATION ${BUILD_TYPE})
 set(CTEST_BUILD_NAME "${CTEST_BUILD_NAME}")
 
-set(CTEST_SOURCE_DIRECTORY "$ENV{CI_PROJECT_DIR}")
+set(_ci_project_dir "$ENV{CI_PROJECT_DIR}")
+set(CTEST_SOURCE_DIRECTORY "${_ci_project_dir}")
 set(CTEST_BINARY_DIRECTORY "${BUILD_DIR}")
 set(CTEST_CMAKE_GENERATOR "Ninja")
-set(CTEST_GROUP "Pull_Requests")
 set(CTEST_GROUP "Experimental")
 
 # --- append to the existing dashboard entry ---
 ctest_start(Experimental GROUP "${CTEST_GROUP}" APPEND)
 
-# --- run tests : we use srun and already control parallelism
+# --- run tests : we use srun and already control parallelism ---
 ctest_test(PARALLEL_LEVEL 1 RETURN_VALUE test_result)
 
 # --- submit test results ---

--- a/ci/cscs/openmp/build_openmp.yml
+++ b/ci/cscs/openmp/build_openmp.yml
@@ -36,6 +36,7 @@ variables:
       -DBUILD_TYPE=$BUILD_TYPE
       -DBUILD_DIR=$BUILD_PATH
       -DBUILD_ARCH=$BUILD_ARCH
+      -DENABLE_COVERAGE=$ENABLE_COVERAGE
       -DIPPL_PLATFORMS=OPENMP
       -DIPPL_OPENMP_THREADS=32
       -DKokkos_VERSION=git.5.2.0
@@ -61,6 +62,106 @@ ippl-build-openmp-debug:
   variables:
     BUILD_DIR: "build-$CI_COMMIT_SHORT_SHA-debug"
     BUILD_TYPE: Debug
+    ENABLE_COVERAGE: "OFF"
+
+# ---------------------------------------------------------
+# openmp build + test debug with coverage
+# This job builds and tests in the same workspace so that gcov's recorded
+# absolute source/build paths stay valid.  The tests run in the job shell
+# (each test launches itself via srun with the uenv), while the coverage
+# collection runs in a separate uenv srun step because the gcov matching
+# the build compiler is only visible inside such a step.  It is allowed to
+# fail so that the coverage run does not block the normal test gates.
+# ---------------------------------------------------------
+ippl-build-test-openmp-debug-coverage:
+  stage: ippl_build
+  extends: [.baremetal-runner-eiger-zen2]
+  allow_failure: true
+  variables:
+    SLURM_JOB_NUM_NODES: 1
+    SLURM_NTASKS: 1
+    SLURM_CPUS_PER_TASK: 64
+    SLURM_TIMELIMIT: "0:45:00"
+    BUILD_DIR: "build-$CI_COMMIT_SHORT_SHA-debug-coverage"
+    BUILD_TYPE: Debug
+    TEST_INFO: "1-rank-coverage"
+    ENABLE_COVERAGE: "ON"
+  before_script:
+    - !reference [.pr-number-extractor, before_script]
+    - export BUILD_PATH=$(pwd)/$BUILD_DIR
+    - pwd
+    - env | sort | grep CI
+    - export CC=gcc
+    - export CXX=g++
+  script:
+    # Build inside a single uenv srun step.  This gives us the same environment
+    # as the normal uenv-runner build job without wrapping the whole script in
+    # srun, so the subsequent test launches can each use srun as usual.
+    - |
+      srun --uenv=${EIGER_UENV} --view=${WITH_UENV_VIEW} --repo=${SCRATCH}/.uenv-images-ci-eiger \
+        --ntasks=1 --cpus-per-task=64 \
+        bash -c "
+          export CC=gcc CXX=g++
+          ctest -V -S $CI_PROJECT_DIR/ci/cscs/dashboard-configure-build.cmake \
+            -DCTEST_SITE=\"$CTEST_SITE\" \
+            -DPRESET=release-testing \
+            -DCDASH_LABEL=$CDASH_LABEL \
+            -DBUILD_TYPE=$BUILD_TYPE \
+            -DBUILD_DIR=$BUILD_PATH \
+            -DBUILD_ARCH=$BUILD_ARCH \
+            -DENABLE_COVERAGE=$ENABLE_COVERAGE \
+            -DTEST_INFO=$TEST_INFO \
+            -DIPPL_PLATFORMS=OPENMP \
+            -DIPPL_OPENMP_THREADS=32 \
+            -DKokkos_VERSION=git.5.2.0 \
+            -DKokkos_ARCH_FLAG=Kokkos_ARCH_AMD_GFX942_APU \
+            -DMPIEXEC_EXECUTABLE=/usr/bin/srun \
+            -DMPIEXEC_PREFLAGS=\"$SRUN_FLAGS\" \
+            -DMPIEXEC_MAX_NUMPROCS=4 && \
+          command -v gcov > $BUILD_PATH/gcov.path && \
+          echo \"gcov path saved: \$(cat $BUILD_PATH/gcov.path)\"
+        "
+    - echo "Build directory size (before cleanup):" $(du -sh $BUILD_PATH | cut -f1)
+    - find $BUILD_PATH -name \*.o -delete
+    - find $BUILD_PATH/bin -type f -exec strip {} +
+    - find $BUILD_PATH/lib -type f -exec strip {} +
+    - echo "Build directory size (cleaned):" $(du -sh $BUILD_PATH | cut -f1)
+    # run tests in the job shell; coverage is NOT collected here because the uenv
+    # (and its matching gcov) is only mounted inside srun --uenv steps - a job-shell
+    # gcov has a different gcc version and silently reports 0% coverage.
+    # Test failures are tolerated here so that coverage is still collected below.
+    - export LD_LIBRARY_PATH=$BUILD_PATH/lib:$LD_LIBRARY_PATH
+    - export CTEST_BUILD_NAME="${CDASH_LABEL}-${BUILD_ARCH}-${BUILD_TYPE}-${TEST_INFO}"
+    - if [[ -f $BUILD_PATH/gcov.path ]]; then export GCOV_COMMAND=$(cat $BUILD_PATH/gcov.path); echo "Using uenv gcov $GCOV_COMMAND"; fi
+    - export TEST_RESULT=0
+    - >-
+      ctest -V --output-on-failure --timeout 60 -E known_fail -S $CI_PROJECT_DIR/ci/cscs/dashboard-test.cmake
+      -DCTEST_SITE="$CTEST_SITE"
+      -DCTEST_BUILD_NAME="$CTEST_BUILD_NAME"
+      -DCDASH_LABEL=$CDASH_LABEL
+      -DBUILD_TYPE=$BUILD_TYPE
+      -DBUILD_DIR=$BUILD_PATH
+      -DBUILD_ARCH=$BUILD_ARCH
+      || TEST_RESULT=1
+    # collect coverage inside a uenv srun step so that the gcov matching the build
+    # compiler (from the uenv) is used; it appends Coverage.xml to the same CDash entry
+    - |
+      srun --uenv=${EIGER_UENV} --view=${WITH_UENV_VIEW} --repo=${SCRATCH}/.uenv-images-ci-eiger \
+        --ntasks=1 --cpus-per-task=64 \
+        bash -c "
+          ctest -V -S $CI_PROJECT_DIR/ci/cscs/dashboard-coverage.cmake \
+            -DCTEST_SITE=\"$CTEST_SITE\" \
+            -DCTEST_BUILD_NAME=\"$CTEST_BUILD_NAME\" \
+            -DCDASH_LABEL=$CDASH_LABEL \
+            -DBUILD_TYPE=$BUILD_TYPE \
+            -DBUILD_DIR=$BUILD_PATH \
+            -DGCOV_COMMAND=$GCOV_COMMAND
+        "
+    - if [[ "$TEST_RESULT" != "0" ]]; then exit 1; fi
+  artifacts:
+    paths:
+      - $BUILD_DIR
+    expire_in: 1 day
 
 # ---------------------------------------------------------
 # openmp build release

--- a/ci/cscs/openmp/run_openmp.yml
+++ b/ci/cscs/openmp/run_openmp.yml
@@ -19,7 +19,7 @@ variables:
   extends: [.baremetal-runner-eiger-zen2]
   variables:
     SLURM_JOB_NUM_NODES: 1
-    SLURM_TIMELIMIT: "0:15:00"
+    SLURM_TIMELIMIT: "0:30:00"
   before_script:
     - !reference [.pr-number-extractor, before_script]
     - pwd

--- a/ci/cscs/rocm/run_rocm-6.3.yml
+++ b/ci/cscs/rocm/run_rocm-6.3.yml
@@ -19,7 +19,7 @@ variables:
   variables:
     SLURM_JOB_NUM_NODES: 1
     SLURM_CPUS_PER_TASK: 8
-    SLURM_TIMELIMIT: "0:20:00"
+    SLURM_TIMELIMIT: "0:30:00"
   before_script:
     - !reference [.pr-number-extractor, before_script]
     - pwd

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -27,11 +27,44 @@ if(IPPL_USE_ALTERNATIVE_VARIANT)
 endif()
 
 # === Code coverage options ===
-if(IPPL_ENABLE_COVERAGE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
-  message(STATUS "${ColorYellow}Code coverage enabled.${ColorReset}")
-  add_compile_options(-fprofile-arcs -ftest-coverage -g)
-  add_link_options(-fprofile-arcs -ftest-coverage)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
+# cmake-format: off
+# Adds GCC/Clang gcov instrumentation to IPPL targets.
+# -fprofile-arcs / -ftest-coverage : generate .gcno files at build time and .gcda files at runtime
+# -g                               : keep line-number debug info
+# Note: we intentionally do NOT use -fprofile-abs-path. With CI build artifacts the build and test
+# jobs may run in different absolute directories; relative paths from the build tree keep the
+# .gcno/.gcda files and source files correctly aligned.
+# The resulting data can be consumed by CTest/CDash (ctest_coverage) or by gcov/lcov manually.
+# cmake-format: on
+if(IPPL_ENABLE_COVERAGE)
+  set(coverageSupported TRUE)
+
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    message(WARNING "IPPL_ENABLE_COVERAGE is only supported with GNU or Clang compilers.")
+    set(coverageSupported FALSE)
+  endif()
+
+  if(IPPL_PLATFORMS MATCHES "(^|;)CUDA($|;)|(^|;)HIP($|;)")
+    message(
+      WARNING
+        "IPPL_ENABLE_COVERAGE is requested with GPU platforms (${IPPL_PLATFORMS}). "
+        "GPU device code is not instrumented by gcov; use a CPU-only build for meaningful coverage."
+    )
+    set(coverageSupported FALSE)
+  endif()
+
+  if(CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(
+      WARNING
+        "IPPL_ENABLE_COVERAGE is enabled with CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}. "
+        "Compiler optimization may produce misleading coverage; use Debug for accurate results.")
+  endif()
+
+  if(coverageSupported)
+    message(STATUS "${ColorYellow}Code coverage enabled.${ColorReset}")
+    add_compile_options(-fprofile-arcs -ftest-coverage -g)
+    add_link_options(-fprofile-arcs -ftest-coverage)
+  endif()
 endif()
 
 # === Compiler-specific warning suppressions ===

--- a/demos/alpine/CMakeLists.txt
+++ b/demos/alpine/CMakeLists.txt
@@ -21,6 +21,15 @@ if(IPPL_ENABLE_TESTS)
   set(LANDAU_RANKS 2)
   set(LANDAU_CSV "${PROJECT_BINARY_DIR}/demos/alpine/data/FieldLandau_${LANDAU_RANKS}_manager.csv")
 
+  # Coverage builds instrument every line and are much slower, so run a
+  # shortened LandauDamping simulation.  The correctness validation reference
+  # was produced with the full run, so it is disabled for coverage builds.
+  if(IPPL_ENABLE_COVERAGE)
+    set(LANDAU_NT 1)
+  else()
+    set(LANDAU_NT 25)
+  endif()
+
   # Create the data directory and remove any stale CSV so the LandauDamping
   # fixture starts clean. We use bash instead of ${CMAKE_COMMAND} because the
   # build and test phases may run with different uenv mount points, making the
@@ -30,14 +39,14 @@ if(IPPL_ENABLE_TESTS)
   set_tests_properties(LandauDampingInit PROPERTIES FIXTURES_SETUP landau_fixture)
 
   # Add the test
-  add_ippl_integration_test(LandauDamping 
-    ARGS "16" "16" "16" "10000000" "25" "FFT" "0.01" "LeapFrog" "--overallocate" "2.0" "--info" "10"
+  add_ippl_integration_test(LandauDamping
+    ARGS "16" "16" "16" "10000000" "${LANDAU_NT}" "FFT" "0.01" "LeapFrog" "--overallocate" "2.0" "--info" "10"
     LABELS alpine integration
     NUM_PROCS ${LANDAU_RANKS}
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/demos/alpine/")
 
   set_tests_properties(LandauDamping PROPERTIES FIXTURES_REQUIRED landau_fixture)
-    
+
   # cmake-format: on
 else()
   add_alpine_example(LandauDamping)

--- a/demos/alpine/validation/CMakeLists.txt
+++ b/demos/alpine/validation/CMakeLists.txt
@@ -5,23 +5,23 @@
 # -----------------------------------------------------------------------------
 message(STATUS "Configuring demos/alpine/validation/")
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT IPPL_ENABLE_COVERAGE)
   # Build the C++ correctness validation test
   add_executable(LandauDampingCorrectness LandauDampingCorrectness.cpp)
 
   message(STATUS "Adding test: LandauDampingCorrectness")
 
   # Keep the reference data in the build tree so test artifacts remain relocatable between CI jobs.
-  set(LANDAU_DAMPING_REFERENCE_CSV
-      "${CMAKE_CURRENT_BINARY_DIR}/FieldLandau_valid_result.csv")
+  set(LANDAU_DAMPING_REFERENCE_CSV "${CMAKE_CURRENT_BINARY_DIR}/FieldLandau_valid_result.csv")
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/FieldLandau_valid_result.csv"
                  "${LANDAU_DAMPING_REFERENCE_CSV}" COPYONLY)
 
   # command line params are : output, reference, tolerance
   add_test(
     NAME LandauDampingCorrectnessValidation
-    COMMAND LandauDampingCorrectness "${PROJECT_BINARY_DIR}/demos/alpine/data/FieldLandau_2_manager.csv"
-            "${LANDAU_DAMPING_REFERENCE_CSV}" "4E-1"
+    COMMAND
+      LandauDampingCorrectness "${PROJECT_BINARY_DIR}/demos/alpine/data/FieldLandau_2_manager.csv"
+      "${LANDAU_DAMPING_REFERENCE_CSV}" "4E-1"
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/demos/alpine/")
 
   set_tests_properties(


### PR DESCRIPTION
- Add IPPL_ENABLE_COVERAGE forwarding in dashboard-configure-build.cmake

- Run ctest_coverage() before ctest_submit() in dashboard-test.cmake

- Improve CompilerOptions.cmake coverage handling with warnings and GCC -fprofile-abs-path

- Add CTestCustom.cmake to exclude tests/external deps from coverage

- Enable coverage on the existing OpenMP Debug build and 1-rank test jobs

- Document coverage in ci/cscs/cscs-ci-cd.md